### PR TITLE
Refine single-select focus behavior

### DIFF
--- a/src/components/admin/shared/AdminSelect/index.tsx
+++ b/src/components/admin/shared/AdminSelect/index.tsx
@@ -56,6 +56,8 @@ const ADMIN_SELECT_INDICATORS_CLASS =
   "my-2 flex shrink-0 self-stretch items-center border-l border-[#cccccc] px-0.5";
 const ADMIN_SELECT_TRIGGER_CLASS =
   "size-8 rounded-none px-0 focus-visible:ring-0";
+const ADMIN_SINGLE_SELECT_INPUT_CLASS =
+  "focus:border-0 focus:outline-none focus:ring-0 focus:ring-offset-0 focus:shadow-none";
 
 const optionText = <Option extends AdminSelectOption>(option: Option) =>
   option.textValue ?? (typeof option.label === "string" ? option.label : option.value);
@@ -200,7 +202,7 @@ export default function AdminSelect<Option extends AdminSelectOption>(
           <ComboboxInputGroup ref={anchorRef} className={ADMIN_SELECT_CONTROL_CLASS}>
             <div
               data-slot="admin-select-input-container"
-              className="relative ml-1 flex min-h-9 min-w-0 flex-1 items-stretch"
+              className="group/admin-select-input relative flex min-h-9 min-w-0 flex-1 items-stretch"
             >
               {props.value && (
                 <ComboboxValue>
@@ -208,7 +210,7 @@ export default function AdminSelect<Option extends AdminSelectOption>(
                     <div
                       data-slot="admin-select-value"
                       className={singleInputValue === ""
-                        ? "pointer-events-none flex min-w-0 flex-1 items-center overflow-hidden px-2.5 py-1 text-sm"
+                        ? "pointer-events-none flex min-w-0 flex-1 items-center overflow-hidden px-2.5 py-1 text-sm group-focus-within/admin-select-input:pl-4"
                         : "invisible flex min-w-0 flex-1 items-center overflow-hidden px-2.5 py-1 text-sm"
                       }
                     >
@@ -220,8 +222,8 @@ export default function AdminSelect<Option extends AdminSelectOption>(
               <ComboboxInput
                 aria-label={accessibleLabel}
                 className={props.value
-                  ? `absolute inset-0 h-full w-full px-2.5 py-1 text-sm ${singleInputValue === "" ? "caret-transparent text-transparent" : "text-black"}`
-                  : "h-9 w-full px-2.5 py-1 text-sm"
+                  ? `absolute inset-0 h-full w-full px-2.5 py-1 text-sm ${ADMIN_SINGLE_SELECT_INPUT_CLASS} ${singleInputValue === "" ? "caret-transparent text-transparent focus:caret-black" : "text-black"}`
+                  : `h-9 w-full px-2.5 py-1 text-sm ${ADMIN_SINGLE_SELECT_INPUT_CLASS}`
                 }
                 placeholder={props.value
                   ? ""

--- a/tests/unit/components/admin-select.test.ts
+++ b/tests/unit/components/admin-select.test.ts
@@ -27,7 +27,13 @@ describe("AdminSelect", () => {
     expect(output).toContain('aria-label="Category"');
     expect(output).toContain('data-slot="admin-select-input-container"');
     expect(output).toContain('data-slot="admin-select-value"');
-    expect(output).toContain("ml-1");
+    expect(output).toContain("group/admin-select-input");
+    expect(output).toContain("group-focus-within/admin-select-input:pl-4");
+    expect(output).toContain("caret-transparent");
+    expect(output).toContain("focus:caret-black");
+    expect(output).toContain("focus:ring-0");
+    expect(output).toContain("focus:shadow-none");
+    expect(output).not.toContain("ml-1");
     expect(output).toContain("rounded-[4px]");
     expect(output).toContain("border-black");
     expect(output).toContain("focus-within:border-[#2684ff]");
@@ -77,6 +83,9 @@ describe("AdminSelect", () => {
     expect(output).toContain('aria-label="Open Categories"');
     expect(output).toContain("rounded-[2px]");
     expect(output).toContain("bg-[#e6e6e6]");
+    expect(output).not.toContain("focus:caret-black");
+    expect(output).not.toContain("focus:ring-0");
+    expect(output).not.toContain("focus:shadow-none");
   });
 
   it("only gives the empty state layout when no options match", () => {


### PR DESCRIPTION
## Summary

- Remove the overlapping inner focus box from single-select controls while preserving the outer legacy blue focus treatment.
- Show a native blinking caret before the selected value when a single select is focused, making its text-search behavior discoverable.
- Keep the multi-select inner search input and focus behavior unchanged.
- Extend `AdminSelect` regression coverage for the single- and multi-select focus differences.

## Related issue

Follow-up to #218.

## Testing

- [x] `yarn vitest run tests/unit/components/admin-select.test.ts`
- [x] `git diff --check`
- [x] `yarn check`
- [x] Manually verified the focused native caret, selected-label spacing, typed search filtering, and unchanged multi-select behavior in a local browser preview.

## Screenshots

N/A — visually verified against the screenshots supplied with the task in a local browser preview.

## Risks

Low. The change is isolated to focused single-select presentation; search behavior remains backed by the existing Base UI input, and multi-select behavior is explicitly unchanged and covered by regression assertions.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed (not applicable).
- [x] No secrets, private configuration, production data, or generated files are included.
