### PR TITLE
#58: Add support for sitemap.xml endpoint

### DIFF
--- a/edge-src/common/PageUtils.js
+++ b/edge-src/common/PageUtils.js
@@ -161,6 +161,43 @@ export class JsonResponseBuilder extends ResponseBuilder {
   }
 }
 
+export class SitemapResponseBuilder extends ResponseBuilder {
+  get _contentType() {
+    return 'text/xml';
+  }
+
+  _getResponse(props) {
+    const res = super._getResponse(props);
+    let xml = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">'
+    xml += `<url><loc>${this.jsonData.home_page_url}</loc><image:image><image:loc>${this.jsonData.icon}</image:loc></image:image></url>`;
+    this.jsonData.items.map((item) => {
+      xml += `<url><loc>${item._microfeed.web_url}</loc><lastmod>${item.date_published}</lastmod>`
+      if (item.attachments) {
+        item.attachments.forEach((attachment) => {
+          if (attachment.mime_type.startsWith('image/')) {
+            xml += `<image:image><image:loc>${attachment.url}</image:loc></image:image>`
+          } else if (attachment.mime_type.startsWith('video/')) {
+            xml += `<video:video><video:title>${item.title}</video:title><video:publication_date>${item.date_published}</video:publication_date><video:content_loc>${attachment.url}</video:content_loc></video:video>`
+          }
+        })
+      }
+      xml += `</url>`
+    })
+    xml += '</urlset>';
+    return new Response(xml, res);
+  }
+
+  get _fetchItems() {
+    const queryKwargs  = this.fetchItemsObj.queryKwargs || {};
+    return getFetchItemsParams(
+      this.request,
+      {
+        // status: STATUSES.PUBLISHED,
+        ...queryKwargs,
+      }, -1);
+  }
+}
+
 class CodeInjector {
   constructor(settings, theme, sharedTheme) {
     this.settings = settings;

--- a/edge-src/models/FeedDb.js
+++ b/edge-src/models/FeedDb.js
@@ -345,7 +345,10 @@ export default class FeedDb {
         orderBy,
         queryKwargs,
       };
-      if (fetchItemsParams.limit > MAX_ITEMS_PER_PAGE) {
+
+      if (fetchItemsParams.limit < 0) {
+        fetchItemsParams.limit = undefined;
+      } else if (fetchItemsParams.limit > MAX_ITEMS_PER_PAGE) {
         fetchItemsParams.limit = MAX_ITEMS_PER_PAGE;
       }
       things = [{

--- a/functions/sitemap.xml.jsx
+++ b/functions/sitemap.xml.jsx
@@ -1,0 +1,15 @@
+import {SitemapResponseBuilder} from '../edge-src/common/PageUtils';
+import {STATUSES} from "../common-src/Constants";
+
+export async function onRequestGet({env, request}) {
+  const sitemapResponseBuilder = new SitemapResponseBuilder(env, request, {
+    queryKwargs: {
+      status: STATUSES.PUBLISHED,
+    },
+  });
+  return sitemapResponseBuilder.getResponse({
+    getComponent: (_, jsonData) => {
+      return jsonData
+    },
+  });
+}


### PR DESCRIPTION
With reference to: https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap#xml

I added a `/sitemap.xml` endpoint that is generated with by grabbing all the items in the database without limits.

It would detect if the post has images or video attachments and append the image and video schema accordingly as well.

Example: https://kb.jarylchng.com/sitemap.xml
![image](https://github.com/microfeed/microfeed/assets/1162128/9cf5a14a-b6b5-4dc8-a6d9-3216ca9f7e03)
