### PR TITLE
Improve microfeed development and CI workflows

### DIFF
--- a/.agents/skills/develop-microfeed/SKILL.md
+++ b/.agents/skills/develop-microfeed/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: develop-microfeed
+description: Develop and contribute changes to the microfeed repository safely from branch creation through validation, commit, push, and draft pull request. Use when Codex is asked to implement a feature, fix a bug, refactor code, add tests, update documentation or CI, or perform other repository maintenance. Do not use for read-only questions, explanations, reviews, or status reports.
+---
+
+# Develop microfeed
+
+Follow the repository's [agent rules](../../../AGENTS.md) and human-facing
+[contribution guide](../../../CONTRIBUTING.md). Keep the change focused and
+leave the repository in a reviewable state.
+
+## Prepare the work
+
+1. Confirm the repository root contains `package.json`, `yarn.lock`, `src/`,
+   and `manage-cli/`.
+2. Inspect `git status --short`, the current branch, recent commits, worktrees,
+   and remotes before editing. Identify exactly which existing changes belong
+   to the task.
+3. Never work directly on `main`. Continue an existing task branch when it is
+   relevant, or create `<type>/<short-kebab-case>` using the primary outcome:
+   - `feature`: new user-facing behavior
+   - `fix`: defect correction
+   - `docs`: documentation only
+   - `refactor`: behavior-preserving restructuring
+   - `test`: test-only work
+   - `ci`: continuous-integration changes
+   - `chore`: repository maintenance spanning other categories
+4. Base ordinary work on the current upstream `main`. Use another base only
+   when the user explicitly requests dependent or stacked work.
+5. If unrelated changes are present, preserve them exactly. Create an isolated
+   worktree and transfer only known task hunks. Never stash, reset, discard, or
+   silently include unrelated files.
+
+## Implement the change
+
+1. Inspect the affected implementation, tests, and documentation before
+   editing. Prefer the smallest coherent change that satisfies the request.
+2. Respect the source boundaries, frontend component rules, and interactive
+   styling requirements in `AGENTS.md`.
+3. Add or update focused tests for behavior changes and regression fixes.
+   Update contributor or user documentation when commands, behavior, or public
+   expectations change.
+4. Treat Cloudflare deployment as a separate workflow. Invoke
+   [`deploy-microfeed`](../deploy-microfeed/SKILL.md) for any install, deploy,
+   publish, configure, or destroy request; do not improvise deployment steps.
+5. Do not commit secrets, local instance state, build output, generated Worker
+   types, or unrelated formatting changes.
+
+## Validate and review
+
+1. Run targeted tests or checks while iterating.
+2. Before committing, run:
+
+   ```console
+   git diff --check
+   yarn check
+   ```
+
+3. If the local sandbox blocks Wrangler logging or Worker test ports, request
+   the minimum permission needed and rerun the same check.
+4. Review `git status --short`, the complete diff, generated files, and the
+   proposed commit scope. Resolve failures before publishing; do not weaken or
+   skip checks to obtain a passing result.
+
+## Commit and publish
+
+1. Stage explicit task paths, not the entire mixed worktree. Commit with a
+   concise imperative title that describes the full change; Conventional
+   Commit prefixes are optional.
+2. Treat publishing as available only when the configured Git remote can push
+   and either the connected GitHub integration can create a pull request or
+   `gh auth status` succeeds. Never ask for a token or credential in chat.
+3. Push the topic branch to `microfeed/microfeed` when the authenticated user
+   has write access. Otherwise reuse an existing contributor fork and keep the
+   PR target on `microfeed/microfeed`. Obtain approval before creating a new
+   fork or adding a new external repository.
+4. Open a draft pull request against the requested base, defaulting to `main`.
+   Prefer the connected GitHub integration and use `gh pr create --draft` as a
+   fallback. Use the repository PR template and include the change, rationale,
+   developer or user impact, related issue when one exists, validation, risks,
+   and screenshots for visible UI changes.
+5. If authentication, push permission, an existing fork, or a remote base is
+   unavailable, keep the validated local commit and report the exact missing
+   prerequisite. Do not improvise another remote or expose credentials.
+6. Report the branch, commit, PR repository and base, draft URL, and validation
+   results. Never mark a draft ready for review or merge it unless the user
+   explicitly requests that separate action.
+
+## Protect history and scope
+
+- Do not rewrite, delete, squash, rebase, force-push, or retarget another
+  contributor's branch. For an agent-owned stacked branch, verify the exact
+  refs before rebasing and use only `--force-with-lease`.
+- Do not broaden a development request into a deployment, release, repository
+  settings change, fork creation, or merge without explicit authorization.
+- Keep each pull request small enough to review as one logical change. Split
+  unrelated outcomes into separate branches and draft pull requests.

--- a/.agents/skills/develop-microfeed/agents/openai.yaml
+++ b/.agents/skills/develop-microfeed/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Develop microfeed"
+  short_description: "Develop and publish microfeed changes safely"
+  default_prompt: "Use $develop-microfeed to implement a focused microfeed change and open a validated draft pull request."
+
+policy:
+  allow_implicit_invocation: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+<!-- What changed, why it changed, and who it helps. -->
+
+## Related issue
+
+<!-- Link an issue when one exists, for example: Closes #123. -->
+
+## Testing
+
+<!-- List the checks you ran and their results. Explain any checks not run. -->
+
+- [ ] `yarn check`
+
+## Screenshots
+
+<!-- Add before-and-after screenshots for visible UI changes, or write N/A. -->
+
+## Risks
+
+<!-- Note compatibility, migration, rollout, or follow-up concerns, or write None. -->
+
+## Checklist
+
+- [ ] This pull request contains one focused change.
+- [ ] Tests were added or updated when behavior changed.
+- [ ] Documentation was updated when commands or public behavior changed.
+- [ ] No secrets, private configuration, production data, or generated files are included.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js 24
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: yarn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,20 @@
 # Repository guidance
 
+## Development workflow
+
+- When a user asks to implement, fix, refactor, test, document, update CI, or
+  otherwise change this repository, use the `develop-microfeed` skill. Do not
+  use it for read-only questions, explanations, reviews, or status reports.
+- Do not make changes directly on `main`. Create or continue a focused branch
+  named `<type>/<short-kebab-case>` where `<type>` is `feature`, `fix`, `docs`,
+  `refactor`, `test`, `ci`, or `chore`. Existing nonconforming branches may be
+  continued when they already contain the task's work.
+- Preserve unrelated changes. Never stash, reset, discard, or stage them to
+  make a task branch clean; use an isolated worktree when necessary.
+- Before publishing, run `git diff --check` and `yarn check`, commit only the
+  scoped files with a concise imperative title, and open a draft pull request
+  against `microfeed/microfeed` when GitHub authentication is available.
+
 ## Cloudflare deployment
 
 - When a user asks to install, deploy, publish, update, configure, destroy,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to microfeed
+
+Thank you for helping improve microfeed. Keep contributions focused, explain
+why the change is useful, and leave the project easier to maintain.
+
+## Before you start
+
+- Search the existing [issues](https://github.com/microfeed/microfeed/issues)
+  and pull requests before starting duplicate work.
+- Open an issue before a substantial feature or architectural change so the
+  approach can be discussed. Small fixes and documentation improvements may go
+  directly to a pull request.
+- Never include passwords, API tokens, `.dev.vars`, `.microfeed/`, production
+  data, or other private configuration in an issue, commit, or pull request.
+
+## Set up local development
+
+Use Node.js 24 and Corepack. The package supports Node.js `>=22.12.0`, but
+development and CI use Node.js 24 without pinning a patch release.
+
+```console
+corepack enable
+yarn install --immutable
+yarn manage init --local --instance personal
+yarn dev --instance personal
+```
+
+Local instances use isolated D1 and R2 simulations and never access or copy
+production data. Create another instance by choosing another name:
+
+```console
+yarn manage init --local --instance company
+yarn dev --instance company
+```
+
+The development URL is printed by Astro. Only one development server at a time
+is supported.
+
+## Choose a branch
+
+Do not commit directly to `main`. Use a lowercase, kebab-case topic branch in
+the form `<type>/<short-description>`:
+
+| Type | Use for | Example |
+| --- | --- | --- |
+| `feature` | New user-facing behavior | `feature/new-editor` |
+| `fix` | Defect corrections | `fix/media-upload-timeout` |
+| `docs` | Documentation only | `docs/local-development` |
+| `refactor` | Behavior-preserving restructuring | `refactor/feed-builder` |
+| `test` | Test-only changes | `test/password-setup` |
+| `ci` | Continuous-integration changes | `ci/update-actions` |
+| `chore` | Cross-cutting repository maintenance | `chore/development-workflow` |
+
+Choose the type that describes the primary outcome. Existing nonconforming
+branches may be completed, but new work should follow this convention.
+
+## Make a focused change
+
+- Follow the architecture and component rules in [AGENTS.md](AGENTS.md).
+- Keep Astro and Worker application code under `src/`; respect the boundaries
+  between `src/server/`, `src/client/`, and `src/shared/`.
+- Keep deployment tooling in `manage-cli/` and update `docs/manage-cli.md` plus
+  `manage-cli/help.ts` together whenever command behavior changes.
+- Add or update tests for behavior changes and regression fixes.
+- Update documentation when commands, public behavior, or contributor
+  expectations change.
+- Avoid unrelated formatting, dependency, or refactoring changes.
+
+Write focused commits with concise imperative titles such as
+`Handle expired upload URLs`. Conventional Commit prefixes are welcome but not
+required.
+
+## Validate the change
+
+Run relevant targeted tests while developing. Before opening a pull request,
+run the complete repository check:
+
+```console
+yarn check
+```
+
+This type-checks the project, runs unit and Worker tests, builds the production
+application, and verifies the Worker bundle with a dry run. Also run
+`git diff --check` and review the complete diff for generated files and
+secrets.
+
+## Open a pull request
+
+- Open the pull request as a draft until the change and validation are ready
+  for review.
+- Use a concise imperative title and explain what changed, why, the impact,
+  tests performed, and any known risks.
+- Link an issue when one exists; an issue is not required for a small fix.
+- Include before-and-after screenshots for visible interface changes.
+- Keep the pull request to one logical outcome and respond to review feedback
+  with focused follow-up commits.
+
+By contributing, you agree that your contribution is licensed under the
+repository's [GNU Affero General Public License v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ If you have any questions or feedback, please don't hesitate to reach out to us 
 * [✍️ Start publishing](#%EF%B8%8F-start-publishing)
 * [💻 FAQs](#-faqs)
 * [💪 Contributions](#-contributions)
-  * [Run microfeed on local](#run-microfeed-on-local)
 * [🛡️ License](#%EF%B8%8F-license)
 
 ## ⭐️ How it works
@@ -795,69 +794,12 @@ You may need to write a script to use [S3-compatible APIs](https://developers.cl
 [Back to 📚TOC](#-table-of-contents)
 
 ## 💪 Contributions
-We welcome contributions to microfeed!
-If you have an idea for a new feature or have found a bug, please [open an issue](https://github.com/microfeed/microfeed/issues/new) in the repository.
-If you'd like to submit a fix or new feature, please create a pull request with a detailed description of your changes.
 
-### Run microfeed on local
-
-Pre-requisites: Node.js 24, Corepack, and Wrangler.
-
-Install dependencies and start the Astro development server:
-
-```console
-corepack enable
-yarn install
-yarn manage init --local --instance personal
-yarn dev --instance personal
-```
-
-Create another fully isolated local instance by choosing another name:
-
-```console
-yarn manage init --local --instance company
-yarn manage use company
-yarn dev
-```
-
-`yarn manage auth setup --local` remains available as a shortcut: in a newly
-created local Git copy of the repository it creates the default `local`
-instance, and for an existing selected instance it configures that instance's
-local dashboard login.
-
-The local initialization prompt lets you skip the built-in login. If you skip it, the
-local dashboard opens without a sign-in screen; enable it later with
-`yarn manage auth setup --local --instance <name>`.
-
-Wrangler provides separate persistent D1 and R2 simulations for every
-instance, and microfeed prepares local database migrations automatically.
-Admin accounts, content, uploaded media, and development secrets are isolated
-between instance names.
-
-You can also run a connected Cloudflare instance locally:
-
-```console
-yarn dev --instance company-changelog
-```
-
-This selects the deployment's configuration shape while still using its
-isolated local D1 and R2 simulations. It never accesses, copies, or changes
-production data, and there is no automatic local-to-production or
-production-to-local synchronization.
-
-The development URL is printed by Astro. One development server at a time is
-supported; automatic port allocation for concurrent instances is not
-currently provided.
-
-Before opening a pull request, run:
-
-```console
-yarn check
-```
-
-The application is written in strict TypeScript and uses Astro with the official Cloudflare adapter, React islands, Vite, and Vitest.
-The package supports Node.js `>=22.12.0`; development and CI use Node.js 24 without pinning a patch release.
-Deployed Workers run on Cloudflare's `workerd` runtime rather than Node.js.
+We welcome bug fixes, features, tests, documentation, and other improvements.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, architecture rules,
+branch naming, validation, and pull request expectations. For substantial
+features or architectural changes, please open an
+[issue](https://github.com/microfeed/microfeed/issues/new) before starting.
 
 [Back to 📚TOC](#-table-of-contents)
 


### PR DESCRIPTION
## Summary

- add a repo-owned `develop-microfeed` skill for branch, validation, commit,
  push, and draft-PR workflows
- make `CONTRIBUTING.md` the human-facing source of truth and add a pull-request
  template
- add concise development invariants to `AGENTS.md` and link the README to the
  contribution guide
- upgrade `actions/checkout` and `actions/setup-node` from v4 to v6 while
  preserving Node.js 24 and Yarn caching

## Related issue

N/A

## Testing

- [x] `yarn check`
- [x] skill creator `quick_validate.py`
- [x] workflow and skill metadata YAML parsing
- [x] `git diff --check`
- [x] three independent dry-run skill scenarios covering clean feature work,
  unrelated dirty changes, and GitHub authentication availability

## Screenshots

N/A — contributor documentation and CI configuration only.

## Risks

Low. This changes contributor and agent workflows but does not change
application runtime behavior, public APIs, data, or deployment configuration.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files
  are included.
