### PR TITLE
feat: update default theme, change icon image link to homepage (/) for easy navigate back

### DIFF
--- a/edge-src/common/default_themes/web_feed.html
+++ b/edge-src/common/default_themes/web_feed.html
@@ -4,7 +4,7 @@
     <div class="flex">
       {{#icon}}
       <div class="mr-4">
-        <a href="{{icon}}" target="_blank">
+        <a href="/">
           <img alt="{{title}}" src="{{icon}}" class="img-lg" loading="lazy"/>
         </a>
       </div>


### PR DESCRIPTION
currently, there is no easy way to navigate back to homepage(and see latest posts) if you keep click 'next->' button to see old posts. (you need click <-prev button multi-times, or remove the query parameters from URL manually, or click one of the post, then click the post title)

To add a link to '/' to the logo image, user can easily navigate back to homepage, more specifically to see the latest posts again.
