### PR TITLE
Revert to use aws4fetch to create r2 presigned url.

### DIFF
--- a/edge-src/EdgeCommonRequests/index.jsx
+++ b/edge-src/EdgeCommonRequests/index.jsx
@@ -1,26 +1,24 @@
-import { JsonResponseBuilder } from "../common/PageUtils";
-import { STATUSES } from "../../common-src/Constants";
-import { getIdFromSlug } from "../../common-src/StringUtils";
-import { S3Client } from "@aws-sdk/client-s3";
-import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { PutObjectCommand } from "@aws-sdk/client-s3";
-import { projectPrefix } from "../../common-src/R2Utils";
+import {JsonResponseBuilder} from "../common/PageUtils";
+import {STATUSES} from "../../common-src/Constants";
+import {getIdFromSlug} from "../../common-src/StringUtils";
+import {AwsClient} from "aws4fetch";
+import {projectPrefix} from "../../common-src/R2Utils";
 
 //
 // Fetch feed / item json
 //
 
-export async function onFetchFeedJsonRequestGet({ env, request }, checkIsAllowed = true) {
+export async function onFetchFeedJsonRequestGet({env, request}, checkIsAllowed = true) {
   const jsonResponseBuilder = new JsonResponseBuilder(env, request, {
     queryKwargs: {
       status: STATUSES.PUBLISHED,
     },
   });
-  return await jsonResponseBuilder.getResponse({ checkIsAllowed });
+  return await jsonResponseBuilder.getResponse({checkIsAllowed});
 }
 
-export async function onFetchItemRequestGet({ params, env, request }, checkIsAllowed = true, statuses = null) {
-  const { slug, itemId } = params;
+export async function onFetchItemRequestGet({params, env, request}, checkIsAllowed = true, statuses = null) {
+  const {slug, itemId} = params;
   const theItemId = itemId || getIdFromSlug(slug);
 
   if (theItemId) {
@@ -49,29 +47,32 @@ export async function onFetchItemRequestGet({ params, env, request }, checkIsAll
 // Fetch presigned url from R2
 //
 
-async function getPresignedUrlFromR2(env, bucket, inputParams) {
-  const { key } = inputParams;
-  const accessKeyId = `${env.R2_ACCESS_KEY_ID}`;
-  const secretAccessKey = `${env.R2_SECRET_ACCESS_KEY}`;
-  const endpoint = `https://${env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com`;
-  const region = "auto"; // Use appropriate region
-
-  const s3Client = new S3Client({
+async function _getPresignedUrl(accessKeyId, secretAccessKey, endpoint, region) {
+  const aws = new AwsClient({
+    accessKeyId,
+    secretAccessKey,
+    'service': 's3',
     region,
-    credentials: {
-      accessKeyId,
-      secretAccessKey,
-    },
-    endpoint,
   });
 
-  const command = new PutObjectCommand({
-    Bucket: bucket,
-    Key: `${projectPrefix(env)}/${key}`,
+  const request = new Request(endpoint, {
+    method: 'PUT',
   });
 
-  const presignedUrl = await getSignedUrl(s3Client, command, { expiresIn: 3600 });
-  return presignedUrl;
+  const presigned = await aws.sign(request, { aws: { signQuery: true }})
+  return presigned.url;
+}
+
+async function getPresignedUrlFromR2(env, bucket, inputParams) {
+  const {
+    key,
+    // size,
+    // type,
+  } = inputParams;
+  const accessKeyId = `${env.R2_ACCESS_KEY_ID}`
+  const secretAccessKey = `${env.R2_SECRET_ACCESS_KEY}`;
+  const endpoint = `https://${bucket}.${env.CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com/${projectPrefix(env)}/${key}`;
+  return _getPresignedUrl(accessKeyId, secretAccessKey, endpoint, 'auto');
 }
 
 /**
@@ -93,7 +94,7 @@ async function getPresignedUrlFromR2(env, bucket, inputParams) {
  *   "mediaBaseUrl": "<pages-project-name>>/<environment>"
  * }
  */
-export async function onGetR2PresignedUrlRequestPost({ inputParams, env }) {
+export async function onGetR2PresignedUrlRequestPost({inputParams, env}) {
   const presignedUrl = await getPresignedUrlFromR2(env, env.R2_PUBLIC_BUCKET, inputParams);
   return {
     presignedUrl,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@swc/jest": "^0.2.23",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/postcss": "^4.0.14",
+    "aws4fetch": "^1.0.20",
     "better-sqlite3": "^11.1.2",
     "clean-webpack-plugin": "^4.0.0",
     "concurrently": "^9.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4197,6 +4197,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"aws4fetch@npm:^1.0.20":
+  version: 1.0.20
+  resolution: "aws4fetch@npm:1.0.20"
+  checksum: 10/1329dd5913224c9a4fcb276633a2677baafe8224c3e4b99083309b30af4b114b33a73b6674369419f1978b83e905c4fff61d4af175c24450707c3cf027bb86da
+  languageName: node
+  linkType: hard
+
 "axios@npm:^1.2.1":
   version: 1.9.0
   resolution: "axios@npm:1.9.0"
@@ -8706,6 +8713,7 @@ __metadata:
     "@tailwindcss/postcss": "npm:^4.0.14"
     "@tanstack/react-table": "npm:^8.5.28"
     "@uiw/react-textarea-code-editor": "npm:^2.1.9"
+    aws4fetch: "npm:^1.0.20"
     axios: "npm:^1.2.1"
     better-sqlite3: "npm:^11.1.2"
     clean-webpack-plugin: "npm:^4.0.0"


### PR DESCRIPTION
Fix this issue:
https://github.com/microfeed/microfeed/issues/180

The AWS SDK for JavaScript doesn't work well with Cloudflare Workers/Pages edge functions. It's likely the Cloudflare Workers runtime changed recently.

Previously, [we used aws4fetch](https://github.com/splithub-io/microfeed/blob/d12022446232914ce8f93231f292fd7da97097e3/edge-src/EdgeCommonRequests/index.jsx) in the Pages function code to create R2 presigned URLs.
Then this pull request https://github.com/microfeed/microfeed/pull/140 switched to using the AWS SDK, which worked at the time.
Now we must revert to aws4fetch to fix the broken deployment.