### PR TITLE
use _microfeed.web_url as rss item link

### DIFF
--- a/edge-src/models/FeedPublicRssBuilder.js
+++ b/edge-src/models/FeedPublicRssBuilder.js
@@ -24,8 +24,12 @@ export default class FeedPublicRssBuilder {
          '@cdata': item['content_html'],
        };
      }
+
      if (item['url']) {
        itemJson['link'] = item['url'];
+     } else {
+      // use _microfeed.web_url as the link to the item post
+      itemJson['link'] = _microfeed['web_url'];
      }
 
      if (item.image) {


### PR DESCRIPTION
I faced an issue since I used API to create post in microfeed.

When I call the API to create a post, I did not set the url parameter, since I want microfeed to generate one automatically.

The API works fine, but I found the generated RSS does not set the post link correctly, it just point to the rss link, not to the post link.

So I made a change, if the post does not have the url set, use the web_url in _microfeed object, and it works well on my instance.

https://1link.fun/rss/

Hope it can merged.
