### PR TITLE
Improve existing instance connection guidance

### DIFF
--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -270,6 +270,11 @@ project with the same name. Explicit invalid names are rejected before
 Cloudflare authorization. D1 database and R2 bucket names are validated
 separately before resource creation.
 
+If a same-named Worker exists but this clone has no saved state for it, `init`
+stops without overwriting it. Use the exact `yarn manage connect --worker
+<name> --instance <name>` command printed by the error when that Worker is an
+existing microfeed installation. Otherwise, choose a different project name.
+
 If resource provisioning or the first-password handoff is incomplete, `init`
 resumes only the unfinished work and preserves every recorded resource. When
 the installation and dashboard login are already ready, it stops without
@@ -324,6 +329,11 @@ yarn manage deploy [--instance <name>] [--preview|--local] [--enable-r2]
 | `--enable-r2` | Require R2 entitlement and permanently prepare/bind the saved bucket, or add the simulated binding with `--local`. Idempotent when already ready. |
 | `--reuse-r2` | Explicitly approve reuse if the saved bucket name already exists during Cloudflare enablement. `--enable-r2` alone never approves reuse. |
 | `--yes` | Run without optional prompts. Pending R2 remains automatic and content-only unless `--enable-r2` is supplied. |
+
+`deploy` only operates on instances with configuration saved in this clone. If
+the microfeed already exists on Cloudflare, run `yarn manage connect --instance
+<name>` first and select its Worker. If it does not exist yet, run `yarn manage
+init --instance <name>` instead.
 
 An ordinary deployment does not probe or prompt when media storage is already
 ready or explicitly disabled. For automatic pending setup, `NotEntitled`

--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -1808,9 +1808,14 @@ async function initializeProduction(context: CommandContext): Promise<void> {
     projectName,
   );
   if (workerExists && !relatedSavedState) {
+    const localInstanceName = context.instanceName ??
+      normalizeLocalInstanceName(projectName);
     throw new Error(
-      `A Worker named \`${projectName}\` already exists. microfeed will not ` +
-      "overwrite an unrelated Worker. Choose a different project name.",
+      `A Worker named \`${projectName}\` already exists, but this clone has ` +
+      "no saved state for it. microfeed will not overwrite it. If it is an " +
+      "existing microfeed installation, connect it with " +
+      `\`yarn manage connect --worker ${projectName} --instance ` +
+      `${localInstanceName}\`. Otherwise, choose a different project name.`,
     );
   }
 

--- a/manage-cli/help.ts
+++ b/manage-cli/help.ts
@@ -52,6 +52,7 @@ export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
       "If Cloudflare returns its subscription-required R2 response, initialization completes in content-only mode and prints the account-specific activation and billing handoff.",
       "Preview initialization creates a separate Worker and D1 database while reusing production media storage.",
       "Authentication is confirmed before creating D1 or R2 resources, an interrupted retry preserves whether each saved resource is owned or reused, and the restore fingerprint is recorded after all initialization steps finish.",
+      "If the selected Worker already exists without saved local state, initialization stops without overwriting it and points existing microfeed installations to connect.",
       "A newly created Cloudflare account may need a few minutes to prepare workers.dev before its first Worker deploy; rerun the same init command to resume safely.",
       "Built-in authentication normally prints a private browser link for setting the first password.",
       "A completed installation stops with guidance to use deploy, status, domain, or auth instead.",
@@ -110,6 +111,7 @@ export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
   {
     changes: "Updates a selected Cloudflare Worker, or prepares a local-only release with --local.",
     details: [
+      "Deploy requires saved local instance configuration. Use connect for an existing Cloudflare microfeed or init for a new installation.",
       "Runs type checks, tests, and a build before deploying, then verifies the public site and protected admin route.",
       "A content-only installation deploys normally. Automatic pending setup prompts once when R2 becomes available; a decline is remembered, while non-interactive runs print the deterministic enable command.",
       "--enable-r2 requires Cloudflare R2 entitlement, creates or explicitly reuses the saved bucket, deploys MEDIA_BUCKET, and verifies the exact bucket and Worker binding before completing.",

--- a/manage-cli/lib/config.ts
+++ b/manage-cli/lib/config.ts
@@ -692,12 +692,18 @@ export async function ensureWranglerConfig(
     const suffix = selectedInstance
       ? ` for instance \`${selectedInstance}\``
       : "";
+    const instanceOption = selectedInstance
+      ? ` --instance ${selectedInstance}`
+      : "";
     throw new Error(
       preview
         ? `No preview environment was found${suffix}. Run ` +
           "`yarn manage init --preview` first."
-        : `No saved microfeed configuration was found${suffix}. Run ` +
-          "`yarn manage init` first.",
+        : `No saved local microfeed configuration was found${suffix}. ` +
+          "To connect an existing Cloudflare microfeed under this local " +
+          `name, run \`yarn manage connect${instanceOption}\`. To create a ` +
+          "new Cloudflare installation, run " +
+          `\`yarn manage init${instanceOption}\`.`,
     );
   }
   if (config && !allowLocal && isLocalOnly(config)) {

--- a/tests/unit/manage-cli/instance-management.test.ts
+++ b/tests/unit/manage-cli/instance-management.test.ts
@@ -536,6 +536,22 @@ describe("first-class local instances", () => {
     expect(runner).not.toHaveBeenCalled();
   });
 
+  it("distinguishes connecting from initializing when deploy has no local state", async () => {
+    const {commands} = await freshModules();
+    const runner = vi.fn<CommandRunner>();
+
+    await expect(
+      commands.deployCommand({instance: "existing-feed"}, runner),
+    ).rejects.toThrow(
+      "No saved local microfeed configuration was found for instance " +
+        "`existing-feed`. To connect an existing Cloudflare microfeed " +
+        "under this local name, run `yarn manage connect --instance " +
+        "existing-feed`. To create a new Cloudflare installation, run " +
+        "`yarn manage init --instance existing-feed`.",
+    );
+    expect(runner).not.toHaveBeenCalled();
+  });
+
   it("creates a content-only local instance and enables simulated R2 later", async () => {
     const {commands, config} = await freshModules();
     const runner = vi.fn<CommandRunner>(async (_executable, args) => {
@@ -621,6 +637,50 @@ describe("first-class local instances", () => {
 });
 
 describe("initialization lifecycle", () => {
+  it("points an existing same-named Worker to connect", async () => {
+    const {commands} = await freshModules();
+    const runner = vi.fn<CommandRunner>(async (_executable, args) => {
+      const command = args.join(" ");
+      if (command === "whoami --json") {
+        return commandResult(JSON.stringify({
+          accounts: [{id: "account-id", name: "Personal"}],
+          authType: "OAuth Token",
+          email: "cloudflare@example.com",
+          tokenPermissions: requiredScopes,
+        }));
+      }
+      if (command === "pages project list --json") {
+        return commandResult("[]");
+      }
+      if (
+        command === "versions list --name existing-feed --json"
+      ) {
+        return commandResult("[]");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+
+    await expect(commands.initCommand({
+      "account-id": "account-id",
+      "admin-path": "admin",
+      "d1-name": "existing-feed-db",
+      instance: "local-feed",
+      "project-name": "existing-feed",
+      "r2-name": "existing-feed-media",
+      yes: true,
+    }, runner)).rejects.toThrow(
+      "A Worker named `existing-feed` already exists, but this clone has " +
+        "no saved state for it. microfeed will not overwrite it. If it is " +
+        "an existing microfeed installation, connect it with " +
+        "`yarn manage connect --worker existing-feed --instance " +
+        "local-feed`. Otherwise, choose a different project name.",
+    );
+    const commandsRun = runner.mock.calls.map(([, args]) => args.join(" "));
+    expect(commandsRun.some((command) =>
+      /(?:d1 create|r2 bucket create|deploy)/u.test(command)
+    )).toBe(false);
+  });
+
   it("defers, explicitly enables, and collision-guards Cloudflare R2", async () => {
     const {commands, config} = await freshModules();
     const {CloudflareClient} = await import(

--- a/tests/unit/manage-cli/manage-cli-help.test.ts
+++ b/tests/unit/manage-cli/manage-cli-help.test.ts
@@ -57,6 +57,11 @@ describe("management CLI help and canonical reference", () => {
     expect(initHelp).toContain("my-domainname-com");
     expect(initHelp).toContain("newly created Cloudflare account");
     expect(initHelp).toContain("rerun the same init command");
+    expect(initHelp).toContain("points existing microfeed installations to connect");
+
+    const deployHelp = renderCliHelp("deploy");
+    expect(deployHelp).toContain("Use connect for an existing Cloudflare microfeed");
+    expect(deployHelp).toContain("init for a new installation");
   });
 
   it("keeps every command and option discoverable in the Markdown contract", async () => {


### PR DESCRIPTION
## Summary

- Clarify that a missing deploy target means local configuration is absent, without implying the Cloudflare instance does not exist.
- Direct existing Cloudflare microfeeds to `connect` and new installations to `init`.
- Add an exact `connect` command when initialization finds a same-named Worker without saved local state.
- Keep CLI help and the canonical management documentation synchronized, with regression coverage for both paths.

## Related issue

None.

## Testing

- [x] `yarn vitest run tests/unit/manage-cli/instance-management.test.ts tests/unit/manage-cli/manage-cli-help.test.ts` (27 tests passed)
- [x] `git diff --check`
- [x] `yarn check` (223 unit tests and 19 Worker tests passed; type checks, build, and Wrangler dry run completed)

## Screenshots

N/A — command-line guidance only.

## Risks

Low. This changes error and help text only; existing collision protection, identity verification, and Cloudflare mutation behavior remain unchanged.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.