### PR TITLE
Add microfeed feature design principles

### DIFF
--- a/.agents/skills/develop-microfeed/SKILL.md
+++ b/.agents/skills/develop-microfeed/SKILL.md
@@ -9,6 +9,24 @@ Follow the repository's [agent rules](../../../AGENTS.md) and human-facing
 [contribution guide](../../../CONTRIBUTING.md). Keep the change focused and
 leave the repository in a reviewable state.
 
+## Design principles
+
+- **Keep Cloudflare Free sufficient.** Keep every feature required for initial
+  deployment or normal core use available on Cloudflare Free. Before
+  implementation, verify the current official Cloudflare documentation for
+  service availability and every limit the design exercises. Evaluate
+  worst-case Worker CPU time and relevant request, storage, operation, payload,
+  and other quotas; do not copy changing numeric limits into this skill.
+  Redesign an essential path that does not fit. Permit paid-only capabilities
+  only as optional enhancements with complete free-account behavior.
+- **Design for people, with or without an agent.** Assume no technical fluency
+  across the product interface, `yarn manage`, documentation, and agent
+  guidance. Use familiar, task-oriented vocabulary first; introduce technical
+  terms only when necessary and explain them where they appear. Keep deployment
+  on one `yarn manage` workflow that works directly or through an agent, and
+  make its choices, effects, progress, and recovery steps clear. Do not depend
+  on an agent-only deployment path.
+
 ## Prepare the work
 
 1. Confirm the repository root contains `package.json`, `yarn.lock`, `src/`,


### PR DESCRIPTION
## Summary

- Add feature-design principles to the develop-microfeed skill.
- Keep essential features and the default deployment compatible with Cloudflare Free, with current official limit reviews including Worker CPU.
- Require plain-language design across the product, management CLI, documentation, and agent guidance while preserving the shared yarn manage deployment workflow.

## Related issue

N/A

## Testing

- [x] Skill validation with quick_validate.py
- [x] Manual review against paid-only, CPU-intensive, and Cloudflare-jargon scenarios
- [x] git diff --check
- [x] yarn check

## Screenshots

N/A — skill guidance only.

## Risks

None. This changes development guidance without changing runtime behavior or public interfaces.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.