### PR TITLE
fix(typo): AdminPanel/CodeEditor - 'Web Boby End' -> 'Web Body End'

### DIFF
--- a/client-src/ClientAdminCustomCodeEditorApp/components/CustomCodeEditorApp/index.jsx
+++ b/client-src/ClientAdminCustomCodeEditorApp/components/CustomCodeEditorApp/index.jsx
@@ -76,7 +76,7 @@ const CODE_FILES_DICT = {
     </div>),
   },
   [CODE_FILES.WEB_BODY_END]: {
-    'name': 'Web Boby End',
+    'name': 'Web Body End',
     language: 'html',
     viewUrl: () => PUBLIC_URLS.webFeed(),
     description: (<div>


### PR DESCRIPTION
Fixes a typo on the admin panel (Admin Panel -> Settings -> Code Editor), changing 'Web Boby End' to 'Web Body End'.

You'll also need to update the screenshot on [README.md#211](https://github.com/microfeed/microfeed/blob/main/README.md?plain=1#L211).
