### PR TITLE
Add named Cloudflare login profiles

### DIFF
--- a/.agents/skills/deploy-microfeed/SKILL.md
+++ b/.agents/skills/deploy-microfeed/SKILL.md
@@ -115,7 +115,8 @@ successful steps were undone.
 ## Choose the management command
 
 - Cloudflare authorization/account discovery: `yarn manage accounts --json`
-- Fresh authorization under another login: `yarn manage accounts --reauthorize`
+- Separate named Cloudflare login: `yarn manage accounts --profile <name>`
+- Fresh authorization for a named login: `yarn manage accounts --profile <name> --reauthorize`
 - Fresh Cloudflare installation: `yarn manage init`
 - Saved Cloudflare installation: `yarn manage deploy`
 - Existing compatible Worker not saved in this clone: `yarn manage connect`;
@@ -165,8 +166,10 @@ user named a target. Do not deploy a local-only instance to Cloudflare.
    Explain that Wrangler may open Cloudflare in the browser and stores the
    resulting OAuth credentials through its OS keyring support. If authorization
    is required, pause for the user to finish it, then resume the command. If no
-   usable account appears, offer `yarn manage accounts --reauthorize`; do not
-   work around OAuth with a token.
+   usable account appears, offer `yarn manage accounts --reauthorize`. If the
+   user wants to preserve the current login and add another, use
+   `yarn manage accounts --profile <name> --reauthorize` instead. Do not work
+   around OAuth with a token.
 6. When exactly one account is returned, use its full ID. When several are
    returned, show each plain-language account name and the last eight ID
    characters, then ask the user which one owns the site. Duplicate names are

--- a/.agents/skills/deploy-microfeed/SKILL.md
+++ b/.agents/skills/deploy-microfeed/SKILL.md
@@ -164,12 +164,14 @@ user named a target. Do not deploy a local-only instance to Cloudflare.
    ```
 
    Explain that Wrangler may open Cloudflare in the browser and stores the
-   resulting OAuth credentials through its OS keyring support. The output lists
-   every stored profile and marks the one active for this repository; the
-   account list belongs to that active profile. If authorization is required,
-   pause for the user to finish it, then resume the command. If no usable
-   account appears, offer `yarn manage accounts --reauthorize`. If the user
-   wants to preserve the current login and add another, use
+   resulting OAuth credentials through its OS keyring support. Explain that a
+   profile is a saved Cloudflare login, while an account is a Cloudflare
+   workspace that owns sites and data. The output lists every stored profile,
+   marks the one active for this repository, shows only that login's accounts,
+   and prints commands for switching to other named profiles. If authorization
+   is required, pause for the user to finish it, then resume the command. If no
+   usable account appears, offer `yarn manage accounts --reauthorize`. If the
+   user wants to preserve the current login and add another, use
    `yarn manage accounts --profile <name> --reauthorize` instead. Do not work
    around OAuth with a token.
 6. When exactly one account is returned, use its full ID. When several are

--- a/.agents/skills/deploy-microfeed/SKILL.md
+++ b/.agents/skills/deploy-microfeed/SKILL.md
@@ -164,10 +164,12 @@ user named a target. Do not deploy a local-only instance to Cloudflare.
    ```
 
    Explain that Wrangler may open Cloudflare in the browser and stores the
-   resulting OAuth credentials through its OS keyring support. If authorization
-   is required, pause for the user to finish it, then resume the command. If no
-   usable account appears, offer `yarn manage accounts --reauthorize`. If the
-   user wants to preserve the current login and add another, use
+   resulting OAuth credentials through its OS keyring support. The output lists
+   every stored profile and marks the one active for this repository; the
+   account list belongs to that active profile. If authorization is required,
+   pause for the user to finish it, then resume the command. If no usable
+   account appears, offer `yarn manage accounts --reauthorize`. If the user
+   wants to preserve the current login and add another, use
    `yarn manage accounts --profile <name> --reauthorize` instead. Do not work
    around OAuth with a token.
 6. When exactly one account is returned, use its full ID. When several are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@
   non-Codex automation whose operator accepts command-history and process-list
   exposure.
 - Discover authorization and accounts first with `yarn manage accounts --json`.
+  When the user wants a separate named login, use `yarn manage accounts
+  --profile <name> --reauthorize`; do not replace another Wrangler profile.
   Let Wrangler open browser authorization when required. If one account is
   returned, use it; if several are returned, explain their names and ID
   suffixes in plain language and ask the user to choose. Pass the exact full

--- a/README.md
+++ b/README.md
@@ -239,6 +239,19 @@ resource. If several accounts are available, choose the one where you want the
 site to live. `yarn manage init` then asks for the site settings and explains
 the Cloudflare resources before creating them.
 
+If you keep personal and company Cloudflare logins on the same computer, you
+can create or select a named Wrangler login for this local Git copy of the
+repository:
+
+```console
+yarn manage accounts --profile <profile-name>
+```
+
+The profile name is only a local login label and does not need to be globally
+unique. It is different from your microfeed site/Worker name, which should be
+globally distinctive. Add `--reauthorize` when you deliberately want to sign
+that profile in again as a different Cloudflare user.
+
 The installer also asks how to protect the microfeed admin dashboard, where you
 create and edit posts, upload media files, and customize your site:
 
@@ -288,6 +301,7 @@ side effect, and safety check.
 | Task | Command |
 | --- | --- |
 | Sign in to Cloudflare and list available accounts | `yarn manage accounts` |
+| Create or select a separate named Cloudflare login for this local repository | `yarn manage accounts --profile <name>` |
 | Create or resume a Cloudflare, preview, or local site | `yarn manage init` |
 | Connect an existing compatible microfeed Worker without changing it | `yarn manage connect` |
 | Deploy an update | `yarn manage deploy` |

--- a/README.md
+++ b/README.md
@@ -236,10 +236,13 @@ Run future `yarn manage` commands from this same `microfeed` folder.
 `yarn manage accounts` opens Cloudflare's sign-in page when needed and lists the
 accounts available to that login without creating or changing any Cloudflare
 resource. It also lists every Wrangler login profile stored on your computer
-and marks the one active for this local repository. If several accounts are
-available, choose the one where you want the site to live. `yarn manage init`
-then asks for the site settings and explains the Cloudflare resources before
-creating them.
+and marks the one active for this local repository. A **profile** is a saved
+Cloudflare login; a **Cloudflare account** is a workspace that owns sites,
+databases, and media storage. The command shows the accounts available through
+the active login and prints commands for switching to other saved profiles. If
+several accounts are available through that login, choose the one where you
+want the site to live. `yarn manage init` then asks for the site settings and
+explains the Cloudflare resources before creating them.
 
 If you keep personal and company Cloudflare logins on the same computer, you
 can create or select a named Wrangler login for this local Git copy of the

--- a/README.md
+++ b/README.md
@@ -235,9 +235,11 @@ Run future `yarn manage` commands from this same `microfeed` folder.
 
 `yarn manage accounts` opens Cloudflare's sign-in page when needed and lists the
 accounts available to that login without creating or changing any Cloudflare
-resource. If several accounts are available, choose the one where you want the
-site to live. `yarn manage init` then asks for the site settings and explains
-the Cloudflare resources before creating them.
+resource. It also lists every Wrangler login profile stored on your computer
+and marks the one active for this local repository. If several accounts are
+available, choose the one where you want the site to live. `yarn manage init`
+then asks for the site settings and explains the Cloudflare resources before
+creating them.
 
 If you keep personal and company Cloudflare logins on the same computer, you
 can create or select a named Wrangler login for this local Git copy of the

--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -140,9 +140,17 @@ Authorize Cloudflare and list every account available to the active Wrangler
 login. This command never creates or changes a Worker, D1 database, R2 bucket,
 domain, or microfeed configuration.
 
-The output lists every locally stored Wrangler profile and marks the one active
-for this local repository. Accounts and the login email belong to that active
-profile; inactive profiles remain stored but are not queried.
+A Wrangler profile is a Cloudflare login saved on the local computer. A
+Cloudflare account is a workspace that owns sites, databases, media storage,
+and other Cloudflare resources. One login profile may have access to one or
+more Cloudflare accounts.
+
+The output lists every locally stored profile, marks the one active for this
+local repository, and prints an exact `yarn manage accounts --profile <name>`
+command for each other named profile. The displayed email and Cloudflare
+accounts belong only to the active profile; inactive profiles remain stored
+but are not queried. Wrangler's `default` profile is a fallback login rather
+than a named profile selected by this option.
 
 Use `--profile <name>` to create or select a named Wrangler OAuth login and
 bind it to this local Git copy of the repository. If the profile does not yet

--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -140,6 +140,10 @@ Authorize Cloudflare and list every account available to the active Wrangler
 login. This command never creates or changes a Worker, D1 database, R2 bucket,
 domain, or microfeed configuration.
 
+The output lists every locally stored Wrangler profile and marks the one active
+for this local repository. Accounts and the login email belong to that active
+profile; inactive profiles remain stored but are not queried.
+
 Use `--profile <name>` to create or select a named Wrangler OAuth login and
 bind it to this local Git copy of the repository. If the profile does not yet
 exist, the command opens Cloudflare authorization to create it. If it already
@@ -155,7 +159,7 @@ yarn manage accounts [--json] [--profile <name>] [--reauthorize]
 
 | Option | Meaning |
 | --- | --- |
-| `--json` | Print the login, active profile, and `{name, id}` accounts as JSON. |
+| `--json` | Print the login, active profile, all profiles with active markers, and `{name, id}` accounts as JSON. |
 | `--profile <name>` | Create or select a named Wrangler OAuth login and bind it to this local repository. |
 | `--reauthorize` | Force fresh browser authorization, for example when the desired account is missing. |
 

--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -78,7 +78,7 @@ use this `yarn manage` interface.
 
 | Command | Purpose | External effect |
 | --- | --- | --- |
-| `accounts` | Authorize and list Cloudflare accounts | Read-only discovery; may update local OAuth credentials |
+| `accounts` | Authorize and list Cloudflare accounts | Read-only discovery; may update local OAuth profiles and the repository binding |
 | `init` | Initialize production, preview, or local installation | Creates or updates Cloudflare resources, or local-only state |
 | `connect` | Save an existing compatible Worker in this clone | Reads Cloudflare; writes local state only |
 | `deploy` | Check, migrate, deploy, and verify | Updates Worker code and D1 migrations |
@@ -108,6 +108,11 @@ Use `yarn manage accounts` first. Commands that operate on a saved deployment
 automatically require its recorded account. Supplying `--account-id <id>` is an
 additional exact-account assertion; it cannot override saved ownership.
 
+To keep separate Cloudflare logins on the same computer, use
+`yarn manage accounts --profile <name>`. The named Wrangler profile is local to
+your computer and does not need to be globally unique. It is separate from the
+microfeed site/Worker name, which should be globally distinctive.
+
 ### Production, preview, and local data
 
 - No environment flag means the production Cloudflare installation.
@@ -128,19 +133,30 @@ deliberately rejects it.
 
 **Purpose:** Authorize Cloudflare and list available accounts.
 
-**Changes:** Read-only Cloudflare discovery; may update local OAuth credentials.
+**Changes:** Read-only Cloudflare discovery; may update local OAuth profiles
+and the repository binding.
 
 Authorize Cloudflare and list every account available to the active Wrangler
 login. This command never creates or changes a Worker, D1 database, R2 bucket,
 domain, or microfeed configuration.
 
+Use `--profile <name>` to create or select a named Wrangler OAuth login and
+bind it to this local Git copy of the repository. If the profile does not yet
+exist, the command opens Cloudflare authorization to create it. If it already
+exists, the command selects it without changing its credentials. Add
+`--reauthorize` to replace that named profile's authorization deliberately.
+Wrangler profile names accept ASCII letters, numbers, hyphens, and underscores;
+`default` and `staging` are reserved. Wrangler currently labels named profiles
+as a beta feature.
+
 ```console
-yarn manage accounts [--json] [--reauthorize]
+yarn manage accounts [--json] [--profile <name>] [--reauthorize]
 ```
 
 | Option | Meaning |
 | --- | --- |
 | `--json` | Print the login, active profile, and `{name, id}` accounts as JSON. |
+| `--profile <name>` | Create or select a named Wrangler OAuth login and bind it to this local repository. |
 | `--reauthorize` | Force fresh browser authorization, for example when the desired account is missing. |
 
 OAuth rejection, missing permissions, zero accounts, or an unavailable browser

--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -53,6 +53,7 @@ import {
   pagesCollisionMessage,
   pagesDomainAttachedMessage,
   pagesDomainIsAttached,
+  validateWranglerProfileName,
 } from "./lib/cloudflare";
 import {
   openUrl,
@@ -317,8 +318,10 @@ function cloudflareAuthorizationMessage(): string {
     "workers_scripts:write, d1:write, pages:write, and zone:read. " +
     "workers_scripts:write is required to safely check and deploy the " +
     "selected site. pages:write is requested only because Wrangler does " +
-    "not expose a pages:read OAuth scope. `yarn manage accounts` only reads " +
-    "your identity and account list; it never changes Cloudflare resources.";
+    "not expose a pages:read OAuth scope. `yarn manage accounts` never " +
+    "changes Cloudflare account resources. With `--profile`, it may create " +
+    "local OAuth credentials and bind that Wrangler profile to this local " +
+    "repository.";
 }
 
 export async function accountsCommand(
@@ -332,6 +335,25 @@ export async function accountsCommand(
     runner,
   };
   const json = flagBoolean(flags, "json");
+  if (flags.profile === true) {
+    throw new Error(
+      "`--profile` requires a name, for example `--profile company`. " +
+        "No Cloudflare resources were changed.",
+    );
+  }
+  const requestedProfile = flagString(flags, "profile");
+  if (requestedProfile) {
+    const profileError = validateWranglerProfileName(requestedProfile);
+    if (profileError) {
+      throw new Error(
+        `Invalid Wrangler profile name \`${requestedProfile}\`. ` +
+          `${profileError} No Cloudflare resources were changed.`,
+      );
+    }
+  }
+  const reauthorizeCommand = requestedProfile
+    ? `yarn manage accounts --profile ${requestedProfile} --reauthorize`
+    : "yarn manage accounts --reauthorize";
   const explainAuthorization = () => {
     if (json) {
       process.stderr.write(`\nCloudflare authorization\n${
@@ -345,39 +367,67 @@ export async function accountsCommand(
     }
   };
 
+  const readIdentity = async (): Promise<{
+    identity: CloudflareIdentity;
+    scopesGranted: boolean;
+  }> => {
+    const identity = await context.cloudflare.identity();
+    return {
+      identity,
+      scopesGranted: identity.accounts.length > 0 &&
+        await context.cloudflare.hasRequiredScopes(),
+    };
+  };
+
   let identity: CloudflareIdentity;
   let scopesGranted: boolean;
-  if (flagBoolean(flags, "reauthorize")) {
+  if (requestedProfile) {
+    let authorizationPerformed = flagBoolean(flags, "reauthorize");
+    if (!authorizationPerformed) {
+      authorizationPerformed = !await context.cloudflare.profileExists(
+        requestedProfile,
+      );
+    }
+    if (authorizationPerformed) {
+      explainAuthorization();
+      await context.cloudflare.authorizeProfile(requestedProfile);
+    }
+    await context.cloudflare.activateProfile(requestedProfile);
+    ({identity, scopesGranted} = await readIdentity());
+    if (
+      !authorizationPerformed &&
+      (identity.accounts.length === 0 || !scopesGranted)
+    ) {
+      explainAuthorization();
+      await context.cloudflare.authorizeProfile(requestedProfile);
+      await context.cloudflare.activateProfile(requestedProfile);
+      ({identity, scopesGranted} = await readIdentity());
+    }
+  } else if (flagBoolean(flags, "reauthorize")) {
     explainAuthorization();
     await context.cloudflare.login();
-    identity = await context.cloudflare.identity();
-    scopesGranted = identity.accounts.length > 0 &&
-      await context.cloudflare.hasRequiredScopes();
+    ({identity, scopesGranted} = await readIdentity());
   } else {
-    identity = await context.cloudflare.identity();
-    scopesGranted = identity.accounts.length > 0 &&
-      await context.cloudflare.hasRequiredScopes();
+    ({identity, scopesGranted} = await readIdentity());
     if (identity.accounts.length === 0 || !scopesGranted) {
       explainAuthorization();
       await context.cloudflare.login();
-      identity = await context.cloudflare.identity();
-      scopesGranted = identity.accounts.length > 0 &&
-        await context.cloudflare.hasRequiredScopes();
+      ({identity, scopesGranted} = await readIdentity());
     }
   }
 
   if (identity.accounts.length === 0) {
     throw new Error(
       "Cloudflare did not return any accounts for this login. No " +
-        "Cloudflare resources were changed. Use `yarn manage accounts " +
-        "--reauthorize` to sign in with another Cloudflare user.",
+        "Cloudflare resources were changed. Use `" + reauthorizeCommand +
+        "` to sign in with another Cloudflare user.",
     );
   }
   if (!scopesGranted) {
     throw new Error(
       "Cloudflare authorization did not grant all permissions microfeed " +
-        "needs. No Cloudflare resources were changed. Run `yarn manage " +
-        "accounts --reauthorize` and approve every requested permission.",
+        "needs. No Cloudflare resources were changed. Run `" +
+        reauthorizeCommand + "` and approve every requested permission.",
     );
   }
 

--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -436,9 +436,18 @@ export async function accountsCommand(
     return;
   }
   prompts.intro("Cloudflare accounts available to microfeed");
+  prompts.log.info(`Login: ${identity.email ?? "not reported"}`);
   prompts.log.info(
-    `Login: ${identity.email ?? "not reported"}\n` +
-      `Wrangler profile: ${identity.profile ?? "default or not reported"}`,
+    "Wrangler profiles:\n" + (identity.profiles.length > 0
+      ? identity.profiles.map(({active, name}) =>
+          `  ${name}${active ? " — active for this repository" : ""}`
+        ).join("\n")
+      : "  none reported"),
+  );
+  prompts.log.info(
+    `Cloudflare accounts available to ${
+      identity.profile ?? "the active login"
+    }:`,
   );
   for (const account of identity.accounts) {
     prompts.log.info(`${account.name} — ${account.id}`);

--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -435,28 +435,61 @@ export async function accountsCommand(
     process.stdout.write(`${JSON.stringify(identity, null, 2)}\n`);
     return;
   }
-  prompts.intro("Cloudflare accounts available to microfeed");
-  prompts.log.info(`Login: ${identity.email ?? "not reported"}`);
+  const profiles = [...identity.profiles].sort((left, right) =>
+    Number(right.active) - Number(left.active) ||
+    Number(left.name === "default") - Number(right.name === "default") ||
+    left.name.localeCompare(right.name)
+  );
+  const activeProfile = identity.profile ?? "the active profile";
+  const accountNoun = identity.accounts.length === 1
+    ? "Cloudflare account"
+    : "Cloudflare accounts";
+  prompts.intro("Cloudflare access for microfeed");
   prompts.log.info(
-    "Wrangler profiles:\n" + (identity.profiles.length > 0
-      ? identity.profiles.map(({active, name}) =>
-          `  ${name}${active ? " — active for this repository" : ""}`
-        ).join("\n")
-      : "  none reported"),
+    "Saved Cloudflare logins (Wrangler profiles)\n" +
+      "A profile is a Cloudflare login saved on this computer. This local " +
+      "microfeed folder uses one profile at a time.\n\n" +
+      (profiles.length > 0
+        ? profiles.map(({active, name}) =>
+            `  ${name} — ${
+              active
+                ? "active for this local microfeed folder"
+                : name === "default"
+                  ? "fallback login, not active"
+                  : "saved, not active"
+            }`
+          ).join("\n")
+        : "  none reported"),
   );
   prompts.log.info(
-    `Cloudflare accounts available to ${
-      identity.profile ?? "the active login"
-    }:`,
+    "Active Cloudflare login\n" +
+      `  Profile: ${activeProfile}\n` +
+      `  Email: ${identity.email ?? "not reported"}`,
   );
-  for (const account of identity.accounts) {
-    prompts.log.info(`${account.name} — ${account.id}`);
+  prompts.log.info(
+    `${accountNoun} available through "${activeProfile}"\n` +
+      "A Cloudflare account is a workspace that owns sites, databases, " +
+      "and media storage.\n\n" +
+      identity.accounts.map(({id, name}) => `  ${name} — ${id}`).join("\n"),
+  );
+  const switchableProfiles = profiles.filter(({active, name}) =>
+    !active && name !== "default"
+  );
+  if (switchableProfiles.length > 0) {
+    prompts.log.info(
+      "Switch this local microfeed folder to another saved login\n" +
+        switchableProfiles.map(({name}) =>
+          `  yarn manage accounts --profile ${name}`
+        ).join("\n"),
+    );
   }
   prompts.outro(
-    identity.accounts.length === 1
-      ? "One account is available; microfeed can use it automatically."
-      : "Choose one of these accounts when deploying. Account names may " +
-        "repeat, so the full ID is the reliable identifier.",
+    `The active "${activeProfile}" login can access ${
+      identity.accounts.length
+    } ${accountNoun}${
+      identity.accounts.length === 1 ? "" : ". Account names may repeat; " +
+        "use the full ID when choosing one"
+    }. Inactive login profiles were listed but not queried.`,
   );
 }
 

--- a/manage-cli/help.ts
+++ b/manage-cli/help.ts
@@ -24,7 +24,8 @@ export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
     details: [
       "Checks the current Wrangler login and required permissions, opening browser authorization when needed.",
       "With --profile, creates or selects a named Wrangler login and binds it to this local repository without changing Cloudflare resources.",
-      "Lists every stored Wrangler profile, marks the one active for this repository, and returns every Cloudflare account available to that login.",
+      "A profile is a Cloudflare login saved on this computer; an account is a Cloudflare workspace that owns sites and data.",
+      "Lists every stored profile, marks the active one, shows only that login's accounts, and prints commands for switching to other named profiles.",
     ],
     examples: [
       "yarn manage accounts",

--- a/manage-cli/help.ts
+++ b/manage-cli/help.ts
@@ -20,23 +20,27 @@ const option = (
 
 export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
   {
-    changes: "Read-only Cloudflare discovery; may update local OAuth credentials.",
+    changes: "Read-only Cloudflare discovery; may update local OAuth profiles and the repository binding.",
     details: [
       "Checks the current Wrangler login and required permissions, opening browser authorization when needed.",
+      "With --profile, creates or selects a named Wrangler login and binds it to this local repository without changing Cloudflare resources.",
       "Returns the login identity, active profile, and every available Cloudflare account without changing account resources.",
     ],
     examples: [
       "yarn manage accounts",
       "yarn manage accounts --json",
+      "yarn manage accounts --profile company",
+      "yarn manage accounts --profile company --reauthorize",
       "yarn manage accounts --reauthorize",
     ],
     name: "accounts",
     options: [
       option("--json", "Print machine-readable identity and account data."),
+      option("--profile <name>", "Create or select a named Wrangler login for this repository."),
       option("--reauthorize", "Force a fresh browser authorization."),
     ],
     summary: "Authorize Cloudflare and list available accounts.",
-    usage: "yarn manage accounts [--json] [--reauthorize]",
+    usage: "yarn manage accounts [--json] [--profile <name>] [--reauthorize]",
   },
   {
     changes: "Creates or updates Cloudflare resources, or creates an isolated local sandbox with --local.",

--- a/manage-cli/help.ts
+++ b/manage-cli/help.ts
@@ -24,7 +24,7 @@ export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
     details: [
       "Checks the current Wrangler login and required permissions, opening browser authorization when needed.",
       "With --profile, creates or selects a named Wrangler login and binds it to this local repository without changing Cloudflare resources.",
-      "Returns the login identity, active profile, and every available Cloudflare account without changing account resources.",
+      "Lists every stored Wrangler profile, marks the one active for this repository, and returns every Cloudflare account available to that login.",
     ],
     examples: [
       "yarn manage accounts",

--- a/manage-cli/lib/cloudflare.ts
+++ b/manage-cli/lib/cloudflare.ts
@@ -1,3 +1,5 @@
+import nodePath from "node:path";
+
 import {
   normalizeAdminAuthMode,
   type AdminAuthMode,
@@ -185,6 +187,12 @@ export interface CloudflareIdentity {
   accounts: Account[];
   email: string | null;
   profile: string | null;
+  profiles: WranglerProfileSummary[];
+}
+
+export interface WranglerProfileSummary {
+  active: boolean;
+  name: string;
 }
 
 const RESERVED_WRANGLER_PROFILE_NAMES = new Set(["default", "staging"]);
@@ -248,11 +256,30 @@ function profilesFromList(output: string): WranglerProfile[] {
   return profiles;
 }
 
-function activeProfileFromList(output: string): string | null {
-  const profiles = profilesFromList(output);
-  return profiles.find(({boundDirectories}) =>
-    boundDirectories.includes(repositoryRoot)
-  )?.name ?? (profiles.some(({name}) => name === "default")
+function bindingContainsRepository(binding: string): boolean {
+  const relative = nodePath.relative(
+    nodePath.resolve(binding),
+    repositoryRoot,
+  );
+  return relative === "" || (
+    relative !== ".." &&
+    !relative.startsWith(`..${nodePath.sep}`) &&
+    !nodePath.isAbsolute(relative)
+  );
+}
+
+function activeProfileFromProfiles(
+  profiles: WranglerProfile[],
+): string | null {
+  const activeBinding = profiles.flatMap(({boundDirectories, name}) =>
+    boundDirectories.split(",").flatMap((directory) => {
+      const binding = directory.trim();
+      return binding && binding !== "-" && bindingContainsRepository(binding)
+        ? [{binding: nodePath.resolve(binding), name}]
+        : [];
+    })
+  ).sort((left, right) => right.binding.length - left.binding.length)[0];
+  return activeBinding?.name ?? (profiles.some(({name}) => name === "default")
     ? "default"
     : null);
 }
@@ -388,19 +415,31 @@ export class CloudflareClient {
     return accountsFromWhoami(data);
   }
 
-  private async activeProfile(): Promise<string | null> {
+  private async profileState(): Promise<{
+    profile: string | null;
+    profiles: WranglerProfileSummary[];
+  }> {
     try {
       const result = await runWrangler(
         this.runner,
         ["auth", "list"],
         {allowFailure: true},
       );
-      return result.exitCode === 0
-        ? activeProfileFromList(result.stdout)
-        : null;
+      if (result.exitCode !== 0) {
+        return {profile: null, profiles: []};
+      }
+      const profiles = profilesFromList(result.stdout);
+      const profile = activeProfileFromProfiles(profiles);
+      return {
+        profile,
+        profiles: profiles.map(({name}) => ({
+          active: name === profile,
+          name,
+        })),
+      };
     } catch {
       // Auth profiles are experimental and may not exist in older Wrangler.
-      return null;
+      return {profile: null, profiles: []};
     }
   }
 
@@ -411,19 +450,20 @@ export class CloudflareClient {
       {allowFailure: true},
     );
     if (result.exitCode !== 0) {
-      return {accounts: [], email: null, profile: null};
+      return {accounts: [], email: null, profile: null, profiles: []};
     }
     const data = parseJsonOutput<Record<string, unknown>>(result.stdout);
     const email = typeof data.email === "string" && data.email
       ? data.email
       : null;
     const authType = typeof data.authType === "string" ? data.authType : "";
+    const profileState = /oauth/iu.test(authType)
+      ? await this.profileState()
+      : {profile: null, profiles: []};
     return {
       accounts: accountsFromWhoami(data),
       email,
-      profile: /oauth/iu.test(authType)
-        ? await this.activeProfile()
-        : null,
+      ...profileState,
     };
   }
 

--- a/manage-cli/lib/cloudflare.ts
+++ b/manage-cli/lib/cloudflare.ts
@@ -187,6 +187,20 @@ export interface CloudflareIdentity {
   profile: string | null;
 }
 
+const RESERVED_WRANGLER_PROFILE_NAMES = new Set(["default", "staging"]);
+
+export function validateWranglerProfileName(
+  name: string,
+): string | undefined {
+  if (RESERVED_WRANGLER_PROFILE_NAMES.has(name.toLowerCase())) {
+    return `\`${name}\` is reserved by Wrangler. Choose another name.`;
+  }
+  if (!/^[A-Za-z0-9_-]+$/u.test(name)) {
+    return "Use only ASCII letters, numbers, hyphens, and underscores.";
+  }
+  return undefined;
+}
+
 function accountsFromWhoami(data: Record<string, unknown>): Account[] {
   const candidates = (
     Array.isArray(data.accounts)
@@ -208,12 +222,17 @@ function accountsFromWhoami(data: Record<string, unknown>): Account[] {
   });
 }
 
-function activeProfileFromList(output: string): string | null {
+interface WranglerProfile {
+  boundDirectories: string;
+  name: string;
+}
+
+function profilesFromList(output: string): WranglerProfile[] {
   const withoutAnsi = output.replace(
     /\u001B\[[0-?]*[ -/]*[@-~]/gu,
     "",
   );
-  let hasDefaultProfile = false;
+  const profiles: WranglerProfile[] = [];
   for (const line of withoutAnsi.split(/\r?\n/u)) {
     const cells = line.split("│").map((cell) => cell.trim());
     if (cells.length < 4) {
@@ -221,15 +240,21 @@ function activeProfileFromList(output: string): string | null {
     }
     const profile = cells[1];
     const boundDirectories = cells[2];
-    if (!profile || profile === "Profile" || !boundDirectories) {
+    if (!profile || profile === "Profile") {
       continue;
     }
-    hasDefaultProfile ||= profile === "default";
-    if (boundDirectories.includes(repositoryRoot)) {
-      return profile;
-    }
+    profiles.push({boundDirectories: boundDirectories ?? "", name: profile});
   }
-  return hasDefaultProfile ? "default" : null;
+  return profiles;
+}
+
+function activeProfileFromList(output: string): string | null {
+  const profiles = profilesFromList(output);
+  return profiles.find(({boundDirectories}) =>
+    boundDirectories.includes(repositoryRoot)
+  )?.name ?? (profiles.some(({name}) => name === "default")
+    ? "default"
+    : null);
 }
 
 function parsePagesProjects(output: string): PagesProject[] {
@@ -293,6 +318,61 @@ export class CloudflareClient {
       );
     }
     this.credentialsPromise = undefined;
+  }
+
+  async authorizeProfile(profile: string): Promise<void> {
+    try {
+      await runWrangler(
+        this.runner,
+        ["auth", "create", profile, "--scopes", ...OAUTH_SCOPES],
+        {
+          env: {
+            ...process.env,
+            CLOUDFLARE_AUTH_USE_KEYRING: "true",
+          },
+          interactive: true,
+        },
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Cloudflare authorization for Wrangler profile \`${profile}\` did ` +
+          "not complete. No Cloudflare resources were changed. Approve the " +
+          "requested permissions and keep this command open until the " +
+          `browser callback finishes, then retry. ${detail}`,
+      );
+    }
+    this.credentialsPromise = undefined;
+  }
+
+  async activateProfile(profile: string): Promise<void> {
+    try {
+      await runWrangler(
+        this.runner,
+        ["auth", "activate", profile, repositoryRoot],
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Wrangler profile \`${profile}\` could not be activated for this ` +
+          "local repository. No Cloudflare resources were changed. " + detail,
+      );
+    }
+    this.credentialsPromise = undefined;
+  }
+
+  async profileExists(profile: string): Promise<boolean> {
+    try {
+      const result = await runWrangler(
+        this.runner,
+        ["auth", "list"],
+        {allowFailure: true},
+      );
+      return result.exitCode === 0 &&
+        profilesFromList(result.stdout).some(({name}) => name === profile);
+    } catch {
+      return false;
+    }
   }
 
   async accounts(): Promise<Account[]> {

--- a/tests/unit/manage-cli/cloudflare.test.ts
+++ b/tests/unit/manage-cli/cloudflare.test.ts
@@ -8,6 +8,7 @@ import {
   pagesDomainAttachedMessage,
   pagesDomainIsAttached,
   pagesProjectDomainsDashboardUrl,
+  validateWranglerProfileName,
 } from "../../../manage-cli/lib/cloudflare";
 import type {
   CommandRunner,
@@ -142,6 +143,42 @@ describe("CloudflareClient", () => {
     await expect(new CloudflareClient(runner).login()).rejects.toThrow(
       "No Cloudflare resources were changed",
     );
+  });
+
+  it("creates named OAuth profiles in the keyring and activates the repository binding", async () => {
+    const runner = vi.fn<CommandRunner>().mockResolvedValue(commandResult());
+    const cloudflare = new CloudflareClient(runner);
+
+    await cloudflare.authorizeProfile("company");
+    await cloudflare.activateProfile("company");
+
+    expect(runner).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/wrangler(?:\.cmd)?$/u),
+      ["auth", "create", "company", "--scopes", ...OAUTH_SCOPES],
+      expect.objectContaining({
+        env: expect.objectContaining({
+          CLOUDFLARE_AUTH_USE_KEYRING: "true",
+        }),
+        interactive: true,
+      }),
+    );
+    expect(runner).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/wrangler(?:\.cmd)?$/u),
+      ["auth", "activate", "company", repositoryRoot],
+      expect.objectContaining({cwd: repositoryRoot}),
+    );
+  });
+
+  it("validates named profiles before Wrangler runs", () => {
+    expect(validateWranglerProfileName("company")).toBeUndefined();
+    expect(validateWranglerProfileName("team_login-2")).toBeUndefined();
+    expect(validateWranglerProfileName("company account")).toContain(
+      "ASCII letters",
+    );
+    expect(validateWranglerProfileName("default")).toContain("reserved");
+    expect(validateWranglerProfileName("STAGING")).toContain("reserved");
   });
 
   it("parses accounts and confirms the required permission set", async () => {

--- a/tests/unit/manage-cli/cloudflare.test.ts
+++ b/tests/unit/manage-cli/cloudflare.test.ts
@@ -1,3 +1,5 @@
+import nodePath from "node:path";
+
 import {afterEach, describe, expect, it, vi} from "vitest";
 
 import {
@@ -215,7 +217,9 @@ describe("CloudflareClient", () => {
           "┌──────────┬───────────────────────────────────────┐",
           "│ Profile  │ Bound Directories                     │",
           "├──────────┼───────────────────────────────────────┤",
-          `│ personal │ ${repositoryRoot} │`,
+          `│ company  │ ${repositoryRoot} │`,
+          "│ default  │ -                                     │",
+          `│ personal │ ${nodePath.dirname(repositoryRoot)} │`,
           "└──────────┴───────────────────────────────────────┘",
         ].join("\n"));
       }
@@ -225,7 +229,12 @@ describe("CloudflareClient", () => {
     await expect(new CloudflareClient(runner).identity()).resolves.toEqual({
       accounts: [{id: "account-a", name: "Personal"}],
       email: "admin@example.com",
-      profile: "personal",
+      profile: "company",
+      profiles: [
+        {active: true, name: "company"},
+        {active: false, name: "default"},
+        {active: false, name: "personal"},
+      ],
     });
   });
 

--- a/tests/unit/manage-cli/commands.test.ts
+++ b/tests/unit/manage-cli/commands.test.ts
@@ -102,6 +102,8 @@ describe("read-only Cloudflare account discovery", () => {
           stderr: "",
           stdout: [
             "│ Profile │ Bound Directories │",
+            "│ company │ - │",
+            "│ default │ - │",
             `│ personal │ ${process.cwd()} │`,
           ].join("\n"),
         };
@@ -111,16 +113,75 @@ describe("read-only Cloudflare account discovery", () => {
 
     await accountsCommand({json: true}, runner);
 
-    expect(write).toHaveBeenCalledWith(expect.stringContaining(
-      '"email": "cloudflare@example.com"',
-    ));
-    expect(write).toHaveBeenCalledWith(expect.stringContaining(
-      '"id": "account-b"',
-    ));
+    const output = String(write.mock.calls.at(-1)?.[0]);
+    expect(JSON.parse(output)).toMatchObject({
+      accounts: [{id: "account-a"}, {id: "account-b"}],
+      email: "cloudflare@example.com",
+      profile: "personal",
+      profiles: [
+        {active: false, name: "company"},
+        {active: false, name: "default"},
+        {active: true, name: "personal"},
+      ],
+    });
     const commands = runner.mock.calls.map(([, args]) => args[0]);
     expect(commands.every((command) =>
       command === "whoami" || command === "auth"
     )).toBe(true);
+  });
+
+  it("shows every stored profile and marks the active one", async () => {
+    const info = vi.spyOn(prompts.log, "info").mockImplementation(
+      () => undefined,
+    );
+    const runner = vi.fn<CommandRunner>(async (_executable, args) => {
+      const command = args.join(" ");
+      if (command === "auth list") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: [
+            "│ Profile │ Bound Directories │",
+            `│ company │ ${process.cwd()} │`,
+            "│ default │ - │",
+            "│ personal │ - │",
+          ].join("\n"),
+        };
+      }
+      if (command === "whoami --json") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: JSON.stringify({
+            accounts: [{id: "account-company", name: "Company"}],
+            authType: "OAuth Token",
+            email: "company@example.com",
+            tokenPermissions: [
+              "account:read",
+              "user:read",
+              "workers:write",
+              "workers_scripts:write",
+              "d1:write",
+              "pages:write",
+              "zone:read",
+            ],
+          }),
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await accountsCommand({}, runner);
+
+    expect(info).toHaveBeenCalledWith(
+      "Wrangler profiles:\n" +
+        "  company — active for this repository\n" +
+        "  default\n" +
+        "  personal",
+    );
+    expect(info).toHaveBeenCalledWith(
+      "Cloudflare accounts available to company:",
+    );
   });
 
   it("forces browser OAuth with keyring storage when reauthorization is requested", async () => {

--- a/tests/unit/manage-cli/commands.test.ts
+++ b/tests/unit/manage-cli/commands.test.ts
@@ -174,13 +174,27 @@ describe("read-only Cloudflare account discovery", () => {
     await accountsCommand({}, runner);
 
     expect(info).toHaveBeenCalledWith(
-      "Wrangler profiles:\n" +
-        "  company — active for this repository\n" +
-        "  default\n" +
-        "  personal",
+      "Saved Cloudflare logins (Wrangler profiles)\n" +
+        "A profile is a Cloudflare login saved on this computer. This " +
+        "local microfeed folder uses one profile at a time.\n\n" +
+        "  company — active for this local microfeed folder\n" +
+        "  personal — saved, not active\n" +
+        "  default — fallback login, not active",
     );
     expect(info).toHaveBeenCalledWith(
-      "Cloudflare accounts available to company:",
+      "Active Cloudflare login\n" +
+        "  Profile: company\n" +
+        "  Email: company@example.com",
+    );
+    expect(info).toHaveBeenCalledWith(
+      "Cloudflare account available through \"company\"\n" +
+        "A Cloudflare account is a workspace that owns sites, databases, " +
+        "and media storage.\n\n" +
+        "  Company — account-company",
+    );
+    expect(info).toHaveBeenCalledWith(
+      "Switch this local microfeed folder to another saved login\n" +
+        "  yarn manage accounts --profile personal",
     );
   });
 

--- a/tests/unit/manage-cli/commands.test.ts
+++ b/tests/unit/manage-cli/commands.test.ts
@@ -163,6 +163,126 @@ describe("read-only Cloudflare account discovery", () => {
       args[0] === "login" && args.includes("--use-keyring")
     )).toBe(true);
   });
+
+  it("creates and activates a separately named Cloudflare login", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const runner = vi.fn<CommandRunner>(async (_executable, args) => {
+      const command = args.join(" ");
+      if (command.startsWith("auth create company --scopes ")) {
+        return {exitCode: 0, stderr: "", stdout: "Authorized"};
+      }
+      if (command === `auth activate company ${process.cwd()}`) {
+        return {exitCode: 0, stderr: "", stdout: "Activated"};
+      }
+      if (command === "auth list") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: [
+            "│ Profile │ Bound Directories │",
+            `│ company │ ${process.cwd()} │`,
+          ].join("\n"),
+        };
+      }
+      if (command === "whoami --json") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: JSON.stringify({
+            accounts: [{id: "account-company", name: "Company"}],
+            authType: "OAuth Token",
+            email: "company@example.com",
+            tokenPermissions: [
+              "account:read",
+              "user:read",
+              "workers:write",
+              "workers_scripts:write",
+              "d1:write",
+              "pages:write",
+              "zone:read",
+            ],
+          }),
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await accountsCommand({
+      json: true,
+      profile: "company",
+      reauthorize: true,
+    }, runner);
+
+    expect(runner.mock.calls.some(([, args]) =>
+      args[0] === "auth" && args[1] === "create" && args[2] === "company"
+    )).toBe(true);
+    expect(runner.mock.calls.some(([, args]) =>
+      args[0] === "auth" && args[1] === "activate" &&
+      args[2] === "company"
+    )).toBe(true);
+    expect(runner.mock.calls.some(([, , options]) =>
+      options?.env?.CLOUDFLARE_AUTH_USE_KEYRING === "true"
+    )).toBe(true);
+  });
+
+  it("selects an existing named profile without replacing its login", async () => {
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const runner = vi.fn<CommandRunner>(async (_executable, args) => {
+      const command = args.join(" ");
+      if (command === "auth list") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: [
+            "│ Profile │ Bound Directories │",
+            `│ company │ ${process.cwd()} │`,
+          ].join("\n"),
+        };
+      }
+      if (command === `auth activate company ${process.cwd()}`) {
+        return {exitCode: 0, stderr: "", stdout: "Activated"};
+      }
+      if (command === "whoami --json") {
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: JSON.stringify({
+            accounts: [{id: "account-company", name: "Company"}],
+            authType: "OAuth Token",
+            email: "company@example.com",
+            tokenPermissions: [
+              "account:read",
+              "user:read",
+              "workers:write",
+              "workers_scripts:write",
+              "d1:write",
+              "pages:write",
+              "zone:read",
+            ],
+          }),
+        };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await accountsCommand({json: true, profile: "company"}, runner);
+
+    expect(runner.mock.calls.some(([, args]) =>
+      args[0] === "login" || (args[0] === "auth" && args[1] === "create")
+    )).toBe(false);
+  });
+
+  it("rejects missing, illegal, and reserved profile names before authorization", async () => {
+    for (const profile of [true, "company account", "default"]) {
+      const runner = vi.fn<CommandRunner>();
+
+      await expect(accountsCommand({profile}, runner)).rejects.toThrow(
+        /profile|Wrangler/iu,
+      );
+      expect(runner).not.toHaveBeenCalled();
+    }
+  });
 });
 
 describe("deployment verification URL", () => {


### PR DESCRIPTION
## Summary

- add `yarn manage accounts --profile <name>` for creating or selecting separate local Cloudflare logins
- preserve existing profiles unless `--reauthorize` is explicitly requested
- validate profile names before opening Cloudflare authorization
- list every saved profile, identify the active login, explain the account scope, and print exact profile-switch commands
- document named-profile behavior in the README, CLI reference, terminal help, and deployment guidance

## Why

People often use personal and company Cloudflare logins on the same computer. The management CLI previously exposed only the active login, which made other saved profiles appear missing and made the distinction between a local login profile and a Cloudflare account unclear.

This change keeps those logins separate, binds the selected profile to the local repository, and makes the active login and its accessible Cloudflare accounts explicit.

## Validation

- `yarn typecheck`
- `yarn test` — 156 tests passed
- `yarn build`
- live read-only verification with `yarn manage accounts`
