### PR TITLE
Correct package license to AGPL-3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "private": true,
   "type": "module",
-  "license": "MIT",
+  "license": "AGPL-3.0",
   "packageManager": "yarn@4.18.0",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary

- Change the package manifest license from `MIT` to `AGPL-3.0`.
- Align package metadata with the root `LICENSE`, README, and contribution guide.
- Confirm that no other tracked project files declare a conflicting project license.

## Related issue

None.

## Testing

- [x] `git diff --check`
- [x] `yarn check` (204 unit tests and 19 Worker tests passed)

## Screenshots

N/A — package metadata only.

## Risks

None. This corrects package metadata and does not change runtime behavior.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed. (No behavior change.)
- [x] Documentation was updated when commands or public behavior changed. (No command or public behavior change.)
- [x] No secrets, private configuration, production data, or generated files are included.
