### PR TITLE
Use custom URL for main url attribute instead for JSON and RSS feeds

### DIFF
--- a/edge-src/models/FeedPublicJsonBuilder.js
+++ b/edge-src/models/FeedPublicJsonBuilder.js
@@ -225,9 +225,7 @@ export default class FeedPublicJsonBuilder {
         newItem['attachments'] = [attachment];
       }
     }
-    if (item.link) {
-      newItem['url'] = item.link;
-    }
+    newItem['url'] = _microfeed['web_url'] || item.link;
     if (mediaFile.isExternalUrl && mediaFile.url) {
       newItem['external_url'] = mediaFile.url;
     }

--- a/edge-src/models/FeedPublicRssBuilder.js
+++ b/edge-src/models/FeedPublicRssBuilder.js
@@ -24,9 +24,7 @@ export default class FeedPublicRssBuilder {
          '@cdata': item['content_html'],
        };
      }
-     if (item['url']) {
-       itemJson['link'] = item['url'];
-     }
+     itemJson['link'] = _microfeed['web_url'] || item['url'];
 
      if (item.image) {
        itemJson['itunes:image'] = {


### PR DESCRIPTION
When accessing the JSON and RSS feeds, I've noticed that the main `url` attribute for posts links to my `pages.dev` domain rather than my custom domain. Likely because I created the posts from there.

This PR changes it to be the same as `_microfeed['web_url']` which will use the custom domain as base regardless.