### PR TITLE
Refine admin settings and item pagination

### DIFF
--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -33,6 +33,7 @@ import {
   SETTINGS_CATEGORIES,
   STATUSES,
 } from "@/shared/Constants";
+import {ITEM_ORDERS, ITEM_SORTS} from "@/shared/ItemPagination";
 import {accessApplicationDashboardUrl} from "@/shared/CloudflareDashboard";
 import type {Account, CommandRunner, MicrofeedConfig} from "./types";
 import {
@@ -5352,6 +5353,25 @@ function validateRemoteRestoreBootstrapRows(input: {
   }
   const subscribeMethods = settings.get(SETTINGS_CATEGORIES.SUBSCRIBE_METHODS);
   const methods = subscribeMethods?.methods;
+  const webGlobalSettings = settings.get(
+    SETTINGS_CATEGORIES.WEB_GLOBAL_SETTINGS,
+  );
+  const sharedWebGlobalSettings = {
+    favicon: {
+      contentType: "image/png",
+      url: "/assets/default/favicon.png",
+    },
+    itemsPerPage: DEFAULT_ITEMS_PER_PAGE,
+    publicBucketUrl: "/media/",
+  };
+  const validWebGlobalSettings = isDeepStrictEqual(webGlobalSettings, {
+    ...sharedWebGlobalSettings,
+    itemsOrder: ITEM_ORDERS.DESC,
+    itemsSort: ITEM_SORTS.PUBLISHED_AT,
+  }) || isDeepStrictEqual(webGlobalSettings, {
+    ...sharedWebGlobalSettings,
+    itemsSortOrder: ITEMS_SORT_ORDERS.NEWEST_FIRST,
+  });
   if (
     settings.size !== 5 || !Array.isArray(methods) || methods.length !== 2 ||
     !validBootstrapSubscribeMethod(
@@ -5362,18 +5382,7 @@ function validateRemoteRestoreBootstrapRows(input: {
       methods[1],
       PREDEFINED_SUBSCRIBE_METHODS.json,
     ) ||
-    !isDeepStrictEqual(
-      settings.get(SETTINGS_CATEGORIES.WEB_GLOBAL_SETTINGS),
-      {
-        favicon: {
-          contentType: "image/png",
-          url: "/assets/default/favicon.png",
-        },
-        itemsPerPage: DEFAULT_ITEMS_PER_PAGE,
-        itemsSortOrder: ITEMS_SORT_ORDERS.NEWEST_FIRST,
-        publicBucketUrl: "/media/",
-      },
-    ) ||
+    !validWebGlobalSettings ||
     !isDeepStrictEqual(settings.get(SETTINGS_CATEGORIES.ACCESS), {
       currentPolicy: "public",
     }) ||

--- a/migrations/0005_normalize_item_timestamps.sql
+++ b/migrations/0005_normalize_item_timestamps.sql
@@ -1,0 +1,16 @@
+-- SQLite's CURRENT_TIMESTAMP uses `YYYY-MM-DD HH:MM:SS`, while application
+-- updates use RFC 3339. Keyset pagination compares these indexed TEXT values,
+-- so normalize legacy rows to one lexicographically sortable representation.
+UPDATE "items"
+SET
+  "created_at" = COALESCE(
+    strftime('%Y-%m-%dT%H:%M:%fZ', "created_at"),
+    "created_at"
+  ),
+  "updated_at" = COALESCE(
+    strftime('%Y-%m-%dT%H:%M:%fZ', "updated_at"),
+    "updated_at"
+  )
+WHERE
+  instr("created_at", 'T') = 0 OR
+  instr("updated_at", 'T') = 0;

--- a/src/client/AdminSettingsScroll.ts
+++ b/src/client/AdminSettingsScroll.ts
@@ -1,0 +1,50 @@
+import {ADMIN_SETTINGS_SECTIONS} from "@/shared/AdminSettingsNavigation";
+
+interface ScrollToAdminSettingsSectionOptions {
+  behavior?: ScrollBehavior;
+  offset?: number;
+}
+
+export function scrollToAdminSettingsSection(
+  sectionId: string,
+  {
+    behavior = "auto",
+    offset = 24,
+  }: ScrollToAdminSettingsSectionOptions = {},
+): boolean {
+  if (!ADMIN_SETTINGS_SECTIONS.some(({id}) => id === sectionId)) {
+    return false;
+  }
+
+  const element = document.getElementById(sectionId);
+  const scrollRoot = document.getElementById("admin-page-content");
+  if (!element || !scrollRoot) {
+    return false;
+  }
+
+  if (scrollRoot.scrollHeight <= scrollRoot.clientHeight) {
+    element.scrollIntoView({behavior, block: "start"});
+    return true;
+  }
+
+  const top = scrollRoot.scrollTop +
+    element.getBoundingClientRect().top -
+    scrollRoot.getBoundingClientRect().top -
+    offset;
+  scrollRoot.scrollTo({behavior, top});
+  return true;
+}
+
+export function scrollToAdminSettingsHash(
+  hash = window.location.hash,
+  options?: ScrollToAdminSettingsSectionOptions,
+): boolean {
+  if (!hash.startsWith("#")) {
+    return false;
+  }
+
+  return scrollToAdminSettingsSection(
+    decodeURIComponent(hash.slice(1)),
+    options,
+  );
+}

--- a/src/components/admin/AdminMobileNavigation.tsx
+++ b/src/components/admin/AdminMobileNavigation.tsx
@@ -10,13 +10,18 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import AdminSidebar from "./AdminSidebar";
-import type {AdminSidebarData} from "./admin-shell-types";
+import AdminSettingsSidebar from "./settings/AdminSettingsSidebar";
+import type {
+  AdminSettingsSidebarData,
+  AdminSidebarData,
+} from "./admin-shell-types";
 
 interface Props {
+  settingsSidebar?: AdminSettingsSidebarData;
   sidebar: AdminSidebarData;
 }
 
-export default function AdminMobileNavigation({sidebar}: Props) {
+export default function AdminMobileNavigation({settingsSidebar, sidebar}: Props) {
   const [navigationOpen, setNavigationOpen] = useState(false);
 
   return (
@@ -38,10 +43,17 @@ export default function AdminMobileNavigation({sidebar}: Props) {
         <SheetDescription className="sr-only">
           Navigate between microfeed dashboard pages.
         </SheetDescription>
-        <AdminSidebar
-          data={sidebar}
-          onNavigate={() => setNavigationOpen(false)}
-        />
+        {settingsSidebar ? (
+          <AdminSettingsSidebar
+            data={settingsSidebar}
+            onNavigate={() => setNavigationOpen(false)}
+          />
+        ) : (
+          <AdminSidebar
+            data={sidebar}
+            onNavigate={() => setNavigationOpen(false)}
+          />
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Code2Icon,
   Globe2Icon,
   HomeIcon,
   ListIcon,
@@ -14,6 +15,8 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import {buttonVariants} from "@/components/ui/button";
+import {cn} from "@/lib/utils";
 import {NAV_ITEMS} from "@/shared/Constants";
 import type {AdminNavItemId} from "@/shared/AdminNavigation";
 import AdminAboutDialog from "./AdminAboutDialog";
@@ -28,8 +31,8 @@ interface Props {
 const navigationIcons: Record<AdminNavItemId, typeof HomeIcon> = {
   [NAV_ITEMS.ADMIN_HOME]: HomeIcon,
   [NAV_ITEMS.EDIT_CHANNEL]: PencilIcon,
-  [NAV_ITEMS.NEW_ITEM]: PlusIcon,
   [NAV_ITEMS.ALL_ITEMS]: ListIcon,
+  [NAV_ITEMS.API]: Code2Icon,
   [NAV_ITEMS.SETTINGS]: SettingsIcon,
 };
 
@@ -77,6 +80,34 @@ export default function AdminSidebar({data, onNavigate}: Props) {
             />
           </DialogContent>
         </Dialog>
+      </div>
+
+      <div className="px-3 pb-2">
+        {data.newItem.disabled ? (
+          <span
+            aria-disabled="true"
+            className={cn(
+              buttonVariants({size: "lg"}),
+              "w-full cursor-not-allowed !text-white opacity-45",
+            )}
+          >
+            <PlusIcon aria-hidden="true" />
+            Add new item
+          </span>
+        ) : (
+          <a
+            className={cn(
+              buttonVariants({size: "lg"}),
+              "w-full !text-white hover:!text-white",
+            )}
+            data-astro-prefetch="hover"
+            href={data.newItem.url}
+            onClick={onNavigate}
+          >
+            <PlusIcon aria-hidden="true" />
+            Add new item
+          </a>
+        )}
       </div>
 
       <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-3" aria-label="Admin navigation">

--- a/src/components/admin/AdminTopBar.astro
+++ b/src/components/admin/AdminTopBar.astro
@@ -4,6 +4,7 @@ import AdminMobileNavigation from "@/components/admin/AdminMobileNavigation";
 import type {
   AdminBreadcrumb,
   AdminIdentitySummary,
+  AdminSettingsSidebarData,
   AdminSidebarData,
 } from "@/components/admin/admin-shell-types";
 
@@ -12,15 +13,23 @@ interface Props {
   breadcrumb?: AdminBreadcrumb;
   identity: AdminIdentitySummary;
   pageTitle: string;
+  settingsSidebar?: AdminSettingsSidebarData;
   sidebar: AdminSidebarData;
 }
 
-const {adminPath, breadcrumb, identity, pageTitle, sidebar} = Astro.props;
+const {
+  adminPath,
+  breadcrumb,
+  identity,
+  pageTitle,
+  settingsSidebar,
+  sidebar,
+} = Astro.props;
 ---
 
-<header class="sticky top-0 z-40 flex min-h-14 items-center gap-2 border-b bg-background/95 px-4 supports-backdrop-filter:backdrop-blur-md lg:grid lg:min-h-16 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] lg:gap-3 lg:px-6">
+<header class="sticky top-0 z-40 flex min-h-14 shrink-0 items-center gap-2 border-b bg-background/95 px-4 supports-backdrop-filter:backdrop-blur-md lg:grid lg:min-h-16 lg:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] lg:gap-3 lg:px-6">
   <div class="flex min-w-0 flex-1 items-center gap-2 lg:flex-initial">
-    <AdminMobileNavigation client:load {sidebar} />
+    <AdminMobileNavigation client:load {settingsSidebar} {sidebar} />
     <h1 class="truncate text-base font-semibold tracking-tight lg:hidden">{pageTitle}</h1>
     {
       breadcrumb && (

--- a/src/components/admin/admin-shell-types.ts
+++ b/src/components/admin/admin-shell-types.ts
@@ -1,4 +1,5 @@
 import type {AdminNavigationItem} from "@/shared/AdminNavigation";
+import type {AdminSettingsSection} from "@/shared/AdminSettingsNavigation";
 
 export interface AdminBreadcrumb {
   childName?: string;
@@ -35,7 +36,18 @@ export interface AdminSidebarData {
   channel: AdminChannelSummary;
   deployment: AdminDeploymentSummary;
   items: AdminNavigationItem[];
+  newItem: {
+    disabled: boolean;
+    url: string;
+  };
   publicLinks: AdminPublicLinks;
+}
+
+export interface AdminSettingsSidebarData {
+  activeSection?: AdminSettingsSection["id"];
+  backUrl: string;
+  deployment: AdminDeploymentSummary;
+  sectionsUrl: string;
 }
 
 export function adminChannelSummary(

--- a/src/components/admin/channel/EditChannelApp/index.tsx
+++ b/src/components/admin/channel/EditChannelApp/index.tsx
@@ -328,7 +328,7 @@ export default class EditChannelApp extends React.Component<Props, any> {
           </details>
         </div>
         <div className="xl:col-span-3">
-          <div className="grid gap-4 xl:sticky xl:top-0">
+          <div className="grid gap-4 xl:sticky xl:top-4">
             <div className="rounded-[14px] border bg-card p-5 text-center text-card-foreground shadow-xs">
               <Button
                 type="submit"

--- a/src/components/admin/items/AllItemsApp/index.tsx
+++ b/src/components/admin/items/AllItemsApp/index.tsx
@@ -24,12 +24,17 @@ import {
 } from "@/shared/Constants";
 import {
   buildItemsListUrl,
-  ITEM_LIST_SORT_ORDERS,
   ITEM_STATUS_FILTERS,
   type ItemStatusFilter,
-  itemListSortDefinition,
   normalizeItemStatusFilter,
 } from "@/shared/ItemList";
+import {
+  ITEM_ORDERS,
+  ITEM_SORTS,
+  type ItemOrder,
+  type ItemSort,
+  itemSortDefinition,
+} from "@/shared/ItemPagination";
 import {isValidMediaFile} from "@/shared/MediaFileUtils";
 import {
   ADMIN_URLS,
@@ -47,6 +52,7 @@ interface MediaFile {
 }
 
 interface ItemTableRow {
+  createdAtMs?: number;
   id: string;
   imageUrl?: string;
   mediaFile?: MediaFile;
@@ -182,6 +188,9 @@ function tableRows(items: FeedItem[], publicBucketUrl: string): ItemTableRow[] {
   return items.map((item) => {
     const image = String(item.image ?? "").trim();
     return {
+      createdAtMs: typeof item.createdAtMs === "number"
+        ? item.createdAtMs
+        : Number(item.createdAtMs),
       id: String(item.id ?? ""),
       imageUrl: image
         ? urlJoinWithRelative(publicBucketUrl, image) ?? undefined
@@ -202,10 +211,12 @@ function tableRows(items: FeedItem[], publicBucketUrl: string): ItemTableRow[] {
 
 function ItemStatusFilters({
   activeFilter,
-  sortOrder,
+  order,
+  sort,
 }: {
   activeFilter: ItemStatusFilter;
-  sortOrder: string;
+  order: ItemOrder;
+  sort: ItemSort;
 }) {
   return (
     <nav
@@ -223,7 +234,7 @@ function ItemStatusFilters({
               active &&
                 "border-brand-light bg-brand-light/10 text-brand-dark ring-1 ring-brand-light/20 hover:bg-brand-light/15 dark:border-brand-light dark:bg-brand-light/20 dark:text-white dark:ring-brand-light/50 dark:hover:bg-brand-light/25",
             )}
-            href={buildItemsListUrl({sortOrder, statusFilter})}
+            href={buildItemsListUrl({order, sort, statusFilter})}
             key={statusFilter}
           >
             {FILTER_LABELS[statusFilter]}
@@ -236,53 +247,49 @@ function ItemStatusFilters({
 
 function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) {
   const activeFilter = currentStatusFilter();
-  const sort = itemListSortDefinition(feed.items_sort_order);
-  const sortOrder = sort.order;
+  const sort = itemSortDefinition(feed.items_sort ?? ITEM_SORTS.UPDATED_AT);
+  const order = feed.items_order ?? ITEM_ORDERS.DESC;
   const nextUrl = feed.items_next_cursor === undefined
     ? undefined
     : buildItemsListUrl({
         nextCursor: feed.items_next_cursor,
-        sortOrder,
+        order,
+        sort: sort.sort,
         statusFilter: activeFilter,
       });
   const prevUrl = feed.items_prev_cursor === undefined
     ? undefined
     : buildItemsListUrl({
         prevCursor: feed.items_prev_cursor,
-        sortOrder,
+        order,
+        sort: sort.sort,
         statusFilter: activeFilter,
       });
 
   const sortableHeader = (
-    field: "published" | "updated",
+    field: ItemSort,
     label: string,
   ) => {
-    const active = field === "updated"
-      ? sort.column === "updated_at"
-      : sort.column === "pub_date";
-    const descendingOrder = field === "updated"
-      ? ITEM_LIST_SORT_ORDERS.UPDATED_DESC
-      : ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC;
-    const ascendingOrder = field === "updated"
-      ? ITEM_LIST_SORT_ORDERS.UPDATED_ASC
-      : ITEM_LIST_SORT_ORDERS.PUBLISHED_ASC;
-    const nextSortOrder = active && sort.descending
-      ? ascendingOrder
-      : descendingOrder;
+    const active = field === sort.sort;
+    const descending = order === ITEM_ORDERS.DESC;
+    const nextOrder = active && descending
+      ? ITEM_ORDERS.ASC
+      : ITEM_ORDERS.DESC;
     const sortUrl = buildItemsListUrl({
-      sortOrder: nextSortOrder,
+      order: nextOrder,
+      sort: field,
       statusFilter: activeFilter,
     });
     return (
       <a
         aria-label={active
-          ? `${label}, sorted ${sort.descending ? "descending" : "ascending"}. Sort ${sort.descending ? "ascending" : "descending"}.`
+          ? `${label}, sorted ${descending ? "descending" : "ascending"}. Sort ${descending ? "ascending" : "descending"}.`
           : `${label}. Sort descending.`}
         className="inline-flex items-center gap-1.5"
         href={sortUrl}
       >
         {label}
-        {active && (sort.descending
+        {active && (descending
           ? <ArrowDownIcon aria-hidden="true" className="size-4" />
           : <ArrowUpIcon aria-hidden="true" className="size-4" />)}
       </a>
@@ -330,11 +337,15 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
       },
     }),
     columnHelper.accessor("pubDateMs", {
-      header: () => sortableHeader("published", "Published at"),
+      header: () => sortableHeader(ITEM_SORTS.PUBLISHED_AT, "Published at"),
+      cell: (info) => formatPublishedAt(info.getValue()),
+    }),
+    columnHelper.accessor("createdAtMs", {
+      header: () => sortableHeader(ITEM_SORTS.CREATED_AT, "Created at"),
       cell: (info) => formatPublishedAt(info.getValue()),
     }),
     columnHelper.accessor("updatedAtMs", {
-      header: () => sortableHeader("updated", "Updated at"),
+      header: () => sortableHeader(ITEM_SORTS.UPDATED_AT, "Updated at"),
       cell: (info) => formatPublishedAt(info.getValue()),
     }),
     columnHelper.accessor("mediaFile", {
@@ -372,7 +383,7 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
 
   return (
     <div>
-      <ItemStatusFilters activeFilter={activeFilter} sortOrder={sortOrder} />
+      <ItemStatusFilters activeFilter={activeFilter} order={order} sort={sort.sort} />
       <div className="overflow-x-auto rounded-[14px] border bg-card">
         <table className="w-full min-w-[64rem] table-fixed border-collapse text-sm">
           <thead>
@@ -381,16 +392,18 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
                 {headerGroup.headers.map((header) => (
                   <th
                     aria-sort={
-                      (header.column.id === "pubDateMs" && sort.column === "pub_date") ||
-                        (header.column.id === "updatedAtMs" && sort.column === "updated_at")
-                        ? sort.descending ? "descending" : "ascending"
+                      (header.column.id === "pubDateMs" && sort.sort === ITEM_SORTS.PUBLISHED_AT) ||
+                        (header.column.id === "createdAtMs" && sort.sort === ITEM_SORTS.CREATED_AT) ||
+                        (header.column.id === "updatedAtMs" && sort.sort === ITEM_SORTS.UPDATED_AT)
+                        ? order === ITEM_ORDERS.DESC ? "descending" : "ascending"
                         : undefined
                     }
                     className={cn(
                       "border-b bg-muted/45 px-5 py-3 text-left text-sm font-semibold text-muted-foreground",
-                      header.column.id === "title" && "w-[36%]",
-                      header.column.id === "pubDateMs" && "w-[16%] whitespace-nowrap",
-                      header.column.id === "updatedAtMs" && "w-[16%] whitespace-nowrap",
+                      header.column.id === "title" && "w-[29%]",
+                      header.column.id === "pubDateMs" && "w-[13%] whitespace-nowrap",
+                      header.column.id === "createdAtMs" && "w-[13%] whitespace-nowrap",
+                      header.column.id === "updatedAtMs" && "w-[13%] whitespace-nowrap",
                       header.column.id === "mediaFile" && "w-[12%]",
                       header.column.id === "actions" && "w-[20%]",
                     )}
@@ -410,7 +423,7 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
           <tbody>
             {table.getRowModel().rows.length === 0 ? (
               <tr>
-                <td className="px-5 py-12 text-center" colSpan={5}>
+                <td className="px-5 py-12 text-center" colSpan={6}>
                   <div className="font-medium text-foreground">
                     No {activeFilter === "all" ? "" : `${activeFilter} `}items yet.
                   </div>
@@ -431,7 +444,7 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
                   <td
                     className={cn(
                       "px-5 py-4 align-middle text-foreground",
-                      ["pubDateMs", "updatedAtMs"].includes(cell.column.id) &&
+                      ["createdAtMs", "pubDateMs", "updatedAtMs"].includes(cell.column.id) &&
                         "whitespace-nowrap",
                     )}
                     key={cell.id}

--- a/src/components/admin/items/AllItemsApp/index.tsx
+++ b/src/components/admin/items/AllItemsApp/index.tsx
@@ -20,15 +20,15 @@ import {
   ENCLOSURE_CATEGORIES,
   ENCLOSURE_CATEGORIES_DICT,
   ITEM_STATUSES_DICT,
-  ITEMS_SORT_ORDERS,
   STATUSES,
 } from "@/shared/Constants";
 import {
   buildItemsListUrl,
+  ITEM_LIST_SORT_ORDERS,
   ITEM_STATUS_FILTERS,
   type ItemStatusFilter,
+  itemListSortDefinition,
   normalizeItemStatusFilter,
-  normalizeItemsSortOrder,
 } from "@/shared/ItemList";
 import {isValidMediaFile} from "@/shared/MediaFileUtils";
 import {
@@ -54,6 +54,7 @@ interface ItemTableRow {
   publicBucketUrl: string;
   status: number;
   title: string;
+  updatedAtMs?: number;
 }
 
 interface Props {
@@ -192,6 +193,9 @@ function tableRows(items: FeedItem[], publicBucketUrl: string): ItemTableRow[] {
       publicBucketUrl,
       status: typeof item.status === "number" ? item.status : STATUSES.PUBLISHED,
       title: String(item.title ?? "").trim() || "Untitled",
+      updatedAtMs: typeof item.updatedAtMs === "number"
+        ? item.updatedAtMs
+        : Number(item.updatedAtMs),
     };
   });
 }
@@ -217,7 +221,7 @@ function ItemStatusFilters({
               buttonVariants({size: "lg", variant: "outline"}),
               "w-full text-sm sm:text-base",
               active &&
-                "border-brand-light bg-brand-light/10 text-brand-dark ring-1 ring-brand-light/20 hover:bg-brand-light/15 dark:text-brand-light",
+                "border-brand-light bg-brand-light/10 text-brand-dark ring-1 ring-brand-light/20 hover:bg-brand-light/15 dark:border-brand-light dark:bg-brand-light/20 dark:text-white dark:ring-brand-light/50 dark:hover:bg-brand-light/25",
             )}
             href={buildItemsListUrl({sortOrder, statusFilter})}
             key={statusFilter}
@@ -232,15 +236,8 @@ function ItemStatusFilters({
 
 function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) {
   const activeFilter = currentStatusFilter();
-  const sortOrder = normalizeItemsSortOrder(feed.items_sort_order);
-  const newestFirst = sortOrder === ITEMS_SORT_ORDERS.NEWEST_FIRST;
-  const nextSortOrder = newestFirst
-    ? ITEMS_SORT_ORDERS.OLDEST_FIRST
-    : ITEMS_SORT_ORDERS.NEWEST_FIRST;
-  const sortUrl = buildItemsListUrl({
-    sortOrder: nextSortOrder,
-    statusFilter: activeFilter,
-  });
+  const sort = itemListSortDefinition(feed.items_sort_order);
+  const sortOrder = sort.order;
   const nextUrl = feed.items_next_cursor === undefined
     ? undefined
     : buildItemsListUrl({
@@ -255,6 +252,42 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
         sortOrder,
         statusFilter: activeFilter,
       });
+
+  const sortableHeader = (
+    field: "published" | "updated",
+    label: string,
+  ) => {
+    const active = field === "updated"
+      ? sort.column === "updated_at"
+      : sort.column === "pub_date";
+    const descendingOrder = field === "updated"
+      ? ITEM_LIST_SORT_ORDERS.UPDATED_DESC
+      : ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC;
+    const ascendingOrder = field === "updated"
+      ? ITEM_LIST_SORT_ORDERS.UPDATED_ASC
+      : ITEM_LIST_SORT_ORDERS.PUBLISHED_ASC;
+    const nextSortOrder = active && sort.descending
+      ? ascendingOrder
+      : descendingOrder;
+    const sortUrl = buildItemsListUrl({
+      sortOrder: nextSortOrder,
+      statusFilter: activeFilter,
+    });
+    return (
+      <a
+        aria-label={active
+          ? `${label}, sorted ${sort.descending ? "descending" : "ascending"}. Sort ${sort.descending ? "ascending" : "descending"}.`
+          : `${label}. Sort descending.`}
+        className="inline-flex items-center gap-1.5"
+        href={sortUrl}
+      >
+        {label}
+        {active && (sort.descending
+          ? <ArrowDownIcon aria-hidden="true" className="size-4" />
+          : <ArrowUpIcon aria-hidden="true" className="size-4" />)}
+      </a>
+    );
+  };
 
   const columns = [
     columnHelper.accessor("title", {
@@ -297,18 +330,11 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
       },
     }),
     columnHelper.accessor("pubDateMs", {
-      header: () => (
-        <a
-          aria-label={`Published at, sorted ${newestFirst ? "descending" : "ascending"}. Sort ${newestFirst ? "ascending" : "descending"}.`}
-          className="inline-flex items-center gap-1.5"
-          href={sortUrl}
-        >
-          Published at
-          {newestFirst
-            ? <ArrowDownIcon aria-hidden="true" className="size-4" />
-            : <ArrowUpIcon aria-hidden="true" className="size-4" />}
-        </a>
-      ),
+      header: () => sortableHeader("published", "Published at"),
+      cell: (info) => formatPublishedAt(info.getValue()),
+    }),
+    columnHelper.accessor("updatedAtMs", {
+      header: () => sortableHeader("updated", "Updated at"),
       cell: (info) => formatPublishedAt(info.getValue()),
     }),
     columnHelper.accessor("mediaFile", {
@@ -354,15 +380,19 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
                   <th
-                    aria-sort={header.column.id === "pubDateMs"
-                      ? newestFirst ? "descending" : "ascending"
-                      : undefined}
+                    aria-sort={
+                      (header.column.id === "pubDateMs" && sort.column === "pub_date") ||
+                        (header.column.id === "updatedAtMs" && sort.column === "updated_at")
+                        ? sort.descending ? "descending" : "ascending"
+                        : undefined
+                    }
                     className={cn(
                       "border-b bg-muted/45 px-5 py-3 text-left text-sm font-semibold text-muted-foreground",
-                      header.column.id === "title" && "w-[44%]",
-                      header.column.id === "pubDateMs" && "w-[20%] whitespace-nowrap",
-                      header.column.id === "mediaFile" && "w-[14%]",
-                      header.column.id === "actions" && "w-[22%]",
+                      header.column.id === "title" && "w-[36%]",
+                      header.column.id === "pubDateMs" && "w-[16%] whitespace-nowrap",
+                      header.column.id === "updatedAtMs" && "w-[16%] whitespace-nowrap",
+                      header.column.id === "mediaFile" && "w-[12%]",
+                      header.column.id === "actions" && "w-[20%]",
                     )}
                     key={header.id}
                   >
@@ -380,7 +410,7 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
           <tbody>
             {table.getRowModel().rows.length === 0 ? (
               <tr>
-                <td className="px-5 py-12 text-center" colSpan={4}>
+                <td className="px-5 py-12 text-center" colSpan={5}>
                   <div className="font-medium text-foreground">
                     No {activeFilter === "all" ? "" : `${activeFilter} `}items yet.
                   </div>
@@ -401,7 +431,8 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
                   <td
                     className={cn(
                       "px-5 py-4 align-middle text-foreground",
-                      cell.column.id === "pubDateMs" && "whitespace-nowrap",
+                      ["pubDateMs", "updatedAtMs"].includes(cell.column.id) &&
+                        "whitespace-nowrap",
                     )}
                     key={cell.id}
                   >

--- a/src/components/admin/items/EditItemApp/index.tsx
+++ b/src/components/admin/items/EditItemApp/index.tsx
@@ -422,7 +422,7 @@ export default class EditItemApp extends React.Component<Props, any> {
           </div>
         </div>
         <div className="xl:col-span-3">
-          <div className="grid gap-4 xl:sticky xl:top-0">
+          <div className="grid gap-4 xl:sticky xl:top-4">
             <div className="rounded-[14px] border bg-card p-5 text-center text-card-foreground shadow-xs">
               <Button
                 type="submit"

--- a/src/components/admin/settings/AccessSettingsApp/index.tsx
+++ b/src/components/admin/settings/AccessSettingsApp/index.tsx
@@ -21,38 +21,32 @@ export default class AccessSettingsApp extends React.Component<any, any> {
     };
   }
 
-  onUpdateAccess(props: any) {
-    this.setState((prevState: any) => ({
-      access: {
-        ...prevState.access,
-        ...props,
-      },
-    }), () => {
+  onUpdateAccess(currentPolicy: string) {
+    const access = {...this.state.access, currentPolicy};
+    this.setState({access}, () => {
       this.props.setChanged();
+      void this.props.onSubmit(
+        {preventDefault() {}},
+        this.state.currentType,
+        access,
+      );
     });
   }
 
   render() {
     const {currentType, access} = this.state;
-    const {submitting, submitForType} = this.props;
+    const {submitting} = this.props;
     return (<SettingsBase
       title="Access control"
-      submitting={submitting}
-      submitForType={submitForType}
       currentType={currentType}
-      onSubmit={(e: any) => {
-        e.preventDefault();
-        this.props.onSubmit(e, currentType, {
-          ...access,
-        });
-      }}
     >
       <AdminRadioGroup
         alignment="start"
         ariaLabel="Access policy"
+        disabled={submitting}
         name="access-policy"
         value={access.currentPolicy}
-        onValueChange={(value) => this.onUpdateAccess({currentPolicy: value})}
+        onValueChange={(value) => this.onUpdateAccess(value)}
         variant="cards"
         options={[
           {

--- a/src/components/admin/settings/AdminSettingsSidebar.tsx
+++ b/src/components/admin/settings/AdminSettingsSidebar.tsx
@@ -1,0 +1,196 @@
+import {useEffect, useMemo, useState} from "react";
+import {
+  ActivityIcon,
+  ArrowLeftIcon,
+  Code2Icon,
+  Globe2Icon,
+  RssIcon,
+  SearchIcon,
+  ShieldCheckIcon,
+} from "lucide-react";
+
+import {Input} from "@/components/ui/input";
+import {
+  ADMIN_SETTINGS_SECTIONS,
+  filterAdminSettingsSections,
+  type AdminSettingsSection,
+} from "@/shared/AdminSettingsNavigation";
+import AdminAboutDialog from "../AdminAboutDialog";
+import type {AdminSettingsSidebarData} from "../admin-shell-types";
+
+interface Props {
+  data: AdminSettingsSidebarData;
+  onNavigate?: () => void;
+}
+
+const sectionIcons: Record<AdminSettingsSection["icon"], typeof ActivityIcon> = {
+  activity: ActivityIcon,
+  code: Code2Icon,
+  globe: Globe2Icon,
+  rss: RssIcon,
+  shield: ShieldCheckIcon,
+};
+
+function sectionFromLocation(): string {
+  if (typeof window === "undefined") {
+    return ADMIN_SETTINGS_SECTIONS[0].id;
+  }
+  return ADMIN_SETTINGS_SECTIONS.some(({id}) => id === window.location.hash.slice(1))
+    ? window.location.hash.slice(1)
+    : ADMIN_SETTINGS_SECTIONS[0].id;
+}
+
+export default function AdminSettingsSidebar({data, onNavigate}: Props) {
+  const [activeSection, setActiveSection] = useState(sectionFromLocation);
+  const [query, setQuery] = useState("");
+  const visibleSections = useMemo(
+    () => filterAdminSettingsSections(query),
+    [query],
+  );
+
+  useEffect(() => {
+    if (data.activeSection) {
+      setActiveSection(data.activeSection);
+      return;
+    }
+
+    const scrollRoot = document.getElementById("admin-page-content");
+    if (!scrollRoot) {
+      return;
+    }
+
+    let animationFrame = 0;
+    const updateActiveSection = () => {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(() => {
+        if (
+          scrollRoot.scrollHeight - scrollRoot.clientHeight - scrollRoot.scrollTop <= 4
+        ) {
+          setActiveSection(
+            ADMIN_SETTINGS_SECTIONS[ADMIN_SETTINGS_SECTIONS.length - 1]!.id,
+          );
+          return;
+        }
+        const rootTop = scrollRoot.getBoundingClientRect().top;
+        const threshold = rootTop + 56;
+        let nextActive: string = ADMIN_SETTINGS_SECTIONS[0].id;
+        for (const section of ADMIN_SETTINGS_SECTIONS) {
+          const element = document.getElementById(section.id);
+          if (element && element.getBoundingClientRect().top <= threshold) {
+            nextActive = section.id;
+          }
+        }
+        setActiveSection(nextActive);
+      });
+    };
+
+    updateActiveSection();
+    scrollRoot.addEventListener("scroll", updateActiveSection, {passive: true});
+    window.addEventListener("resize", updateActiveSection);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      scrollRoot.removeEventListener("scroll", updateActiveSection);
+      window.removeEventListener("resize", updateActiveSection);
+    };
+  }, [data.activeSection]);
+
+  const openSection = (section: AdminSettingsSection) => {
+    const sectionUrl = `${data.sectionsUrl}#${section.id}`;
+    const element = document.getElementById(section.id);
+    const scrollRoot = document.getElementById("admin-page-content");
+    if (!element || !scrollRoot) {
+      onNavigate?.();
+      window.location.assign(sectionUrl);
+      return;
+    }
+
+    const top = scrollRoot.scrollTop +
+      element.getBoundingClientRect().top -
+      scrollRoot.getBoundingClientRect().top -
+      24;
+    scrollRoot.scrollTo({behavior: "smooth", top});
+    window.history.replaceState(null, "", sectionUrl);
+    setActiveSection(section.id);
+    onNavigate?.();
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-sidebar p-3 text-sidebar-foreground">
+      <a
+        aria-label="Go to Home"
+        className="mb-5 inline-flex h-11 items-center gap-2 self-start rounded-xl px-3 text-base font-medium text-sidebar-foreground outline-none transition hover:bg-sidebar-accent focus-visible:ring-3 focus-visible:ring-sidebar-ring/40"
+        href={data.backUrl}
+        onClick={onNavigate}
+      >
+        <ArrowLeftIcon aria-hidden="true" className="size-5" />
+        <span>Home</span>
+      </a>
+
+      <label className="relative mb-5 block">
+        <SearchIcon
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <span className="sr-only">Search settings</span>
+        <Input
+          className="h-11 bg-background pl-10"
+          placeholder="Search settings..."
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && visibleSections[0]) {
+              event.preventDefault();
+              openSection(visibleSections[0]);
+            }
+          }}
+        />
+      </label>
+
+      <nav className="min-h-0 flex-1 overflow-y-auto" aria-label="Settings sections">
+        {visibleSections.length ? (
+          <ul className="grid gap-1">
+            {visibleSections.map((section) => {
+              const Icon = sectionIcons[section.icon];
+              const active = section.id === (data.activeSection ?? activeSection);
+              const sectionUrl = `${data.sectionsUrl}#${section.id}`;
+              return (
+                <li key={section.id}>
+                  <a
+                    aria-current={active ? "location" : undefined}
+                    className={[
+                      "relative flex min-h-11 items-center gap-3 rounded-xl px-3 py-2 text-base font-medium outline-none transition-colors",
+                      active
+                        ? "bg-sidebar-accent text-sidebar-accent-foreground before:absolute before:inset-y-2 before:left-0 before:w-0.5 before:rounded-full before:bg-brand-light"
+                        : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                    ].join(" ")}
+                    href={sectionUrl}
+                    onClick={(event) => {
+                      if (document.getElementById(section.id)) {
+                        event.preventDefault();
+                        openSection(section);
+                      } else {
+                        onNavigate?.();
+                      }
+                    }}
+                  >
+                    <Icon aria-hidden="true" className="size-[18px]" />
+                    {section.name}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <p className="px-3 py-2 text-sm text-muted-foreground">
+            No settings sections found.
+          </p>
+        )}
+      </nav>
+
+      <div className="-mx-3 -mb-3 mt-3 border-t border-sidebar-border p-3">
+        <AdminAboutDialog deployment={data.deployment} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/settings/ApiSettingsApp/index.tsx
+++ b/src/components/admin/settings/ApiSettingsApp/index.tsx
@@ -1,142 +1,162 @@
-import React from 'react';
-import SettingsBase from "../SettingsBase";
-import AdminSwitch from "@/components/admin/shared/AdminSwitch";
+import {useState} from "react";
 import clsx from "clsx";
-import {randomHex, randomShortUUID} from "@/shared/StringUtils";
+import {ExternalLinkIcon} from "lucide-react";
+
 import AdminInput from "@/components/admin/shared/AdminInput";
-import {SETTINGS_CATEGORIES} from "@/shared/Constants";
+import AdminSwitch from "@/components/admin/shared/AdminSwitch";
 import {Button} from "@/components/ui/button";
+import {Card, CardContent} from "@/components/ui/card";
+import {showToast} from "@/client/ToastUtils";
+import Requests from "@/client/requests";
+import {SETTINGS_CATEGORIES} from "@/shared/Constants";
+import {
+  ADMIN_URLS,
+  randomHex,
+  randomShortUUID,
+} from "@/shared/StringUtils";
+import type {FeedContent} from "@/types";
 
-export default class ApiSettingsApp extends React.Component<any, any> {
-  constructor(props: any) {
-    super(props);
+interface ApiApp {
+  createdAtMs: number;
+  id: string;
+  name: string;
+  token: string;
+}
 
-    this.setApiEnabled = this.setApiEnabled.bind(this);
-    this.updateApiApps = this.updateApiApps.bind(this);
+interface ApiBundle {
+  apps: ApiApp[];
+  enabled: boolean;
+}
 
-    const currentType = SETTINGS_CATEGORIES.API_SETTINGS;
-    const {feed} = props;
+interface Props {
+  feed: FeedContent;
+}
 
-    let apiBundle = {
-      enabled: false,
-      apps: [{
-        id: randomShortUUID(),
-        name: 'Default',
-        token: randomHex(),
-        createdAtMs: new Date().getTime(),
-      }],
-    };
+function initialApiBundle(feed: FeedContent): ApiBundle {
+  const saved = feed.settings?.apiSettings;
+  const savedApp = saved?.apps?.[0];
+  return {
+    enabled: saved?.enabled === true,
+    apps: [{
+      createdAtMs: typeof savedApp?.createdAtMs === "number"
+        ? savedApp.createdAtMs
+        : Date.now(),
+      id: typeof savedApp?.id === "string" && savedApp.id
+        ? savedApp.id
+        : randomShortUUID(),
+      name: typeof savedApp?.name === "string" && savedApp.name
+        ? savedApp.name
+        : "Default",
+      token: typeof savedApp?.token === "string" && savedApp.token
+        ? savedApp.token
+        : randomHex(),
+    }],
+  };
+}
 
-    if (feed.settings && feed.settings[currentType]) {
-      apiBundle = feed.settings[currentType];
+export default function ApiSettingsApp({feed}: Props) {
+  const [apiBundle, setApiBundle] = useState(() => initialApiBundle(feed));
+  const [saving, setSaving] = useState(false);
+  const app = apiBundle.apps[0]!;
+
+  const saveBundle = async (nextBundle: ApiBundle) => {
+    const previousBundle = apiBundle;
+    setApiBundle(nextBundle);
+    setSaving(true);
+    try {
+      await Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {
+        settings: {[SETTINGS_CATEGORIES.API_SETTINGS]: nextBundle},
+      });
+      showToast("API settings updated.", "success");
+    } catch (error: any) {
+      setApiBundle(previousBundle);
+      showToast(
+        error?.response
+          ? "Failed to update API settings. Please try again."
+          : "Network error. Please refresh the page and try again.",
+        "error",
+      );
+    } finally {
+      setSaving(false);
     }
+  };
 
-    this.state = {
-      feed,
-
-      currentType,
-      apiBundle,
-    };
-  }
-
-  setApiEnabled(checked: any) {
-    this.setState({apiBundle: {...this.state.apiBundle, enabled: checked}}, () => {
-      this.props.setChanged();
-    });
-  }
-
-  updateApiApps(app: any) {
-    const {apiBundle} = this.state;
-    const newApps = apiBundle.apps.map((a: any) => {
-      if (a.id === app.id) {
-        return app;
-      }
-      return a;
-    });
-    this.setState({apiBundle: {...apiBundle, apps: newApps}}, () => {
-      this.props.setChanged();
-    });
-  }
-
-  render() {
-    const {currentType, apiBundle} = this.state;
-    const {submitting, submitForType} = this.props;
-    const app = apiBundle.apps[0];
-    return (<SettingsBase
-      title="API"
-      submitting={submitting}
-      submitForType={submitForType}
-      currentType={currentType}
-      onSubmit={(e: any) => {
-        e.preventDefault();
-        this.props.onSubmit(e, currentType, {
-          ...apiBundle,
-        });
-      }}
-    >
-      <div className="mb-4">
-        <div className="">
+  return (
+    <Card className="gap-0 py-0">
+      <CardContent className="p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <AdminSwitch
-            label="API Enabled"
-            labelClassName={clsx('', apiBundle.enabled ? 'text-foreground' : 'text-muted-foreground')}
             checked={apiBundle.enabled}
-            onCheckedChange={(checked) => this.setApiEnabled(checked)}
+            disabled={saving}
+            label="API enabled"
+            labelClassName={clsx(
+              apiBundle.enabled ? "text-foreground" : "text-muted-foreground",
+            )}
+            onCheckedChange={(enabled) => saveBundle({...apiBundle, enabled})}
           />
-          <div className="text-muted-color text-xs mt-2">
-            You can use the API to manage contents of your feed, e.g., create, update, and delete items.
-          </div>
+          {saving && (
+            <span aria-live="polite" className="text-xs text-muted-foreground">
+              Saving...
+            </span>
+          )}
         </div>
-        <div className="flex items-center mt-8">
-          <div
-            className={clsx('flex-none text-sm', !apiBundle.enabled && 'text-muted-color')}
-          >
-            API Key:
-          </div>
-          <div className="flex-1 mx-2">
+        <p className="mt-2 text-xs text-muted-foreground">
+          Use the API to create, update, and delete items in your feed.
+        </p>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="min-w-0 flex-1">
             <AdminInput
+              customClass={clsx(
+                "select-all font-mono text-sm",
+                !apiBundle.enabled && "text-muted-foreground",
+              )}
               disabled
+              label="API key"
               value={app.token}
-              customClass={clsx('text-sm p-1 select-all', !apiBundle.enabled && 'text-muted-color')}
-              description={"Set the X-MicrofeedAPI-Key header to the API key, e.g., " +
-                `curl -H X-MicrofeedAPI-Key: ${app.token} ...`}
             />
           </div>
-          <div className="flex-none">
-            <Button
-              type="button"
-              disabled={!apiBundle.enabled}
-              size="sm"
-              variant="outline"
-              onClick={(e: any) => {
-                e.preventDefault();
-                const ok = confirm('Are you sure you want to reset the API key?');
-                if (ok) {
-                  this.updateApiApps({...app, token: randomHex()});
-                }
-              }}
-            >
-              Reset
-            </Button>
-          </div>
+          <Button
+            disabled={!apiBundle.enabled || saving}
+            type="button"
+            variant="outline"
+            onClick={() => {
+              if (window.confirm("Are you sure you want to reset the API key?")) {
+                saveBundle({
+                  ...apiBundle,
+                  apps: [{...app, token: randomHex()}],
+                });
+              }
+            }}
+          >
+            Reset key
+          </Button>
         </div>
-        <div className="text-xs mt-8">
-          How to use API key?
-        </div>
-        <div className="mt-2 text-xs text-helper-color">
-          {"Set the X-MicrofeedAPI-Key header to the API key, e.g., " +
-            'curl -H "X-MicrofeedAPI-Key: <API_KEY>" ...'}
-        </div>
-        <div className="mt-8">
-          <a href="/json/openapi.html" target="_blank" rel="noopener noreferrer">
-            Documentation of microfeed's API <span className="lh-icon-arrow-right"/>
+        <p className="mt-3 break-all text-xs text-muted-foreground">
+          Set the <code>X-MicrofeedAPI-Key</code> request header to this key.
+        </p>
+
+        <div className="mt-8 flex flex-col items-start gap-3 text-sm">
+          <a
+            className="inline-flex items-center gap-1.5"
+            href="/json/openapi.html"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            API documentation
+            <ExternalLinkIcon aria-hidden="true" className="size-3.5" />
+          </a>
+          <a
+            className="inline-flex items-center gap-1.5"
+            href="/json/openapi.yaml"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            OpenAPI specification (YAML)
+            <ExternalLinkIcon aria-hidden="true" className="size-3.5" />
           </a>
         </div>
-        <div className="mt-4">
-          <a href="/json/openapi.yaml" target="_blank" rel="noopener noreferrer">
-            OpenAPI Spec in YAML <span className="lh-icon-arrow-right" />
-          </a>
-        </div>
-      </div>
-    </SettingsBase>);
-  }
+      </CardContent>
+    </Card>
+  );
 }

--- a/src/components/admin/settings/FormExplainTexts.ts
+++ b/src/components/admin/settings/FormExplainTexts.ts
@@ -12,10 +12,10 @@ export const CONTROLS_TEXTS_DICT = {
     json: '{ "_microfeed": { "subscribe_methods": [{"name": "RSS", "type": "rss", "url": "https://www.microfeed.org/rss/"}] } }',
   },
   [SETTINGS_CONTROLS.ITEMS_SORT_ORDER]: {
-    linkName: 'Sort order',
-    modalTitle: 'Items sort order',
-    text: "Sort order of items in the feed: Newest first, or Oldest first?",
+    linkName: 'Sort by',
+    modalTitle: 'Items sorting',
+    text: "Choose which item timestamp controls the feed order.",
     rss: null,
-    json: '{ "_microfeed": { "items_sort_order": "newest_first" }',
+    json: '{ "_microfeed": { "items_sort": "published_at", "items_order": "desc" } }',
   },
 };

--- a/src/components/admin/settings/SettingsApp.tsx
+++ b/src/components/admin/settings/SettingsApp.tsx
@@ -12,7 +12,7 @@ import {ONBOARDING_TYPES} from "@/shared/Constants";
 import {
   preventCloseWhenChanged,
 } from "@/client/BrowserUtils";
-import ApiSettingsApp from "./ApiSettingsApp";
+import {scrollToAdminSettingsHash} from "@/client/AdminSettingsScroll";
 import type {FeedContent, OnboardingResult} from "@/types";
 
 const SUBMIT_STATUS__START = 1;
@@ -24,6 +24,7 @@ interface Props {
 
 export default class SettingsApp extends React.Component<Props, any> {
   private cleanupNavigationGuard?: () => void;
+  private initialHashScrollFrame?: number;
 
   constructor(props: Props) {
     super(props);
@@ -40,9 +41,15 @@ export default class SettingsApp extends React.Component<Props, any> {
 
   componentDidMount() {
     this.cleanupNavigationGuard = preventCloseWhenChanged(() => this.state.changed);
+    this.initialHashScrollFrame = window.requestAnimationFrame(() => {
+      scrollToAdminSettingsHash();
+    });
   }
 
   componentWillUnmount() {
+    if (this.initialHashScrollFrame !== undefined) {
+      window.cancelAnimationFrame(this.initialHashScrollFrame);
+    }
     this.cleanupNavigationGuard?.();
   }
 
@@ -50,15 +57,16 @@ export default class SettingsApp extends React.Component<Props, any> {
     this.setState({changed: true});
   }
 
-  onSubmit(e: any, bundleKey: any, bundle: any) {
+  async onSubmit(e: any, bundleKey: any, bundle: any) {
     e.preventDefault();
     this.setState({submitForType: bundleKey, submitStatus: SUBMIT_STATUS__START});
-    Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {settings: {[bundleKey]: bundle}})
-      .then(() => {
-        this.setState({submitStatus: null, submitForType: null, changed: false}, () => {
-          showToast('Updated!', 'success');
-        });
-      }).catch((error: any) => {
+    try {
+      await Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {settings: {[bundleKey]: bundle}});
+      this.setState({submitStatus: null, submitForType: null, changed: false}, () => {
+        showToast('Updated!', 'success');
+      });
+      return true;
+    } catch (error: any) {
       this.setState({submitStatus: null, submitForType: null}, () => {
         if (!error.response) {
           showToast('Network error. Please refresh the page and try again.', 'error');
@@ -66,7 +74,8 @@ export default class SettingsApp extends React.Component<Props, any> {
           showToast('Failed. Please try again.', 'error');
         }
       });
-    });
+      return false;
+    }
   }
 
   render() {
@@ -78,67 +87,52 @@ export default class SettingsApp extends React.Component<Props, any> {
     ];
     const mediaStorageReady = mediaStorage?.ready !== false;
     return (<AdminPageApp>
-      <div className="grid grid-cols-1 gap-4">
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-          <div className="h-full">
-            <TrackingSettingsApp
-              submitting={submitting}
-              submitForType={submitForType}
-              feed={feed}
-              onSubmit={this.onSubmit}
-              setChanged={this.setChanged}
-            />
-          </div>
-          <div className="h-full">
-            <AccessSettingsApp
-              submitting={submitting}
-              submitForType={submitForType}
-              feed={feed}
-              onSubmit={this.onSubmit}
-              setChanged={this.setChanged}
-            />
-          </div>
-        </div>
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-          <div className="h-full">
-            <SubscribeSettingsApp
-              submitting={submitting}
-              submitForType={submitForType}
-              feed={feed}
-              onSubmit={this.onSubmit}
-              setChanged={this.setChanged}
-            />
-          </div>
-          <div className="h-full">
-            <WebGlobalSettingsApp
-              submitting={submitting}
-              submitForType={submitForType}
-              feed={feed}
-              mediaStorage={mediaStorage}
-              mediaStorageReady={mediaStorageReady}
-              onSubmit={this.onSubmit}
-              setChanged={this.setChanged}
-            />
-          </div>
-        </div>
-        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-          <div className="h-full">
-            <CustomCodeSettingsApp
-              submitting={submitting}
-              submitForType={submitForType}
-              feed={feed}
-            />
-          </div>
-          <div className="h-full">
-            <ApiSettingsApp
-              submitting={submitting}
-              submitForType={submitForType}
-              feed={feed}
-              onSubmit={this.onSubmit}
-              setChanged={this.setChanged}
-            />
-          </div>
-        </div>
+      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-5">
+        <section className="scroll-mt-6" id="tracking-urls">
+          <TrackingSettingsApp
+            submitting={submitting}
+            submitForType={submitForType}
+            feed={feed}
+            onSubmit={this.onSubmit}
+            setChanged={this.setChanged}
+          />
+        </section>
+        <section className="scroll-mt-6" id="access-control">
+          <AccessSettingsApp
+            submitting={submitting}
+            submitForType={submitForType}
+            feed={feed}
+            onSubmit={this.onSubmit}
+            setChanged={this.setChanged}
+          />
+        </section>
+        <section className="scroll-mt-6" id="subscribe-methods">
+          <SubscribeSettingsApp
+            submitting={submitting}
+            submitForType={submitForType}
+            feed={feed}
+            onSubmit={this.onSubmit}
+            setChanged={this.setChanged}
+          />
+        </section>
+        <section className="scroll-mt-6" id="web-settings">
+          <WebGlobalSettingsApp
+            submitting={submitting}
+            submitForType={submitForType}
+            feed={feed}
+            mediaStorage={mediaStorage}
+            mediaStorageReady={mediaStorageReady}
+            onSubmit={this.onSubmit}
+            setChanged={this.setChanged}
+          />
+        </section>
+        <section className="scroll-mt-6" id="custom-code">
+          <CustomCodeSettingsApp
+            submitting={submitting}
+            submitForType={submitForType}
+            feed={feed}
+          />
+        </section>
       </div>
     </AdminPageApp>);
   }

--- a/src/components/admin/settings/SubscribeSettingsApp/index.tsx
+++ b/src/components/admin/settings/SubscribeSettingsApp/index.tsx
@@ -3,9 +3,8 @@ import clsx from "clsx";
 import SettingsBase from "../SettingsBase";
 import {PUBLIC_URLS, randomShortUUID} from "@/shared/StringUtils";
 import {
-  ArrowDownIcon,
-  ArrowUpIcon,
   CirclePlusIcon,
+  GripVerticalIcon,
   Trash2Icon,
 } from "lucide-react";
 import AdminInput from "@/components/admin/shared/AdminInput";
@@ -29,7 +28,58 @@ function initMethodsDict() {
   };
 }
 
-function MethodRow({method, updateMethodByAttr, index, firstIndex, lastIndex, moveCard}: any) {
+export function subscribeMethodsBundle(methodsDict: any) {
+  return {
+    ...methodsDict,
+    methods: (methodsDict.methods || [])
+      .filter((method: any) => !method.deleted)
+      .map((method: any) => {
+        const savedMethod = {...method};
+        delete savedMethod.deleted;
+        return savedMethod;
+      }),
+  };
+}
+
+export function reorderSubscribeMethods(
+  methods: any[],
+  draggedMethodId: string,
+  targetMethodId: string,
+  position: "before" | "after",
+) {
+  if (draggedMethodId === targetMethodId) {
+    return methods;
+  }
+  const draggedIndex = methods.findIndex(({id}) => id === draggedMethodId);
+  const targetIndex = methods.findIndex(({id}) => id === targetMethodId);
+  if (draggedIndex < 0 || targetIndex < 0) {
+    return methods;
+  }
+
+  const reordered = [...methods];
+  const [draggedMethod] = reordered.splice(draggedIndex, 1);
+  const adjustedTargetIndex = reordered.findIndex(({id}) => id === targetMethodId);
+  reordered.splice(
+    position === "after" ? adjustedTargetIndex + 1 : adjustedTargetIndex,
+    0,
+    draggedMethod,
+  );
+  return reordered.every(({id}, index) => id === methods[index]?.id)
+    ? methods
+    : reordered;
+}
+
+function MethodRow({
+  beginDragging,
+  dragging,
+  dropPosition,
+  firstIndex,
+  index,
+  lastIndex,
+  method,
+  moveCard,
+  updateMethodByAttr,
+}: any) {
   const { id, name, type, editable, enabled, image, deleted } = method;
   let { url } = method;
   if (!url && !editable) {
@@ -45,33 +95,49 @@ function MethodRow({method, updateMethodByAttr, index, firstIndex, lastIndex, mo
     }
   }
 
-  return (<div className={clsx('flex flex-wrap items-start gap-y-3 border-b py-4 sm:flex-nowrap')}>
-    <div className="flex-none mr-2 flex items-center justify-start">
+  return (<div
+    className={clsx(
+      'relative flex flex-wrap items-start gap-y-3 border-b py-4 transition sm:flex-nowrap',
+      dragging && 'bg-muted/40 opacity-60',
+      dropPosition && 'z-10 bg-brand-light/8 ring-1 ring-inset ring-brand-light/40',
+      dropPosition === 'before' &&
+        'before:absolute before:inset-x-0 before:top-0 before:h-0.5 before:rounded-full before:bg-brand-light',
+      dropPosition === 'after' &&
+        'after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:rounded-full after:bg-brand-light',
+    )}
+    data-subscribe-method-id={id}
+  >
+    <div className="mr-3 flex flex-none items-center justify-start">
       <Button
-        aria-label={`Move ${name} up`}
-        className={firstIndex ? 'text-muted-foreground' : ''}
-        disabled={firstIndex}
+        aria-label={`Drag to change the order of ${name}`}
+        aria-roledescription="sortable item"
+        className="cursor-grab touch-none text-muted-foreground active:cursor-grabbing"
         size="icon-sm"
+        title="Drag to change the order. Use Arrow Up or Arrow Down with the keyboard."
         type="button"
         variant="ghost"
-        onClick={(e: any) => moveCard(e, index, index - 1)}
+        onKeyDown={(event: React.KeyboardEvent) => {
+          if (event.key === "ArrowUp" && !firstIndex) {
+            moveCard(event, index, index - 1);
+          } else if (event.key === "ArrowDown" && !lastIndex) {
+            moveCard(event, index, index + 1);
+          }
+        }}
+        onPointerDown={(event: React.PointerEvent<HTMLButtonElement>) => {
+          if (event.button !== 0) return;
+          event.currentTarget.setPointerCapture(event.pointerId);
+          beginDragging(id, event);
+        }}
       >
-        <ArrowUpIcon className="w-4" />
-      </Button>
-      <Button
-        aria-label={`Move ${name} down`}
-        className={lastIndex ? 'text-muted-foreground' : ''}
-        disabled={lastIndex}
-        size="icon-sm"
-        type="button"
-        variant="ghost"
-        onClick={(e: any) => moveCard(e, index, index + 1)}
-      >
-        <ArrowDownIcon className="w-4" />
+        <GripVerticalIcon className="size-4" />
       </Button>
     </div>
-    <div className="flex-none mr-4 flex items-center justify-end">
-      <img src={image} className={clsx('w-14', enabled ? '' : 'opacity-50')} alt={name} />
+    <div className="mr-4 flex flex-none items-center justify-end">
+      <img
+        src={image}
+        className={clsx('size-11 object-contain', enabled ? '' : 'opacity-50')}
+        alt={name}
+      />
     </div>
     <div className="min-w-0 flex-[1_1_18rem]">
       <div className="grid grid-cols-1 gap-2 md:grid-cols-12">
@@ -79,7 +145,7 @@ function MethodRow({method, updateMethodByAttr, index, firstIndex, lastIndex, mo
           <AdminInput
             value={name}
             disabled={!editable || !enabled}
-            onChange={(e: any) => updateMethodByAttr(id, 'name', e.target.value)}
+            onChange={(e: any) => updateMethodByAttr(id, 'name', e.target.value, false)}
             customClass="text-xs p-1"
           />
         </div>
@@ -88,7 +154,7 @@ function MethodRow({method, updateMethodByAttr, index, firstIndex, lastIndex, mo
             <AdminInput
               value={url}
               disabled={!editable || !enabled}
-              onChange={(e: any) => updateMethodByAttr(id, 'url', e.target.value)}
+              onChange={(e: any) => updateMethodByAttr(id, 'url', e.target.value, false)}
               customClass="text-xs p-1"
             />
             <div className="flex-none ml-1">
@@ -117,14 +183,17 @@ function MethodRow({method, updateMethodByAttr, index, firstIndex, lastIndex, mo
               }}>
               <Trash2Icon className="w-4"/>
               Delete
-            </Button></div> : <div className="text-xs text-muted-color">
-              <i>Click "Update" to sync up and actually delete it. Or <a
-                href="#"
-                className="text-brand-light text-xs"
-                onClick={(e: any) => {
-                  e.preventDefault();
-                  updateMethodByAttr(id, 'deleted', false);
-                }}>Undo</a>.</i>
+            </Button></div> : <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <span>Deleted.</span>
+              <Button
+                className="h-auto px-0 text-xs text-brand-light"
+                size="xs"
+                type="button"
+                variant="link"
+                onClick={() => updateMethodByAttr(id, 'deleted', false)}
+              >
+                Undo
+              </Button>
             </div>}
           </div>}
         </div>
@@ -133,19 +202,59 @@ function MethodRow({method, updateMethodByAttr, index, firstIndex, lastIndex, mo
   </div>);
 }
 
-function AddNewMethod({isOpenNewMethod, setIsOpenNewMethod, addNewMethod}: any) {
-  return (<div>
-    <Button
-      className="mx-auto"
-      type="button"
-      variant="ghost"
-      onClick={() => {
-        setIsOpenNewMethod(true);
+function FloatingMethodPreview({method, position}: any) {
+  const {enabled, image, name, type, url} = method;
+  const displayUrl = url || (type === "rss"
+    ? PUBLIC_URLS.rssFeed()
+    : type === "json"
+      ? PUBLIC_URLS.jsonFeed()
+      : "");
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed z-[100] flex min-h-20 items-center gap-3 rounded-xl border border-brand-light/60 bg-card/95 px-4 py-3 shadow-2xl ring-2 ring-brand-light/20 backdrop-blur-sm"
+      style={{
+        left: position.left,
+        maxWidth: "calc(100vw - 1rem)",
+        top: position.top,
+        transform: "rotate(0.35deg) scale(1.01)",
+        width: position.width,
       }}
     >
-      <CirclePlusIcon aria-hidden="true" className="size-4 shrink-0" />
-      <span>Add new subscribe method</span>
-    </Button>
+      <GripVerticalIcon className="size-4 shrink-0 text-brand-light" />
+      <img
+        alt=""
+        className={clsx("size-11 shrink-0 object-contain", !enabled && "opacity-50")}
+        src={image}
+      />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-semibold text-card-foreground">
+          {name}
+        </span>
+        {displayUrl && (
+          <span className="mt-1 block truncate text-xs text-muted-foreground">
+            {displayUrl}
+          </span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function AddNewMethod({isOpenNewMethod, setIsOpenNewMethod, addNewMethod}: any) {
+  return (<div>
+    <div className="flex justify-center">
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => {
+          setIsOpenNewMethod(true);
+        }}
+      >
+        <CirclePlusIcon aria-hidden="true" className="size-4 shrink-0" />
+        <span>Add new subscribe method</span>
+      </Button>
+    </div>
     <div className="mt-1 text-xs text-muted-color text-center">e.g., Apple Podcasts, Spotify, Listen Notes...</div>
     <NewSubscribeDialog
       isOpen={isOpenNewMethod}
@@ -156,12 +265,23 @@ function AddNewMethod({isOpenNewMethod, setIsOpenNewMethod, addNewMethod}: any) 
 }
 
 export default class SubscribeSettingsApp extends React.Component<any, any> {
+  private activeDragPointerId: number | null = null;
+  private dragOrderChanged = false;
+  private saveQueue: Promise<void> = Promise.resolve();
+  private textSaveTimer?: ReturnType<typeof setTimeout>;
+
   constructor(props: any) {
     super(props);
-    this.updateMethodsDict = this.updateMethodsDict.bind(this);
     this.updateMethodByAttr = this.updateMethodByAttr.bind(this);
     this.addNewMethod = this.addNewMethod.bind(this);
+    this.beginDragging = this.beginDragging.bind(this);
+    this.dragMethod = this.dragMethod.bind(this);
+    this.endDragging = this.endDragging.bind(this);
+    this.handleDragPointerEnd = this.handleDragPointerEnd.bind(this);
+    this.handleDragPointerMove = this.handleDragPointerMove.bind(this);
+    this.handleDragWindowBlur = this.handleDragWindowBlur.bind(this);
     this.moveCard = this.moveCard.bind(this);
+    this.persistMethods = this.persistMethods.bind(this);
 
     const currentType = SETTINGS_CATEGORIES.SUBSCRIBE_METHODS;
     const {settings} = props.feed;
@@ -173,74 +293,254 @@ export default class SubscribeSettingsApp extends React.Component<any, any> {
     }
     this.state = {
       currentType,
+      dragOverMethodId: null,
+      dragOverPosition: null,
+      dragPreview: null,
+      draggedMethodId: null,
       methodsDict,
       isOpenNewMethod: false,
     };
   }
 
-  updateMethodByAttr(methodId: any, attrName: any, attrValue: any) {
-    const {methods} = this.state.methodsDict;
-    methods.forEach((method: any) => {
-      if (method.id !== methodId) {
+  componentWillUnmount() {
+    this.removeDragListeners();
+    if (this.textSaveTimer !== undefined) {
+      clearTimeout(this.textSaveTimer);
+    }
+  }
+
+  persistMethods(methodsDict: any) {
+    const bundle = subscribeMethodsBundle(methodsDict);
+    const {currentType} = this.state;
+    this.saveQueue = this.saveQueue
+      .then(async () => {
+        await this.props.onSubmit(
+          {preventDefault() {}},
+          currentType,
+          bundle,
+        );
+      })
+      .catch(() => undefined);
+  }
+
+  updateMethods(
+    transform: (methods: any[]) => any[],
+    persistImmediately = true,
+  ) {
+    this.setState((prevState: any) => {
+      const methods = transform(prevState.methodsDict.methods || []);
+      return {
+        methodsDict: {
+          ...prevState.methodsDict,
+          methods,
+        },
+      };
+    }, () => {
+      this.props.setChanged();
+      if (persistImmediately) {
+        if (this.textSaveTimer !== undefined) {
+          clearTimeout(this.textSaveTimer);
+          this.textSaveTimer = undefined;
+        }
+        this.persistMethods(this.state.methodsDict);
         return;
       }
-      method[attrName] = attrValue;
+      if (this.textSaveTimer !== undefined) {
+        clearTimeout(this.textSaveTimer);
+      }
+      this.textSaveTimer = setTimeout(() => {
+        this.textSaveTimer = undefined;
+        this.persistMethods(this.state.methodsDict);
+      }, 600);
     });
-    this.updateMethodsDict(methods);
+  }
+
+  updateMethodByAttr(
+    methodId: any,
+    attrName: any,
+    attrValue: any,
+    persistImmediately = true,
+  ) {
+    this.updateMethods(
+      (methods) => methods.map((method: any) => method.id === methodId
+        ? {...method, [attrName]: attrValue}
+        : method),
+      persistImmediately,
+    );
   }
 
   addNewMethod(newMethod: any) {
-    const methods = this.state.methodsDict.methods || [];
-    methods.push(newMethod);
-    this.updateMethodsDict(methods);
+    this.updateMethods((methods) => [...methods, newMethod]);
   }
 
-  updateMethodsDict(methods: any, callback?: any) {
-    this.setState((prevState: any) => ({
-      methodsDict: {
-        ...prevState.methodsDict,
-        methods: [
-          ...methods,
-        ],
-      },
-    }), () => {
-      if (callback) {
-        callback();
+  beginDragging(
+    methodId: string,
+    event: React.PointerEvent<HTMLButtonElement>,
+  ) {
+    this.removeDragListeners();
+    this.activeDragPointerId = event.pointerId;
+    window.addEventListener("blur", this.handleDragWindowBlur);
+    window.addEventListener("pointercancel", this.handleDragPointerEnd);
+    window.addEventListener("pointermove", this.handleDragPointerMove, {
+      passive: false,
+    });
+    window.addEventListener("pointerup", this.handleDragPointerEnd);
+    this.dragOrderChanged = false;
+    const row = event.currentTarget.closest<HTMLElement>(
+      "[data-subscribe-method-id]",
+    );
+    const bounds = row?.getBoundingClientRect();
+    this.setState({
+      dragOverMethodId: null,
+      dragOverPosition: null,
+      dragPreview: bounds
+        ? {
+            left: bounds.left,
+            offsetX: event.clientX - bounds.left,
+            offsetY: event.clientY - bounds.top,
+            top: bounds.top,
+            width: bounds.width,
+          }
+        : null,
+      draggedMethodId: methodId,
+    });
+  }
+
+  handleDragPointerMove(event: PointerEvent) {
+    if (
+      event.pointerId !== this.activeDragPointerId ||
+      !this.state.draggedMethodId
+    ) {
+      return;
+    }
+    event.preventDefault();
+    this.dragMethod(event, this.state.draggedMethodId);
+  }
+
+  handleDragPointerEnd(event: PointerEvent) {
+    if (event.pointerId !== this.activeDragPointerId) return;
+    this.endDragging();
+  }
+
+  handleDragWindowBlur() {
+    this.endDragging();
+  }
+
+  removeDragListeners() {
+    if (typeof window === "undefined") return;
+    window.removeEventListener("blur", this.handleDragWindowBlur);
+    window.removeEventListener("pointercancel", this.handleDragPointerEnd);
+    window.removeEventListener("pointermove", this.handleDragPointerMove);
+    window.removeEventListener("pointerup", this.handleDragPointerEnd);
+  }
+
+  dragMethod(
+    event: Pick<PointerEvent, "clientX" | "clientY">,
+    draggedMethodId: string,
+  ) {
+    this.setState((prevState: any) => prevState.dragPreview
+      ? {
+          dragPreview: {
+            ...prevState.dragPreview,
+            left: event.clientX - prevState.dragPreview.offsetX,
+            top: event.clientY - prevState.dragPreview.offsetY,
+          },
+        }
+      : null);
+    const targetRow = document.elementFromPoint(event.clientX, event.clientY)
+      ?.closest<HTMLElement>("[data-subscribe-method-id]");
+    const targetMethodId = targetRow?.dataset.subscribeMethodId;
+    if (!targetRow || !targetMethodId || targetMethodId === draggedMethodId) {
+      this.setState({dragOverMethodId: null, dragOverPosition: null});
+      return;
+    }
+    const targetBounds = targetRow.getBoundingClientRect();
+    const position = event.clientY < targetBounds.top + targetBounds.height / 2
+      ? "before"
+      : "after";
+    this.setState((prevState: any) => {
+      const currentMethods = prevState.methodsDict.methods || [];
+      const methods = reorderSubscribeMethods(
+        currentMethods,
+        draggedMethodId,
+        targetMethodId,
+        position,
+      );
+      if (methods === currentMethods) {
+        return prevState.dragOverMethodId === targetMethodId &&
+            prevState.dragOverPosition === position
+          ? null
+          : {
+              dragOverMethodId: targetMethodId,
+              dragOverPosition: position,
+            };
       }
+      this.dragOrderChanged = true;
+      return {
+        dragOverMethodId: targetMethodId,
+        dragOverPosition: position,
+        methodsDict: {
+          ...prevState.methodsDict,
+          methods,
+        },
+      };
+    });
+  }
+
+  endDragging() {
+    this.removeDragListeners();
+    this.activeDragPointerId = null;
+    const orderChanged = this.dragOrderChanged;
+    this.dragOrderChanged = false;
+    this.setState({
+      dragOverMethodId: null,
+      dragOverPosition: null,
+      dragPreview: null,
+      draggedMethodId: null,
+    }, () => {
+      if (!orderChanged) return;
       this.props.setChanged();
+      if (this.textSaveTimer !== undefined) {
+        clearTimeout(this.textSaveTimer);
+        this.textSaveTimer = undefined;
+      }
+      this.persistMethods(this.state.methodsDict);
     });
   }
 
   moveCard(e: any, oldIndex: any, newIndex: any) {
     e.preventDefault();
-    const {methods} = this.state.methodsDict;
-    const element = methods.splice(oldIndex, 1)[0];
-    methods.splice(newIndex, 0, element);
-    this.updateMethodsDict(methods);
+    this.updateMethods((methods) => {
+      const reordered = [...methods];
+      const element = reordered.splice(oldIndex, 1)[0];
+      reordered.splice(newIndex, 0, element);
+      return reordered;
+    });
   }
 
   render() {
-    const {currentType, methodsDict, isOpenNewMethod} = this.state;
-    const {submitting, submitForType} = this.props;
+    const {
+      currentType,
+      dragOverMethodId,
+      dragOverPosition,
+      dragPreview,
+      draggedMethodId,
+      methodsDict,
+      isOpenNewMethod,
+    } = this.state;
     const methods = methodsDict.methods || [];
+    const draggedMethod = draggedMethodId
+      ? methods.find(({id}: any) => id === draggedMethodId)
+      : null;
     return (<SettingsBase
       titleComponent={<ExplainText bundle={CONTROLS_TEXTS_DICT[SETTINGS_CONTROLS.SUBSCRIBE_METHODS]}/>}
-      submitting={submitting}
-      submitForType={submitForType}
       currentType={currentType}
-      onSubmit={(e: any) => {
-        e.preventDefault();
-        const newMethods = methods.filter((m: any) => !m.deleted);
-        this.updateMethodsDict(newMethods, () => {
-          this.props.onSubmit(e, currentType, {
-            ...methodsDict,
-            methods: newMethods,
-          });
-        });
-      }}
     >
       <div className="mb-4">
         {methods.map((method: any, i: any) => <MethodRow
+          beginDragging={this.beginDragging}
+          dragging={draggedMethodId === method.id}
+          dropPosition={dragOverMethodId === method.id ? dragOverPosition : null}
           method={method}
           key={`${method.id}-row`}
           updateMethodByAttr={this.updateMethodByAttr}
@@ -255,6 +555,9 @@ export default class SubscribeSettingsApp extends React.Component<any, any> {
         setIsOpenNewMethod={(isOpen: any) => this.setState({isOpenNewMethod: isOpen})}
         addNewMethod={this.addNewMethod}
       />
+      {dragPreview && draggedMethod && (
+        <FloatingMethodPreview method={draggedMethod} position={dragPreview} />
+      )}
     </SettingsBase>);
   }
 }

--- a/src/components/admin/settings/TrackingSettingsApp/index.tsx
+++ b/src/components/admin/settings/TrackingSettingsApp/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import AdminTextarea from "@/components/admin/shared/AdminTextarea";
+import {Button} from "@/components/ui/button";
 import {buildAudioUrlWithTracking} from "@/shared/StringUtils";
 import SettingsBase from '../SettingsBase';
 import {SETTINGS_CATEGORIES} from "@/shared/Constants";
@@ -17,25 +18,23 @@ export default class TrackingSettingsApp extends React.Component<any, any> {
     }
     this.state = {
       trackingUrls,
+      savedTrackingUrls: trackingUrls,
       currentType,
     };
   }
 
   render() {
-    const {trackingUrls, currentType} = this.state;
+    const {trackingUrls, savedTrackingUrls, currentType} = this.state;
     const {submitting, submitForType, setChanged} = this.props;
     const urls = trackingUrls.trim() !== '' ? trackingUrls.trim().split(/\n/) : [];
+    const changed = trackingUrls !== savedTrackingUrls;
+    const submittingForThis = submitForType === currentType;
     const exampleAudio = 'https://example.com/audio.mp3';
     return (<SettingsBase
       title="Tracking urls"
       submitting={submitting}
       submitForType={submitForType}
       currentType={currentType}
-      onSubmit={(e: any) => {
-        this.props.onSubmit(e, currentType, {
-          urls,
-        });
-      }}
     >
       <div>
         <AdminTextarea
@@ -53,6 +52,23 @@ export default class TrackingSettingsApp extends React.Component<any, any> {
           Example: if an audio url is {exampleAudio}, then the final url in the rss feed will be:
         </div>
         <b>{buildAudioUrlWithTracking(exampleAudio, urls)}</b>
+      </div>}
+      {changed && <div className="mt-5 flex justify-end">
+        <Button
+          disabled={submittingForThis || submitting}
+          type="button"
+          onClick={(e: any) => {
+            const submittedTrackingUrls = trackingUrls;
+            void Promise.resolve(this.props.onSubmit(e, currentType, {urls}))
+              .then((updated) => {
+                if (updated) {
+                  this.setState({savedTrackingUrls: submittedTrackingUrls});
+                }
+              });
+          }}
+        >
+          {submittingForThis ? 'Updating...' : 'Update'}
+        </Button>
       </div>}
     </SettingsBase>);
   }

--- a/src/components/admin/settings/WebGlobalSettingsApp/index.tsx
+++ b/src/components/admin/settings/WebGlobalSettingsApp/index.tsx
@@ -5,9 +5,15 @@ import AdminInput from "@/components/admin/shared/AdminInput";
 import {
   SETTINGS_CATEGORIES,
   DEFAULT_ITEMS_PER_PAGE,
-  ITEMS_SORT_ORDERS,
   MAX_ITEMS_PER_PAGE,
 } from "@/shared/Constants";
+import {
+  ITEM_ORDERS,
+  ITEM_SORTS,
+  type ItemOrder,
+  type ItemSort,
+  resolveItemPaginationSettings,
+} from "@/shared/ItemPagination";
 import AdminRadioGroup from "@/components/admin/shared/AdminRadioGroup";
 import {showToast} from "@/client/ToastUtils";
 import ExplainText from "@/components/admin/shared/ExplainText";
@@ -29,11 +35,14 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
     let favicon = '';
     let publicBucketUrl = '';
     let itemsPerPage = DEFAULT_ITEMS_PER_PAGE;
-    let itemsSortOrder = ITEMS_SORT_ORDERS.NEWEST_FIRST;
+    let itemsOrder: ItemOrder = ITEM_ORDERS.DESC;
+    let itemsSort: ItemSort = ITEM_SORTS.PUBLISHED_AT;
     if (feed.settings && feed.settings[currentType]) {
       favicon = feed.settings[currentType].favicon || {};
       publicBucketUrl = feed.settings[currentType].publicBucketUrl || '/media/';
-      itemsSortOrder = feed.settings[currentType].itemsSortOrder || ITEMS_SORT_ORDERS.NEWEST_FIRST;
+      ({itemsOrder, itemsSort} = resolveItemPaginationSettings(
+        feed.settings[currentType],
+      ));
       itemsPerPage = feed.settings[currentType].itemsPerPage || DEFAULT_ITEMS_PER_PAGE;
     }
     const isLocalDevelopment = isLocalDevelopmentHostname(
@@ -51,7 +60,8 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
       isLocalDevelopment,
       publicBucketUrl,
       itemsPerPage,
-      itemsSortOrder,
+      itemsOrder,
+      itemsSort,
     };
   }
 
@@ -63,7 +73,8 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
       isLocalDevelopment,
       publicBucketUrl,
       itemsPerPage,
-      itemsSortOrder,
+      itemsOrder,
+      itemsSort,
     } = this.state;
     const {submitting, submitForType, setChanged} = this.props;
     return (<SettingsBase
@@ -89,7 +100,8 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
         this.props.onSubmit(e, currentType, {
           favicon,
           publicBucketUrl: normalizedPublicBucketUrl,
-          itemsSortOrder,
+          itemsOrder,
+          itemsSort,
           itemsPerPage,
         });
       }}
@@ -129,7 +141,7 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
         </details>
         <details open>
           <summary className="mb-2 cursor-pointer font-semibold text-foreground">Items settings</summary>
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
             <div>
               <AdminInput
                 label="Items per page"
@@ -153,22 +165,39 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
                 }}
               />
             </div>
-            <div>
+            <div className="contents">
               <AdminRadioGroup
                 labelComponent={<ExplainText
                   bundle={CONTROLS_TEXTS_DICT[SETTINGS_CONTROLS.ITEMS_SORT_ORDER]}
                   customClass="m-input-label-small"
                 />}
-                name="items-sort-order"
-                value={itemsSortOrder}
+                name="items-sort"
+                value={itemsSort}
+                options={[{
+                  label: 'Published at',
+                  value: ITEM_SORTS.PUBLISHED_AT,
+                }, {
+                  label: 'Created at',
+                  value: ITEM_SORTS.CREATED_AT,
+                }, {
+                  label: 'Updated at',
+                  value: ITEM_SORTS.UPDATED_AT,
+                }]}
+                onValueChange={(value) => this.setState({itemsSort: value}, () => setChanged())}
+              />
+              <AdminRadioGroup
+                label="Order"
+                labelClassName="m-input-label-small"
+                name="items-order"
+                value={itemsOrder}
                 options={[{
                   label: 'Newest first',
-                  value: ITEMS_SORT_ORDERS.NEWEST_FIRST,
+                  value: ITEM_ORDERS.DESC,
                 }, {
                   label: 'Oldest first',
-                  value: ITEMS_SORT_ORDERS.OLDEST_FIRST,
+                  value: ITEM_ORDERS.ASC,
                 }]}
-                onValueChange={(value) => this.setState({itemsSortOrder: value}, () => setChanged())}
+                onValueChange={(value) => this.setState({itemsOrder: value}, () => setChanged())}
               />
             </div>
           </div>

--- a/src/components/admin/settings/WebGlobalSettingsApp/index.tsx
+++ b/src/components/admin/settings/WebGlobalSettingsApp/index.tsx
@@ -67,7 +67,7 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
     } = this.state;
     const {submitting, submitForType, setChanged} = this.props;
     return (<SettingsBase
-      title="Web global settings"
+      title="Global settings"
       submitting={submitting}
       submitForType={submitForType}
       currentType={currentType}

--- a/src/layouts/AdminShell.astro
+++ b/src/layouts/AdminShell.astro
@@ -4,6 +4,7 @@ import "@fontsource-variable/geist";
 import {ClientRouter} from "astro:transitions";
 
 import AdminSidebar from "@/components/admin/AdminSidebar";
+import AdminSettingsSidebar from "@/components/admin/settings/AdminSettingsSidebar";
 import AdminThemeScript from "@/components/admin/AdminThemeScript.astro";
 import AdminTopBar from "@/components/admin/AdminTopBar.astro";
 import {Toaster} from "@/components/ui/sonner";
@@ -12,14 +13,16 @@ import type {
   AdminBreadcrumb,
   AdminDeploymentSummary,
   AdminIdentitySummary,
+  AdminSettingsSidebarData,
   AdminSidebarData,
 } from "@/components/admin/admin-shell-types";
 import {cloudflareAccessIdentity} from "@/server/auth/admin-protection";
-import {normalizeAdminPath} from "@/shared/AdminPath";
+import {adminUrl, normalizeAdminPath} from "@/shared/AdminPath";
 import {
   getAdminNavigationItems,
   type AdminNavItemId,
 } from "@/shared/AdminNavigation";
+import type {AdminSettingsSection} from "@/shared/AdminSettingsNavigation";
 import {
   PUBLIC_URLS,
   resolvePublicBucketUrl,
@@ -38,6 +41,8 @@ interface Props {
   feedContent: FeedContent;
   onboardingResult: OnboardingResult;
   pageTitle: string;
+  settingsActiveSection?: AdminSettingsSection["id"];
+  settingsNavigation?: boolean;
 }
 
 const {
@@ -47,6 +52,8 @@ const {
   feedContent,
   onboardingResult,
   pageTitle,
+  settingsActiveSection,
+  settingsNavigation = false,
 } = Astro.props;
 const adminPath = normalizeAdminPath(env.MICROFEED_ADMIN_PATH);
 const accessIdentity = cloudflareAccessIdentity(Astro.request);
@@ -93,16 +100,33 @@ const sidebar: AdminSidebarData = {
     activeNavItem,
     onboardingResult,
   ),
+  newItem: {
+    disabled: !onboardingResult.requiredOk,
+    url: adminUrl("items/new", adminPath),
+  },
   publicLinks: {
     json: PUBLIC_URLS.jsonFeed(Astro.url.origin),
     rss: PUBLIC_URLS.rssFeed(Astro.url.origin),
     website: PUBLIC_URLS.webFeed(Astro.url.origin),
   },
 };
+const settingsSidebar: AdminSettingsSidebarData | undefined = settingsNavigation
+  ? {
+      activeSection: settingsActiveSection,
+      backUrl: adminUrl("", adminPath),
+      deployment,
+      sectionsUrl: adminUrl("settings", adminPath),
+    }
+  : undefined;
 ---
 
 <!doctype html>
-<html lang="en" transition:name="admin-root" transition:animate="none">
+<html
+  class="lg:h-full lg:overflow-hidden"
+  lang="en"
+  transition:name="admin-root"
+  transition:animate="none"
+>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -115,23 +139,35 @@ const sidebar: AdminSidebarData = {
     <AdminThemeScript />
     <ClientRouter fallback="swap" />
   </head>
-  <body>
-    <div class="min-h-svh bg-admin-canvas lg:flex lg:gap-3">
-      <aside class="sticky top-0 hidden h-svh w-[17rem] shrink-0 overflow-hidden bg-sidebar lg:block">
-        <AdminSidebar client:load data={sidebar} />
+  <body class="lg:h-full lg:overflow-hidden">
+    <div class="min-h-svh bg-admin-canvas lg:flex lg:h-svh lg:min-h-0 lg:gap-3 lg:overflow-hidden">
+      <aside
+        class:list={[
+          "sticky top-0 hidden h-svh shrink-0 overflow-hidden bg-sidebar lg:block",
+          settingsNavigation ? "w-[19rem]" : "w-[17rem]",
+        ]}
+      >
+        {
+          settingsSidebar ? (
+            <AdminSettingsSidebar client:load data={settingsSidebar} />
+          ) : (
+            <AdminSidebar client:load data={sidebar} />
+          )
+        }
       </aside>
-      <section class="min-h-svh min-w-0 flex-1 bg-background lg:mt-3 lg:h-[calc(100svh-0.75rem)] lg:min-h-0 lg:overflow-hidden lg:rounded-tl-[var(--radius-shell)] lg:border lg:border-r-0 lg:border-b-0 lg:shadow-xs">
+      <section class="min-h-svh min-w-0 flex-1 bg-background lg:mt-3 lg:flex lg:h-[calc(100svh-0.75rem)] lg:min-h-0 lg:flex-col lg:overflow-hidden lg:rounded-tl-[var(--radius-shell)] lg:border lg:border-r-0 lg:border-b-0 lg:shadow-xs">
         <AdminTopBar
           {adminPath}
           {breadcrumb}
           {identity}
           {pageTitle}
+          {settingsSidebar}
           {sidebar}
         >
           <div slot="toolbar"><slot name="toolbar" /></div>
         </AdminTopBar>
         <main
-          class="min-h-0 w-full lg:max-h-[calc(100svh-4.75rem)] lg:overflow-y-auto"
+          class="min-h-0 w-full lg:flex-1 lg:overscroll-contain lg:overflow-y-auto"
           id="admin-page-content"
         >
           <div class="mx-auto w-full max-w-[90rem] p-4 sm:p-6 xl:p-8">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,10 +9,8 @@ import {
   normalizeAdminPath,
 } from "@/shared/AdminPath";
 import {SETTINGS_CATEGORIES, STATUSES} from "@/shared/Constants";
-import {
-  ITEM_LIST_SORT_ORDERS,
-  itemQueryForStatusFilter,
-} from "@/shared/ItemList";
+import {itemQueryForStatusFilter} from "@/shared/ItemList";
+import {ITEM_ORDERS, ITEM_SORTS} from "@/shared/ItemPagination";
 import {
   canonicalPathname,
   resolvePublicBucketUrl,
@@ -198,12 +196,14 @@ export const onRequest = defineMiddleware(async (context, next) => {
     const editingExistingItem = isExistingItemEditorPath(pathname, adminPath);
     if (!editingExistingItem) {
       let query;
-      let itemsSortOrder;
+      let itemsOrder;
+      let itemsSort;
       if (pathname.startsWith(adminUrl("items/list", adminPath))) {
         query = itemQueryForStatusFilter(
           context.url.searchParams.get("status"),
         );
-        itemsSortOrder = ITEM_LIST_SORT_ORDERS.UPDATED_DESC;
+        itemsOrder = ITEM_ORDERS.DESC;
+        itemsSort = ITEM_SORTS.UPDATED_AT;
       } else if (
         pathname.startsWith(adminUrl("feed/json", adminPath))
       ) {
@@ -218,7 +218,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
         context.request,
         {
           adminProtection: protection,
-          itemsSortOrder,
+          itemsOrder,
+          itemsSort,
           ...(query
             ? {
                 limit: pathname.startsWith(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,7 +9,10 @@ import {
   normalizeAdminPath,
 } from "@/shared/AdminPath";
 import {SETTINGS_CATEGORIES, STATUSES} from "@/shared/Constants";
-import {itemQueryForStatusFilter} from "@/shared/ItemList";
+import {
+  ITEM_LIST_SORT_ORDERS,
+  itemQueryForStatusFilter,
+} from "@/shared/ItemList";
 import {
   canonicalPathname,
   resolvePublicBucketUrl,
@@ -195,10 +198,12 @@ export const onRequest = defineMiddleware(async (context, next) => {
     const editingExistingItem = isExistingItemEditorPath(pathname, adminPath);
     if (!editingExistingItem) {
       let query;
+      let itemsSortOrder;
       if (pathname.startsWith(adminUrl("items/list", adminPath))) {
         query = itemQueryForStatusFilter(
           context.url.searchParams.get("status"),
         );
+        itemsSortOrder = ITEM_LIST_SORT_ORDERS.UPDATED_DESC;
       } else if (
         pathname.startsWith(adminUrl("feed/json", adminPath))
       ) {
@@ -213,6 +218,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
         context.request,
         {
           adminProtection: protection,
+          itemsSortOrder,
           ...(query
             ? {
                 limit: pathname.startsWith(

--- a/src/pages/[adminPath]/api/index.astro
+++ b/src/pages/[adminPath]/api/index.astro
@@ -1,6 +1,6 @@
 ---
-import SettingsApp from "@/components/admin/settings/SettingsApp";
 import AdminPageFallback from "@/components/admin/AdminPageFallback.astro";
+import ApiSettingsApp from "@/components/admin/settings/ApiSettingsApp";
 import {NAV_ITEMS} from "@/shared/Constants";
 import AdminShell from "../../../layouts/AdminShell.astro";
 
@@ -11,14 +11,15 @@ if (!feedContent || !onboardingResult) {
 ---
 
 <AdminShell
-  activeNavItem={NAV_ITEMS.SETTINGS}
-  documentTitle="Settings | microfeed.org"
+  activeNavItem={NAV_ITEMS.API}
+  documentTitle="API | microfeed.org"
   {feedContent}
   {onboardingResult}
-  pageTitle="Settings"
-  settingsNavigation
+  pageTitle="API"
 >
-  <SettingsApp client:only="react" {feedContent} {onboardingResult}>
-    <AdminPageFallback slot="fallback" kind="settings" />
-  </SettingsApp>
+  <div class="mx-auto max-w-5xl">
+    <ApiSettingsApp client:only="react" feed={feedContent}>
+      <AdminPageFallback slot="fallback" kind="settings" />
+    </ApiSettingsApp>
+  </div>
 </AdminShell>

--- a/src/pages/[adminPath]/items/new/index.astro
+++ b/src/pages/[adminPath]/items/new/index.astro
@@ -1,7 +1,6 @@
 ---
 import EditItemApp from "@/components/admin/items/EditItemApp";
 import AdminPageFallback from "@/components/admin/AdminPageFallback.astro";
-import {NAV_ITEMS} from "@/shared/Constants";
 import AdminShell from "../../../../layouts/AdminShell.astro";
 
 const {feedContent, onboardingResult} = Astro.locals;
@@ -11,7 +10,7 @@ if (!feedContent || !onboardingResult) {
 ---
 
 <AdminShell
-  activeNavItem={NAV_ITEMS.NEW_ITEM}
+  activeNavItem={null}
   documentTitle="New item | microfeed.org"
   {feedContent}
   {onboardingResult}

--- a/src/pages/[adminPath]/settings/code-editor/index.astro
+++ b/src/pages/[adminPath]/settings/code-editor/index.astro
@@ -50,6 +50,8 @@ const codeType = Object.values(CODE_TYPES).includes(requestedCodeType)
   {feedContent}
   {onboardingResult}
   pageTitle={invalidTheme ? "Code editor not found" : "Code editor"}
+  settingsActiveSection="custom-code"
+  settingsNavigation
   breadcrumb={{
     name: "Settings",
     url: adminUrl("settings", Astro.params.adminPath),

--- a/src/server/feed/FeedDb.ts
+++ b/src/server/feed/FeedDb.ts
@@ -1,62 +1,45 @@
 import {randomShortUUID} from "@/shared/StringUtils";
 import {
   STATUSES, PREDEFINED_SUBSCRIBE_METHODS,
-  SETTINGS_CATEGORIES, DEFAULT_ITEMS_PER_PAGE, ITEMS_SORT_ORDERS, MAX_ITEMS_PER_PAGE,
+  SETTINGS_CATEGORIES, DEFAULT_ITEMS_PER_PAGE, MAX_ITEMS_PER_PAGE,
 } from '@/shared/Constants';
 import {msToRFC3339, rfc3399ToMs} from "@/shared/TimeUtils";
 import {
-  decodeItemListCursor,
-  encodeItemListCursor,
-  ITEM_LIST_SORT_ORDERS,
-  itemListSortDefinition,
-} from "@/shared/ItemList";
+  encodeItemCursor,
+  ITEM_ORDERS,
+  ITEM_SORTS,
+  type ItemOrder,
+  type ItemSort,
+  resolveItemPagination,
+  resolveItemPaginationSettings,
+  type ResolvedItemPagination,
+} from "@/shared/ItemPagination";
 import FeedPublicJsonBuilder from "./FeedPublicJsonBuilder";
 
 /**
  * support url query parameters:
- * - next_cursor: selected sort timestamp in milliseconds
- * - prev_cursor: selected sort timestamp in milliseconds
- * - sort: "oldest_first", "newest_first", "updated_asc", or "updated_desc".
+ * Canonical pagination uses sort=created_at|updated_at|published_at,
+ * order=asc|desc, and Base64URL [timestamp, item ID] cursors. Explicit legacy
+ * sort=newest_first|oldest_first requests keep numeric published timestamps.
  *
  * if next_cursor and prev_cursor co-exist, we choose next_cursor and ignore prev_cursor
  *
- * Example: /json/?next_cursor=1669249854169&sort=oldest_first
+ * Example: /json/?sort=published_at&order=desc
  */
 export function getFetchItemsParams(
   request: Request,
   queryKwargs: Record<string, any> = {},
   limit: number | null = null,
-  defaultSortOrder?: string,
+  defaultSort?: ItemSort,
+  defaultOrder?: ItemOrder,
 ) {
-  const fetchItems = {
+  return {
+    defaultOrder,
+    defaultSort,
     queryKwargs,
-    fromUrl: {},
     limit,
+    searchParams: new URL(request.url).searchParams,
   };
-
-  const { searchParams } = new URL(request.url)
-  const nextCursor = searchParams.get('next_cursor');
-  const prevCursor = searchParams.get('prev_cursor');
-  const sortOrder = searchParams.get('sort');
-  if (sortOrder) {
-    (fetchItems.fromUrl as any).sortOrder = sortOrder;
-  } else if (defaultSortOrder) {
-    (fetchItems.fromUrl as any).sortOrder = defaultSortOrder;
-  }
-  if (nextCursor) {
-    const decodedCursor = decodeItemListCursor(nextCursor);
-    const numericCursor = Number(nextCursor);
-    if (decodedCursor || Number.isFinite(numericCursor)) {
-      (fetchItems.fromUrl as any).nextCursor = decodedCursor ?? numericCursor;
-    }
-  } else if (prevCursor) {
-    const decodedCursor = decodeItemListCursor(prevCursor);
-    const numericCursor = Number(prevCursor);
-    if (decodedCursor || Number.isFinite(numericCursor)) {
-      (fetchItems.fromUrl as any).prevCursor = decodedCursor ?? numericCursor;
-    }
-  }
-  return fetchItems;
 }
 
 function getSettingJson(settingObj: any) {
@@ -76,6 +59,7 @@ function getChannelJson(channelObj: any) {
 
 function getItemJson(itemObj: any) {
   return {
+    createdAtMs: rfc3399ToMs(itemObj.created_at),
     id: itemObj.id,
     status: itemObj.status,
     pubDateMs: rfc3399ToMs(itemObj.pub_date),
@@ -134,9 +118,10 @@ export default class FeedDb {
   }
 
   getUpsertSql(table: any, primaryKey: any, queryKwargs: any, keyValuePairs: any) {
+    const timestamp = (new Date()).toISOString();
     let updateSql = 'UPDATE SET';
     const setList = ['updated_at = ?'];
-    const updateBindList = [(new Date()).toISOString()];
+    const updateBindList = [timestamp];
     Object.keys(keyValuePairs).forEach((key: any) => {
       setList.push(`${key} = ?`);
       updateBindList.push(keyValuePairs[key]);
@@ -144,7 +129,12 @@ export default class FeedDb {
     updateSql = `${updateSql} ${setList.join(', ')}`;
 
     let insertSql = `INSERT INTO ${table}`;
-    const insertKeyValuePairs = {...queryKwargs, ...keyValuePairs};
+    const insertKeyValuePairs = {
+      created_at: timestamp,
+      updated_at: timestamp,
+      ...queryKwargs,
+      ...keyValuePairs,
+    };
     const colList = Object.keys(insertKeyValuePairs)
     const insertBindList = Object.values(insertKeyValuePairs);
     const placeholderList = insertBindList.map(() => '?');
@@ -168,7 +158,8 @@ export default class FeedDb {
           'url': '/assets/default/favicon.png',
           'contentType': 'image/png',
         },
-        'itemsSortOrder': ITEMS_SORT_ORDERS.NEWEST_FIRST,
+        'itemsOrder': ITEM_ORDERS.DESC,
+        'itemsSort': ITEM_SORTS.PUBLISHED_AT,
         'itemsPerPage': DEFAULT_ITEMS_PER_PAGE,
       },
       [SETTINGS_CATEGORIES.ACCESS]: {
@@ -233,7 +224,10 @@ export default class FeedDb {
    *      }
    *   ]
    */
-  async _getContent(things: any, sortOrder?: any, fromUrl?: any) {
+  async _getContent(
+    things: any,
+    pagination?: ResolvedItemPagination,
+  ) {
     const batchStatements: any[] = [];
     things.forEach((thing: any) => {
       let sql = `SELECT * FROM ${thing.table}`;
@@ -297,33 +291,46 @@ export default class FeedDb {
           }
         });
       } else if (thing.table === 'items') {
-        let nextCursor;
-        let prevCursor: any;
-        const sort = itemListSortDefinition(
-          sortOrder,
-          ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
-        );
-        (contentJson as any)['items'] = response.results.map((result: any) => getItemJson(result));
-        (contentJson as any)['items'].sort((a: any, b: any) => {
-          const timestampDifference = sort.descending
-            ? b[sort.timestampKey] - a[sort.timestampKey]
-            : a[sort.timestampKey] - b[sort.timestampKey];
-          return timestampDifference || a.id.localeCompare(b.id);
-        });
-        (contentJson as any)['items'].forEach((itemJson: any) => {
-          nextCursor = sort.column === "updated_at"
-            ? encodeItemListCursor(itemJson[sort.timestampKey], itemJson.id)
-            : itemJson[sort.timestampKey];
-          if (!prevCursor) {
-            prevCursor = nextCursor;
-          }
-        });
-
-        if (thing.limit <= (contentJson as any)['items'].length) {
-          (contentJson as any)['items_next_cursor'] = nextCursor;
+        const hasLookahead = thing.pageLimit !== undefined &&
+          response.results.length > thing.pageLimit;
+        const pageResults = hasLookahead
+          ? response.results.slice(0, thing.pageLimit)
+          : response.results;
+        (contentJson as any)['items'] = pageResults.map((result: any) => getItemJson(result));
+        if (pagination?.prevCursor !== undefined) {
+          (contentJson as any)['items'].reverse();
         }
-        if (fromUrl.nextCursor || fromUrl.prevCursor) {
-          (contentJson as any)['items_prev_cursor'] = prevCursor;
+
+        const hasItems = (contentJson as any)['items'].length > 0;
+        const requestedNextPage = pagination?.nextCursor !== undefined;
+        const requestedPreviousPage = pagination?.prevCursor !== undefined;
+        const hasNextPage = hasItems && (
+          requestedPreviousPage ||
+          (!requestedPreviousPage && hasLookahead)
+        );
+        const hasPreviousPage = hasItems && (
+          requestedNextPage ||
+          (requestedPreviousPage && hasLookahead)
+        );
+        const firstItem = (contentJson as any)['items'][0];
+        const lastItem = (contentJson as any)['items'].at(-1);
+        const cursorForItem = (item: any) => pagination?.mode === "legacy"
+          ? item?.pubDateMs
+          : encodeItemCursor(
+            item?.[pagination?.timestampKey ?? "pubDateMs"],
+            item?.id,
+          );
+        if (hasNextPage) {
+          (contentJson as any)['items_next_cursor'] = cursorForItem(lastItem);
+        }
+        if (hasPreviousPage) {
+          (contentJson as any)['items_prev_cursor'] = cursorForItem(firstItem);
+        }
+        if (pagination?.mode === "legacy") {
+          (contentJson as any)['items_sort_order'] = pagination.legacySort;
+        } else if (pagination) {
+          (contentJson as any)['items_sort'] = pagination.sort;
+          (contentJson as any)['items_order'] = pagination.order;
         }
       }
     }
@@ -355,68 +362,55 @@ export default class FeedDb {
     if (fetchItems) {
       const webGlobalSettings = (contentJson as any).settings.webGlobalSettings || {};
 
-      const fromUrl = fetchItems.fromUrl || {};
-      const queryKwargs = fetchItems.queryKwargs || {};
-      const sort = itemListSortDefinition(
-        fromUrl.sortOrder || webGlobalSettings.itemsSortOrder,
-        ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
+      const savedPagination = resolveItemPaginationSettings(webGlobalSettings);
+      const pagination = resolveItemPagination(
+        fetchItems.searchParams ?? new URLSearchParams(),
+        {
+          order: fetchItems.defaultOrder ?? savedPagination.itemsOrder,
+          sort: fetchItems.defaultSort ?? savedPagination.itemsSort,
+        },
       );
-      const sortOrder = sort.order;
-      const {nextCursor, prevCursor} = fromUrl;
-      const compoundNextCursor = sort.column === "updated_at" &&
-          typeof nextCursor === "object"
-        ? nextCursor
-        : undefined;
-      const compoundPrevCursor = sort.column === "updated_at" &&
-          typeof prevCursor === "object"
-        ? prevCursor
-        : undefined;
-
-      let orderBy = [
-        `${sort.column}${sort.descending ? " desc" : ""}`,
-        'id',
-      ];
-      if (nextCursor) {
-        const queryParam = `${sort.column}__${sort.descending ? '<' : '>'}`;
+      const queryKwargs = {...(fetchItems.queryKwargs || {})};
+      const requestedCursor = pagination.nextCursor ?? pagination.prevCursor;
+      const previousPage = pagination.prevCursor !== undefined;
+      const displayDescending = pagination.order === ITEM_ORDERS.DESC;
+      const queryDescending = previousPage
+        ? !displayDescending
+        : displayDescending;
+      const queryDirection = queryDescending ? "desc" : "asc";
+      const cursorDirection = previousPage
+        ? displayDescending ? ">" : "<"
+        : displayDescending ? "<" : ">";
+      const orderBy = pagination.mode === "legacy"
+        ? [
+            `${pagination.column} ${queryDirection}`,
+            `id ${previousPage ? "desc" : "asc"}`,
+          ]
+        : [
+            `${pagination.column} ${queryDirection}`,
+            `id ${queryDirection}`,
+          ];
+      let cursor;
+      if (requestedCursor !== undefined) {
         try {
-          if (!compoundNextCursor) {
-            queryKwargs[queryParam] = msToRFC3339(nextCursor);
-          }
-        } catch (error) {
-          console.log(error);
-        }
-      } else if (prevCursor) {
-        orderBy = [
-          `${sort.column}${sort.descending ? "" : " desc"}`,
-          'id desc',
-        ];
-        const queryParam = `${sort.column}__${sort.descending ? '>' : '<'}`;
-        try {
-          if (!compoundPrevCursor) {
-            queryKwargs[queryParam] = msToRFC3339(prevCursor);
+          if (pagination.mode === "legacy" && typeof requestedCursor === "number") {
+            queryKwargs[`${pagination.column}__${cursorDirection}`] =
+              msToRFC3339(requestedCursor);
+          } else if (typeof requestedCursor === "object") {
+            cursor = {
+              column: pagination.column,
+              id: requestedCursor.id,
+              idOp: cursorDirection,
+              timestamp: msToRFC3339(requestedCursor.timestamp),
+              timestampOp: cursorDirection,
+            };
           }
         } catch (error) {
           console.log(error);
         }
       }
       const fetchItemsParams = {
-        cursor: compoundNextCursor
-          ? {
-              column: sort.column,
-              id: compoundNextCursor.id,
-              idOp: ">",
-              timestamp: msToRFC3339(compoundNextCursor.timestamp),
-              timestampOp: sort.descending ? "<" : ">",
-            }
-          : compoundPrevCursor
-          ? {
-              column: sort.column,
-              id: compoundPrevCursor.id,
-              idOp: "<",
-              timestamp: msToRFC3339(compoundPrevCursor.timestamp),
-              timestampOp: sort.descending ? ">" : "<",
-            }
-          : undefined,
+        cursor,
         limit: fetchItems.limit || webGlobalSettings.itemsPerPage || DEFAULT_ITEMS_PER_PAGE,
         orderBy,
         queryKwargs,
@@ -427,12 +421,17 @@ export default class FeedDb {
       } else if (fetchItemsParams.limit > MAX_ITEMS_PER_PAGE) {
         fetchItemsParams.limit = MAX_ITEMS_PER_PAGE;
       }
-      things = [{
-        table: 'items',
-        ...fetchItemsParams,
-      }];
-      itemJson = await this._getContent(things, sortOrder, fromUrl);
-      (itemJson as any)['items_sort_order'] = sortOrder;
+      const pageLimit = fetchItemsParams.limit;
+      const queryLimit = pageLimit === undefined ? undefined : pageLimit + 1;
+      itemJson = await this._getContent(
+        [{
+          table: 'items',
+          ...fetchItemsParams,
+          limit: queryLimit,
+          pageLimit,
+        }],
+        pagination,
+      );
     }
 
     return {...contentJson, ...itemJson};
@@ -478,7 +477,7 @@ export default class FeedDb {
   }
 
   async _putItemToContent(item: any) {
-    const {id, pubDateMs, status, ...data} = item;
+    const {createdAtMs: _createdAtMs, id, pubDateMs, status, updatedAtMs: _updatedAtMs, ...data} = item;
     const keyValuePairs = {
       status,
       'pub_date': msToRFC3339(pubDateMs),

--- a/src/server/feed/FeedDb.ts
+++ b/src/server/feed/FeedDb.ts
@@ -4,13 +4,19 @@ import {
   SETTINGS_CATEGORIES, DEFAULT_ITEMS_PER_PAGE, ITEMS_SORT_ORDERS, MAX_ITEMS_PER_PAGE,
 } from '@/shared/Constants';
 import {msToRFC3339, rfc3399ToMs} from "@/shared/TimeUtils";
+import {
+  decodeItemListCursor,
+  encodeItemListCursor,
+  ITEM_LIST_SORT_ORDERS,
+  itemListSortDefinition,
+} from "@/shared/ItemList";
 import FeedPublicJsonBuilder from "./FeedPublicJsonBuilder";
 
 /**
  * support url query parameters:
- * - next_cursor: pub_date in milliseconds
- * - prev_cursor: pub_date in milliseconds
- * - sort: "oldest_first", or "newest_first" (default).
+ * - next_cursor: selected sort timestamp in milliseconds
+ * - prev_cursor: selected sort timestamp in milliseconds
+ * - sort: "oldest_first", "newest_first", "updated_asc", or "updated_desc".
  *
  * if next_cursor and prev_cursor co-exist, we choose next_cursor and ignore prev_cursor
  *
@@ -20,6 +26,7 @@ export function getFetchItemsParams(
   request: Request,
   queryKwargs: Record<string, any> = {},
   limit: number | null = null,
+  defaultSortOrder?: string,
 ) {
   const fetchItems = {
     queryKwargs,
@@ -33,18 +40,20 @@ export function getFetchItemsParams(
   const sortOrder = searchParams.get('sort');
   if (sortOrder) {
     (fetchItems.fromUrl as any).sortOrder = sortOrder;
+  } else if (defaultSortOrder) {
+    (fetchItems.fromUrl as any).sortOrder = defaultSortOrder;
   }
   if (nextCursor) {
-    try {
-      (fetchItems.fromUrl as any).nextCursor = parseInt(nextCursor, 10);
-    } catch (error) {
-      console.log(error);
+    const decodedCursor = decodeItemListCursor(nextCursor);
+    const numericCursor = Number(nextCursor);
+    if (decodedCursor || Number.isFinite(numericCursor)) {
+      (fetchItems.fromUrl as any).nextCursor = decodedCursor ?? numericCursor;
     }
   } else if (prevCursor) {
-    try {
-      (fetchItems.fromUrl as any).prevCursor = parseInt(prevCursor, 10);
-    } catch (error) {
-      console.log(error);
+    const decodedCursor = decodeItemListCursor(prevCursor);
+    const numericCursor = Number(prevCursor);
+    if (decodedCursor || Number.isFinite(numericCursor)) {
+      (fetchItems.fromUrl as any).prevCursor = decodedCursor ?? numericCursor;
     }
   }
   return fetchItems;
@@ -70,6 +79,7 @@ function getItemJson(itemObj: any) {
     id: itemObj.id,
     status: itemObj.status,
     pubDateMs: rfc3399ToMs(itemObj.pub_date),
+    updatedAtMs: rfc3399ToMs(itemObj.updated_at),
     ...JSON.parse(itemObj.data)
   };
 }
@@ -249,6 +259,16 @@ export default class FeedDb {
       if (whereList.length > 0) {
         sql = `${sql} WHERE ${whereList.join(' AND ')}`;
       }
+      if (thing.cursor) {
+        const cursorClause = `(${thing.cursor.column} ${thing.cursor.timestampOp} ? OR (` +
+          `${thing.cursor.column} == ? AND id ${thing.cursor.idOp} ?))`;
+        sql = `${sql}${whereList.length > 0 ? " AND" : " WHERE"} ${cursorClause}`;
+        bindList.push(
+          thing.cursor.timestamp,
+          thing.cursor.timestamp,
+          thing.cursor.id,
+        );
+      }
       if (thing.orderBy && thing.orderBy.length > 0) {
         sql = `${sql} ORDER BY ${thing.orderBy.join(',')}`
       }
@@ -279,16 +299,23 @@ export default class FeedDb {
       } else if (thing.table === 'items') {
         let nextCursor;
         let prevCursor: any;
+        const sort = itemListSortDefinition(
+          sortOrder,
+          ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
+        );
         (contentJson as any)['items'] = response.results.map((result: any) => getItemJson(result));
-        if (sortOrder === ITEMS_SORT_ORDERS.NEWEST_FIRST) {
-          (contentJson as any)['items'].sort((a: any, b: any) => (b.pubDateMs - a.pubDateMs));
-        } else {
-          (contentJson as any)['items'].sort((a: any, b: any) => (a.pubDateMs - b.pubDateMs));
-        }
+        (contentJson as any)['items'].sort((a: any, b: any) => {
+          const timestampDifference = sort.descending
+            ? b[sort.timestampKey] - a[sort.timestampKey]
+            : a[sort.timestampKey] - b[sort.timestampKey];
+          return timestampDifference || a.id.localeCompare(b.id);
+        });
         (contentJson as any)['items'].forEach((itemJson: any) => {
-          nextCursor = itemJson.pubDateMs;
+          nextCursor = sort.column === "updated_at"
+            ? encodeItemListCursor(itemJson[sort.timestampKey], itemJson.id)
+            : itemJson[sort.timestampKey];
           if (!prevCursor) {
-            prevCursor = itemJson.pubDateMs;
+            prevCursor = nextCursor;
           }
         });
 
@@ -330,28 +357,66 @@ export default class FeedDb {
 
       const fromUrl = fetchItems.fromUrl || {};
       const queryKwargs = fetchItems.queryKwargs || {};
-      const sortOrder = fromUrl.sortOrder || webGlobalSettings.itemsSortOrder || ITEMS_SORT_ORDERS.NEWEST_FIRST;
+      const sort = itemListSortDefinition(
+        fromUrl.sortOrder || webGlobalSettings.itemsSortOrder,
+        ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
+      );
+      const sortOrder = sort.order;
       const {nextCursor, prevCursor} = fromUrl;
+      const compoundNextCursor = sort.column === "updated_at" &&
+          typeof nextCursor === "object"
+        ? nextCursor
+        : undefined;
+      const compoundPrevCursor = sort.column === "updated_at" &&
+          typeof prevCursor === "object"
+        ? prevCursor
+        : undefined;
 
-      let orderBy = sortOrder === ITEMS_SORT_ORDERS.NEWEST_FIRST ?
-        ['pub_date desc', 'id'] : ['pub_date', 'id'];
+      let orderBy = [
+        `${sort.column}${sort.descending ? " desc" : ""}`,
+        'id',
+      ];
       if (nextCursor) {
-        const queryParam = sortOrder === ITEMS_SORT_ORDERS.NEWEST_FIRST ? 'pub_date__<' : 'pub_date__>';
+        const queryParam = `${sort.column}__${sort.descending ? '<' : '>'}`;
         try {
-          queryKwargs[queryParam] = msToRFC3339(nextCursor);
+          if (!compoundNextCursor) {
+            queryKwargs[queryParam] = msToRFC3339(nextCursor);
+          }
         } catch (error) {
           console.log(error);
         }
       } else if (prevCursor) {
-        orderBy = sortOrder === ITEMS_SORT_ORDERS.NEWEST_FIRST ? ['pub_date', 'id'] : ['pub_date desc', 'id'];
-        const queryParam = sortOrder === ITEMS_SORT_ORDERS.NEWEST_FIRST ? 'pub_date__>' : 'pub_date__<';
+        orderBy = [
+          `${sort.column}${sort.descending ? "" : " desc"}`,
+          'id desc',
+        ];
+        const queryParam = `${sort.column}__${sort.descending ? '>' : '<'}`;
         try {
-          queryKwargs[queryParam] = msToRFC3339(prevCursor);
+          if (!compoundPrevCursor) {
+            queryKwargs[queryParam] = msToRFC3339(prevCursor);
+          }
         } catch (error) {
           console.log(error);
         }
       }
       const fetchItemsParams = {
+        cursor: compoundNextCursor
+          ? {
+              column: sort.column,
+              id: compoundNextCursor.id,
+              idOp: ">",
+              timestamp: msToRFC3339(compoundNextCursor.timestamp),
+              timestampOp: sort.descending ? "<" : ">",
+            }
+          : compoundPrevCursor
+          ? {
+              column: sort.column,
+              id: compoundPrevCursor.id,
+              idOp: "<",
+              timestamp: msToRFC3339(compoundPrevCursor.timestamp),
+              timestampOp: sort.descending ? ">" : "<",
+            }
+          : undefined,
         limit: fetchItems.limit || webGlobalSettings.itemsPerPage || DEFAULT_ITEMS_PER_PAGE,
         orderBy,
         queryKwargs,

--- a/src/server/feed/FeedPublicJsonBuilder.ts
+++ b/src/server/feed/FeedPublicJsonBuilder.ts
@@ -10,6 +10,7 @@ import {humanizeMs, msToRFC3339} from "@/shared/TimeUtils";
 import {ENCLOSURE_CATEGORIES, ITEM_STATUSES_DICT, STATUSES} from "@/shared/Constants";
 import {isValidMediaFile} from "@/shared/MediaFileUtils";
 import {MICROFEED_VERSION} from "@/shared/Version";
+import {buildItemPaginationUrl} from "@/shared/ItemPagination";
 
 export default class FeedPublicJsonBuilder {
   [member: string]: any;
@@ -65,9 +66,16 @@ export default class FeedPublicJsonBuilder {
 
     (publicContent as any)['feed_url'] = PUBLIC_URLS.jsonFeed(this.baseUrl);
 
-    if (this.content.items_next_cursor && !this.forOneItem) {
-      (publicContent as any)['next_url'] = `${(publicContent as any)['feed_url']}?next_cursor=${this.content.items_next_cursor}&` +
-        `sort=${this.content.items_sort_order}`;
+    if (this.content.items_next_cursor !== undefined && !this.forOneItem) {
+      (publicContent as any)['next_url'] = buildItemPaginationUrl(
+        (publicContent as any)['feed_url'],
+        {
+          legacySort: this.content.items_sort_order,
+          nextCursor: this.content.items_next_cursor,
+          order: this.content.items_order,
+          sort: this.content.items_sort,
+        },
+      );
     }
 
     (publicContent as any)['description'] = channel.description || '';
@@ -175,15 +183,35 @@ export default class FeedPublicJsonBuilder {
     if (channel['itunes:email']) {
       (microfeedExtra as any)['itunes:email'] = channel['itunes:email'];
     }
-    (microfeedExtra as any)['items_sort_order'] = this.content.items_sort_order;
-    if (this.content.items_next_cursor && !this.forOneItem) {
-      (microfeedExtra as any)['items_next_cursor'] = this.content.items_next_cursor;
-      (microfeedExtra as any)['next_url'] = publicContent['next_url'];
+    if (this.content.items_sort_order) {
+      (microfeedExtra as any)['items_sort_order'] = this.content.items_sort_order;
+    } else {
+      (microfeedExtra as any)['items_sort'] = this.content.items_sort;
+      (microfeedExtra as any)['items_order'] = this.content.items_order;
     }
-    if (this.content.items_prev_cursor && !this.forOneItem) {
+    if (this.content.items_next_cursor !== undefined && !this.forOneItem) {
+      (microfeedExtra as any)['items_next_cursor'] = this.content.items_next_cursor;
+      (microfeedExtra as any)['next_url'] = buildItemPaginationUrl(
+        this.request.url,
+        {
+          legacySort: this.content.items_sort_order,
+          nextCursor: this.content.items_next_cursor,
+          order: this.content.items_order,
+          sort: this.content.items_sort,
+        },
+      );
+    }
+    if (this.content.items_prev_cursor !== undefined && !this.forOneItem) {
       (microfeedExtra as any)['items_prev_cursor'] = this.content.items_prev_cursor;
-      (microfeedExtra as any)['prev_url'] = `${publicContent['feed_url']}?prev_cursor=${this.content.items_prev_cursor}&` +
-        `sort=${this.content.items_sort_order}`;
+      (microfeedExtra as any)['prev_url'] = buildItemPaginationUrl(
+        publicContent['feed_url'],
+        {
+          legacySort: this.content.items_sort_order,
+          order: this.content.items_order,
+          prevCursor: this.content.items_prev_cursor,
+          sort: this.content.items_sort,
+        },
+      );
     }
     return microfeedExtra;
   }

--- a/src/server/feed/FeedPublicRssBuilder.ts
+++ b/src/server/feed/FeedPublicRssBuilder.ts
@@ -2,6 +2,7 @@ import {XMLBuilder} from "fast-xml-parser";
 import {PUBLIC_URLS, secondsToHHMMSS} from "@/shared/StringUtils";
 import {msToUtcString} from "@/shared/TimeUtils";
 import {OUR_BRAND} from "@/shared/Constants";
+import {buildItemPaginationUrl} from "@/shared/ItemPagination";
 
 export default class FeedPublicRssBuilder {
   [member: string]: any;
@@ -102,19 +103,39 @@ export default class FeedPublicRssBuilder {
     if (this.jsonData.home_page_url) {
       linksTags.push(this.jsonData.home_page_url);
     }
-    if (this.jsonData._microfeed.items_next_cursor) {
-      const {items_next_cursor, items_sort_order} = this.jsonData._microfeed;
+    if (this.jsonData._microfeed.items_next_cursor !== undefined) {
+      const {
+        items_next_cursor,
+        items_order,
+        items_sort,
+        items_sort_order,
+      } = this.jsonData._microfeed;
       linksTags.push({
         '@_rel': 'next',
-        '@_href': `${PUBLIC_URLS.rssFeed(this.baseUrl)}?next_cursor=${items_next_cursor}&sort=${items_sort_order}`,
+        '@_href': buildItemPaginationUrl(PUBLIC_URLS.rssFeed(this.baseUrl), {
+          legacySort: items_sort_order,
+          nextCursor: items_next_cursor,
+          order: items_order,
+          sort: items_sort,
+        }),
         '@_type': 'application/rss+xml',
       });
     }
-    if (this.jsonData._microfeed.items_prev_cursor) {
-      const {items_prev_cursor, items_sort_order} = this.jsonData._microfeed;
+    if (this.jsonData._microfeed.items_prev_cursor !== undefined) {
+      const {
+        items_order,
+        items_prev_cursor,
+        items_sort,
+        items_sort_order,
+      } = this.jsonData._microfeed;
       linksTags.push({
         '@_rel': 'prev',
-        '@_href': `${PUBLIC_URLS.rssFeed(this.baseUrl)}?prev_cursor=${items_prev_cursor}&sort=${items_sort_order}`,
+        '@_href': buildItemPaginationUrl(PUBLIC_URLS.rssFeed(this.baseUrl), {
+          legacySort: items_sort_order,
+          order: items_order,
+          prevCursor: items_prev_cursor,
+          sort: items_sort,
+        }),
         '@_type': 'application/rss+xml',
       });
     }

--- a/src/server/feed/feed.ts
+++ b/src/server/feed/feed.ts
@@ -9,10 +9,12 @@ import type {
   OnboardingResult,
   PublicFeed,
 } from "@/types";
+import type {ItemOrder, ItemSort} from "@/shared/ItemPagination";
 
 export interface FeedQuery {
   adminProtection?: AdminProtectionStatus;
-  itemsSortOrder?: string;
+  itemsOrder?: ItemOrder;
+  itemsSort?: ItemSort;
   limit?: number;
   queryKwargs?: Record<string, unknown>;
 }
@@ -34,7 +36,8 @@ export async function loadFeed(
         request,
         query.queryKwargs ?? {},
         query.limit,
-        query.itemsSortOrder,
+        query.itemsSort,
+        query.itemsOrder,
       )
     : null;
   const content = await database.getContent(fetchItems) as FeedContent;

--- a/src/server/feed/feed.ts
+++ b/src/server/feed/feed.ts
@@ -12,6 +12,7 @@ import type {
 
 export interface FeedQuery {
   adminProtection?: AdminProtectionStatus;
+  itemsSortOrder?: string;
   limit?: number;
   queryKwargs?: Record<string, unknown>;
 }
@@ -29,7 +30,12 @@ export async function loadFeed(
 ): Promise<LoadedFeed> {
   const database = new FeedDb(runtimeEnv, request);
   const fetchItems = query
-    ? getFetchItemsParams(request, query.queryKwargs ?? {}, query.limit)
+    ? getFetchItemsParams(
+        request,
+        query.queryKwargs ?? {},
+        query.limit,
+        query.itemsSortOrder,
+      )
     : null;
   const content = await database.getContent(fetchItems) as FeedContent;
   const onboarding = new OnboardingChecker(

--- a/src/server/openapi/openapi.yaml
+++ b/src/server/openapi/openapi.yaml
@@ -26,7 +26,7 @@ tags:
       Endpoints to do CRUD operations on the microfeed instance, e.g.,
       create a new item, update an existing item, delete an item, upload media files...
       You need to use your microfeed instance's API key to access these endpoints.
-      You can find your microfeed instance's API key at the API section of {{baseUrl}}{{adminBasePath}}settings/.
+      You can find your microfeed instance's API key at {{baseUrl}}{{adminBasePath}}api/.
 paths:
   /json:
     get:
@@ -41,24 +41,10 @@ paths:
         {{adminBasePath}}settings/code-editor/?type=themes&theme=custom#webFeed
       operationId: fetchFeedJson
       parameters:
-        - name: next_cursor
-          in: query
-          description: |
-            Offset for items, for pagination. You'll use **next_cursor** from response for this parameter.
-          required: false
-          schema:
-            type: integer
-            example: 1672707197212
-        - name: sort
-          in: query
-          description: |
-            How do you want to sort these items?
-          required: false
-          schema:
-            type: string
-            example: newest_first
-            default: newest_first
-            enum: [ "newest_first", "oldest_first" ]
+        - $ref: '#/components/parameters/itemsNextCursorParam'
+        - $ref: '#/components/parameters/itemsPrevCursorParam'
+        - $ref: '#/components/parameters/itemsSortParam'
+        - $ref: '#/components/parameters/itemsOrderParam'
       responses:
         200:
           description: Success response.
@@ -67,8 +53,9 @@ paths:
               operationId: fetchFeedJson
               parameters:
                 next_cursor: $response.body#/_microfeed/items_next_cursor
-                sort: $response.body#/_microfeed/items_sort_order
-              description: Pagination through items.
+                sort: $response.body#/_microfeed/items_sort
+                order: $response.body#/_microfeed/items_order
+              description: Canonical pagination through items. Legacy clients can follow next_url.
           content:
             application/json:
               schema:
@@ -240,6 +227,10 @@ paths:
       operationId: apiFetchFeed
       parameters:
       - $ref: '#/components/parameters/apiKeyParam'
+      - $ref: '#/components/parameters/itemsNextCursorParam'
+      - $ref: '#/components/parameters/itemsPrevCursorParam'
+      - $ref: '#/components/parameters/itemsSortParam'
+      - $ref: '#/components/parameters/itemsOrderParam'
       responses:
         200:
           description: Success response.
@@ -248,8 +239,9 @@ paths:
               operationId: apiFetchFeed
               parameters:
                 next_cursor: $response.body#/_microfeed/items_next_cursor
-                sort: $response.body#/_microfeed/items_sort_order
-              description: Pagination through items.
+                sort: $response.body#/_microfeed/items_sort
+                order: $response.body#/_microfeed/items_order
+              description: Canonical pagination through items. Legacy clients can follow next_url.
           content:
             application/json:
               schema:
@@ -316,7 +308,7 @@ components:
       explode: false
       schema:
         type: string
-      description: "Get API Key on {{baseUrl}}{{adminBasePath}}settings/"
+      description: "Get API Key on {{baseUrl}}{{adminBasePath}}api/"
     itemIdParam:
       name: id
       in: path
@@ -327,6 +319,58 @@ components:
       schema:
         type: string
       example: GOwipulXxh9
+    itemsNextCursorParam:
+      name: next_cursor
+      in: query
+      description: |
+        Fetch the page after this cursor. Canonical cursors are unpadded Base64URL-encoded
+        JSON tuples in the form `[timestampMs, itemId]`. Explicit legacy sort values use
+        numeric published timestamps. If next_cursor and prev_cursor are both supplied,
+        next_cursor takes precedence. Malformed or mode-incompatible cursors are ignored.
+      required: false
+      schema:
+        type: string
+      example: WzE2NzI3MDcxOTcyMTIsIml0ZW0tYSJd
+    itemsPrevCursorParam:
+      name: prev_cursor
+      in: query
+      description: |
+        Fetch the page before this cursor. It uses the same canonical or legacy encoding
+        as next_cursor.
+      required: false
+      schema:
+        type: string
+      example: WzE2NzI3MDcxOTcyMTIsIml0ZW0tYSJd
+    itemsSortParam:
+      name: sort
+      in: query
+      description: |
+        Timestamp used to sort items. `published_at`, `created_at`, and `updated_at` use
+        deterministic canonical pagination. Deprecated `newest_first` and `oldest_first`
+        values preserve numeric published-timestamp cursors for backward compatibility.
+      required: false
+      schema:
+        type: string
+        default: published_at
+        enum:
+          - published_at
+          - created_at
+          - updated_at
+          - newest_first
+          - oldest_first
+      example: published_at
+    itemsOrderParam:
+      name: order
+      in: query
+      description: |
+        Canonical sort direction. Defaults to descending and is ignored when sort is the
+        deprecated newest_first or oldest_first value.
+      required: false
+      schema:
+        type: string
+        default: desc
+        enum: [ "asc", "desc" ]
+      example: desc
   schemas:
     FeedJson:
       type: object
@@ -369,7 +413,7 @@ components:
           description: |
             The URL of a feed that provides the next n items, where n is defined in {{adminBasePath}}settings/.
             This allows for pagination.
-          example: https://my-website.com/json/?next_cursor=1672707197212&sort=newest_first
+          example: "https://my-website.com/json/?next_cursor=WzE2NzI3MDcxOTcyMTIsIml0ZW0tYSJd&sort=published_at&order=desc"
         icon:
           type: string
           description: |
@@ -398,7 +442,9 @@ components:
           type: array
           description: |
             The first n items in the feed.
-            The sort order is determined by _microfeed.items_sort_order.
+            Canonical sorting is described by _microfeed.items_sort and
+            _microfeed.items_order. Explicit legacy requests instead expose the
+            deprecated _microfeed.items_sort_order field.
             Please follow the next_url field to see next page of items.
           items:
             $ref: "#/components/schemas/ItemJson"
@@ -584,20 +630,48 @@ components:
             - episodic
             - serial
           default: episodic
+        items_sort:
+          type: string
+          description: The timestamp key used by canonical pagination.
+          enum:
+            - published_at
+            - created_at
+            - updated_at
+          default: published_at
+        items_order:
+          type: string
+          description: The direction used by canonical pagination.
+          enum:
+            - asc
+            - desc
+          default: desc
         items_sort_order:
-          type: string,
+          type: string
+          deprecated: true
           description: |
-            The sort order of items.
+            Legacy published timestamp sorting. This field is returned only when the
+            request explicitly uses sort=newest_first or sort=oldest_first.
           enum:
             - newest_first
             - oldest_first
-          default: newest_first
         items_next_cursor:
-          type: string
+          oneOf:
+            - type: string
+            - type: integer
           description: |
-            This data field is for pagination through items.
-            You can pass a next_cursor=[items_next_cursor] query string to feed_url to fetch next page of items.
-          example: 1672705853661
+            Cursor for the next page. Canonical responses use an unpadded Base64URL JSON
+            tuple `[timestampMs, itemId]`; explicit legacy responses use a numeric timestamp.
+        items_prev_cursor:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Cursor for the previous page, using the active pagination mode.
+        next_url:
+          type: string
+          description: Fully escaped URL for the next page, including the active mode.
+        prev_url:
+          type: string
+          description: Fully escaped URL for the previous page, including the active mode.
         "itunes:block":
           type: boolean
           description: |

--- a/src/server/themes/defaults/web_feed.html
+++ b/src/server/themes/defaults/web_feed.html
@@ -72,19 +72,19 @@
     </div>
 
     <div class="flex justify-center mt-4">
-      {{#_microfeed.items_prev_cursor}}
+      {{#_microfeed.prev_url}}
       <div class="px-2">
-        <a href="?prev_cursor={{_microfeed.items_prev_cursor}}&sort={{_microfeed.items_sort_order}}"><span
+        <a href="{{_microfeed.prev_url}}"><span
           class="icon-arrow-left"> Prev</span></a>
       </div>
-      {{/_microfeed.items_prev_cursor}}
+      {{/_microfeed.prev_url}}
 
-      {{#_microfeed.items_next_cursor}}
+      {{#_microfeed.next_url}}
       <div class="px-2">
-        <a href="?next_cursor={{_microfeed.items_next_cursor}}&sort={{_microfeed.items_sort_order}}">Next <span
+        <a href="{{_microfeed.next_url}}">Next <span
           class="icon-arrow-right"></span></a>
       </div>
-      {{/_microfeed.items_next_cursor}}
+      {{/_microfeed.next_url}}
     </div>
   </section>
 </main>

--- a/src/shared/AdminNavigation.ts
+++ b/src/shared/AdminNavigation.ts
@@ -15,8 +15,8 @@ export interface AdminNavigationItem {
 const NAVIGATION_PATHS: Array<[AdminNavItemId, string]> = [
   [NAV_ITEMS.ADMIN_HOME, ""],
   [NAV_ITEMS.EDIT_CHANNEL, "channels/primary"],
-  [NAV_ITEMS.NEW_ITEM, "items/new"],
   [NAV_ITEMS.ALL_ITEMS, "items/list"],
+  [NAV_ITEMS.API, "api"],
   [NAV_ITEMS.SETTINGS, "settings"],
 ];
 

--- a/src/shared/AdminSettingsNavigation.ts
+++ b/src/shared/AdminSettingsNavigation.ts
@@ -1,0 +1,42 @@
+export const ADMIN_SETTINGS_SECTIONS = [
+  {
+    icon: "activity",
+    id: "tracking-urls",
+    name: "Tracking URLs",
+  },
+  {
+    icon: "shield",
+    id: "access-control",
+    name: "Access control",
+  },
+  {
+    icon: "rss",
+    id: "subscribe-methods",
+    name: "Subscribe methods",
+  },
+  {
+    icon: "globe",
+    id: "web-settings",
+    name: "Global settings",
+  },
+  {
+    icon: "code",
+    id: "custom-code",
+    name: "Custom code",
+  },
+] as const;
+
+export type AdminSettingsSection = typeof ADMIN_SETTINGS_SECTIONS[number];
+
+export function filterAdminSettingsSections(
+  query: string,
+): readonly AdminSettingsSection[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) {
+    return ADMIN_SETTINGS_SECTIONS;
+  }
+
+  return ADMIN_SETTINGS_SECTIONS.filter((section) =>
+    section.name.toLocaleLowerCase().includes(normalizedQuery)
+  );
+}

--- a/src/shared/Constants.ts
+++ b/src/shared/Constants.ts
@@ -178,8 +178,8 @@ export const SUPPORTED_ENCLOSURE_CATEGORIES = [
 export const NAV_ITEMS = {
   ADMIN_HOME: 'admin_home',
   EDIT_CHANNEL: 'edit_channel',
-  NEW_ITEM: 'new_item',
   ALL_ITEMS: 'all_items',
+  API: 'api',
   SETTINGS: 'settings',
 } as const;
 
@@ -190,11 +190,11 @@ export const NAV_ITEMS_DICT = {
   [NAV_ITEMS.EDIT_CHANNEL]: {
     name: 'Edit channel',
   },
-  [NAV_ITEMS.NEW_ITEM]: {
-    name: 'Add new item',
-  },
   [NAV_ITEMS.ALL_ITEMS]: {
     name: 'See all items',
+  },
+  [NAV_ITEMS.API]: {
+    name: 'API',
   },
   [NAV_ITEMS.SETTINGS]: {
     name: 'Settings',

--- a/src/shared/ItemList.ts
+++ b/src/shared/ItemList.ts
@@ -8,7 +8,29 @@ export const ITEM_STATUS_FILTERS = [
 ] as const;
 
 export type ItemStatusFilter = typeof ITEM_STATUS_FILTERS[number];
-export type ItemsSortOrder = typeof ITEMS_SORT_ORDERS[keyof typeof ITEMS_SORT_ORDERS];
+
+export const ITEM_LIST_SORT_ORDERS = {
+  PUBLISHED_ASC: ITEMS_SORT_ORDERS.OLDEST_FIRST,
+  PUBLISHED_DESC: ITEMS_SORT_ORDERS.NEWEST_FIRST,
+  UPDATED_ASC: "updated_asc",
+  UPDATED_DESC: "updated_desc",
+} as const;
+
+export type ItemListSortOrder = typeof ITEM_LIST_SORT_ORDERS[
+  keyof typeof ITEM_LIST_SORT_ORDERS
+];
+
+export interface ItemListCursor {
+  id: string;
+  timestamp: number;
+}
+
+interface ItemListSortDefinition {
+  column: "pub_date" | "updated_at";
+  descending: boolean;
+  order: ItemListSortOrder;
+  timestampKey: "pubDateMs" | "updatedAtMs";
+}
 
 const ITEM_STATUS_BY_FILTER = {
   published: STATUSES.PUBLISHED,
@@ -23,10 +45,45 @@ export function normalizeItemStatusFilter(value: unknown): ItemStatusFilter {
     : "all";
 }
 
-export function normalizeItemsSortOrder(value: unknown): ItemsSortOrder {
-  return value === ITEMS_SORT_ORDERS.OLDEST_FIRST
-    ? ITEMS_SORT_ORDERS.OLDEST_FIRST
-    : ITEMS_SORT_ORDERS.NEWEST_FIRST;
+export function normalizeItemListSortOrder(
+  value: unknown,
+  fallback: ItemListSortOrder = ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
+): ItemListSortOrder {
+  const values = Object.values(ITEM_LIST_SORT_ORDERS) as string[];
+  return values.includes(String(value)) ? value as ItemListSortOrder : fallback;
+}
+
+export function itemListSortDefinition(
+  value: unknown,
+  fallback: ItemListSortOrder = ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
+): ItemListSortDefinition {
+  const order = normalizeItemListSortOrder(value, fallback);
+  const updated = order === ITEM_LIST_SORT_ORDERS.UPDATED_ASC ||
+    order === ITEM_LIST_SORT_ORDERS.UPDATED_DESC;
+  return {
+    column: updated ? "updated_at" : "pub_date",
+    descending: order === ITEM_LIST_SORT_ORDERS.UPDATED_DESC ||
+      order === ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
+    order,
+    timestampKey: updated ? "updatedAtMs" : "pubDateMs",
+  };
+}
+
+export function encodeItemListCursor(timestamp: number, id: string): string {
+  return `${Math.trunc(timestamp)}:${id}`;
+}
+
+export function decodeItemListCursor(value: unknown): ItemListCursor | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const separator = value.indexOf(":");
+  if (separator < 1) {
+    return undefined;
+  }
+  const timestamp = Number(value.slice(0, separator));
+  const id = value.slice(separator + 1);
+  return Number.isFinite(timestamp) && id ? {id, timestamp} : undefined;
 }
 
 export function itemQueryForStatusFilter(
@@ -41,8 +98,8 @@ export function itemQueryForStatusFilter(
 }
 
 interface ItemsListUrlOptions {
-  nextCursor?: number;
-  prevCursor?: number;
+  nextCursor?: number | string;
+  prevCursor?: number | string;
   sortOrder?: unknown;
   statusFilter?: unknown;
 }
@@ -59,12 +116,18 @@ export function buildItemsListUrl({
   if (normalizedStatus !== "all") {
     searchParams.set("status", normalizedStatus);
   }
-  if (Number.isFinite(nextCursor)) {
+  if (
+    Number.isFinite(nextCursor) ||
+    (typeof nextCursor === "string" && nextCursor.length > 0)
+  ) {
     searchParams.set("next_cursor", String(nextCursor));
-  } else if (Number.isFinite(prevCursor)) {
+  } else if (
+    Number.isFinite(prevCursor) ||
+    (typeof prevCursor === "string" && prevCursor.length > 0)
+  ) {
     searchParams.set("prev_cursor", String(prevCursor));
   }
-  searchParams.set("sort", normalizeItemsSortOrder(sortOrder));
+  searchParams.set("sort", normalizeItemListSortOrder(sortOrder));
 
   return `?${searchParams.toString()}`;
 }

--- a/src/shared/ItemList.ts
+++ b/src/shared/ItemList.ts
@@ -1,4 +1,11 @@
-import {ITEMS_SORT_ORDERS, STATUSES} from "./Constants";
+import {STATUSES} from "./Constants";
+import {
+  applyItemPaginationParams,
+  ITEM_ORDERS,
+  ITEM_SORTS,
+  type ItemOrder,
+  type ItemSort,
+} from "./ItemPagination";
 
 export const ITEM_STATUS_FILTERS = [
   "all",
@@ -8,29 +15,6 @@ export const ITEM_STATUS_FILTERS = [
 ] as const;
 
 export type ItemStatusFilter = typeof ITEM_STATUS_FILTERS[number];
-
-export const ITEM_LIST_SORT_ORDERS = {
-  PUBLISHED_ASC: ITEMS_SORT_ORDERS.OLDEST_FIRST,
-  PUBLISHED_DESC: ITEMS_SORT_ORDERS.NEWEST_FIRST,
-  UPDATED_ASC: "updated_asc",
-  UPDATED_DESC: "updated_desc",
-} as const;
-
-export type ItemListSortOrder = typeof ITEM_LIST_SORT_ORDERS[
-  keyof typeof ITEM_LIST_SORT_ORDERS
-];
-
-export interface ItemListCursor {
-  id: string;
-  timestamp: number;
-}
-
-interface ItemListSortDefinition {
-  column: "pub_date" | "updated_at";
-  descending: boolean;
-  order: ItemListSortOrder;
-  timestampKey: "pubDateMs" | "updatedAtMs";
-}
 
 const ITEM_STATUS_BY_FILTER = {
   published: STATUSES.PUBLISHED,
@@ -43,47 +27,6 @@ export function normalizeItemStatusFilter(value: unknown): ItemStatusFilter {
   return ITEM_STATUS_FILTERS.includes(normalized as ItemStatusFilter)
     ? normalized as ItemStatusFilter
     : "all";
-}
-
-export function normalizeItemListSortOrder(
-  value: unknown,
-  fallback: ItemListSortOrder = ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
-): ItemListSortOrder {
-  const values = Object.values(ITEM_LIST_SORT_ORDERS) as string[];
-  return values.includes(String(value)) ? value as ItemListSortOrder : fallback;
-}
-
-export function itemListSortDefinition(
-  value: unknown,
-  fallback: ItemListSortOrder = ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
-): ItemListSortDefinition {
-  const order = normalizeItemListSortOrder(value, fallback);
-  const updated = order === ITEM_LIST_SORT_ORDERS.UPDATED_ASC ||
-    order === ITEM_LIST_SORT_ORDERS.UPDATED_DESC;
-  return {
-    column: updated ? "updated_at" : "pub_date",
-    descending: order === ITEM_LIST_SORT_ORDERS.UPDATED_DESC ||
-      order === ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
-    order,
-    timestampKey: updated ? "updatedAtMs" : "pubDateMs",
-  };
-}
-
-export function encodeItemListCursor(timestamp: number, id: string): string {
-  return `${Math.trunc(timestamp)}:${id}`;
-}
-
-export function decodeItemListCursor(value: unknown): ItemListCursor | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const separator = value.indexOf(":");
-  if (separator < 1) {
-    return undefined;
-  }
-  const timestamp = Number(value.slice(0, separator));
-  const id = value.slice(separator + 1);
-  return Number.isFinite(timestamp) && id ? {id, timestamp} : undefined;
 }
 
 export function itemQueryForStatusFilter(
@@ -99,15 +42,17 @@ export function itemQueryForStatusFilter(
 
 interface ItemsListUrlOptions {
   nextCursor?: number | string;
+  order?: ItemOrder;
   prevCursor?: number | string;
-  sortOrder?: unknown;
+  sort?: ItemSort;
   statusFilter?: unknown;
 }
 
 export function buildItemsListUrl({
   nextCursor,
+  order = ITEM_ORDERS.DESC,
   prevCursor,
-  sortOrder,
+  sort = ITEM_SORTS.UPDATED_AT,
   statusFilter,
 }: ItemsListUrlOptions = {}): string {
   const searchParams = new URLSearchParams();
@@ -116,18 +61,12 @@ export function buildItemsListUrl({
   if (normalizedStatus !== "all") {
     searchParams.set("status", normalizedStatus);
   }
-  if (
-    Number.isFinite(nextCursor) ||
-    (typeof nextCursor === "string" && nextCursor.length > 0)
-  ) {
-    searchParams.set("next_cursor", String(nextCursor));
-  } else if (
-    Number.isFinite(prevCursor) ||
-    (typeof prevCursor === "string" && prevCursor.length > 0)
-  ) {
-    searchParams.set("prev_cursor", String(prevCursor));
-  }
-  searchParams.set("sort", normalizeItemListSortOrder(sortOrder));
+  applyItemPaginationParams(searchParams, {
+    nextCursor,
+    order,
+    prevCursor,
+    sort,
+  });
 
   return `?${searchParams.toString()}`;
 }

--- a/src/shared/ItemPagination.ts
+++ b/src/shared/ItemPagination.ts
@@ -1,0 +1,269 @@
+import {ITEMS_SORT_ORDERS} from "./Constants";
+
+export const ITEM_SORTS = {
+  CREATED_AT: "created_at",
+  PUBLISHED_AT: "published_at",
+  UPDATED_AT: "updated_at",
+} as const;
+
+export type ItemSort = typeof ITEM_SORTS[keyof typeof ITEM_SORTS];
+
+export const ITEM_ORDERS = {
+  ASC: "asc",
+  DESC: "desc",
+} as const;
+
+export type ItemOrder = typeof ITEM_ORDERS[keyof typeof ITEM_ORDERS];
+
+export type LegacyItemSort = typeof ITEMS_SORT_ORDERS[
+  keyof typeof ITEMS_SORT_ORDERS
+];
+
+export interface ItemCursor {
+  id: string;
+  timestamp: number;
+}
+
+export interface ItemSortDefinition {
+  column: "created_at" | "pub_date" | "updated_at";
+  sort: ItemSort;
+  timestampKey: "createdAtMs" | "pubDateMs" | "updatedAtMs";
+}
+
+export interface ResolvedItemPagination extends ItemSortDefinition {
+  legacySort?: LegacyItemSort;
+  mode: "canonical" | "legacy";
+  nextCursor?: ItemCursor | number;
+  order: ItemOrder;
+  prevCursor?: ItemCursor | number;
+}
+
+export interface ItemPaginationDefaults {
+  order?: unknown;
+  sort?: unknown;
+}
+
+export interface ItemPaginationSettings {
+  itemsOrder?: unknown;
+  itemsSort?: unknown;
+  itemsSortOrder?: unknown;
+}
+
+export interface ItemPaginationUrlOptions {
+  legacySort?: unknown;
+  nextCursor?: number | string;
+  order?: unknown;
+  prevCursor?: number | string;
+  sort?: unknown;
+}
+
+const ITEM_SORT_DEFINITIONS: Record<ItemSort, ItemSortDefinition> = {
+  [ITEM_SORTS.CREATED_AT]: {
+    column: "created_at",
+    sort: ITEM_SORTS.CREATED_AT,
+    timestampKey: "createdAtMs",
+  },
+  [ITEM_SORTS.PUBLISHED_AT]: {
+    column: "pub_date",
+    sort: ITEM_SORTS.PUBLISHED_AT,
+    timestampKey: "pubDateMs",
+  },
+  [ITEM_SORTS.UPDATED_AT]: {
+    column: "updated_at",
+    sort: ITEM_SORTS.UPDATED_AT,
+    timestampKey: "updatedAtMs",
+  },
+};
+
+function encodeUtf8Base64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+function decodeUtf8Base64Url(value: string): string | undefined {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    return undefined;
+  }
+  try {
+    const padded = value.replace(/-/g, "+").replace(/_/g, "/")
+      .padEnd(Math.ceil(value.length / 4) * 4, "=");
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return undefined;
+  }
+}
+
+export function normalizeItemSort(
+  value: unknown,
+  fallback: ItemSort = ITEM_SORTS.PUBLISHED_AT,
+): ItemSort {
+  return Object.values(ITEM_SORTS).includes(value as ItemSort)
+    ? value as ItemSort
+    : fallback;
+}
+
+export function normalizeItemOrder(
+  value: unknown,
+  fallback: ItemOrder = ITEM_ORDERS.DESC,
+): ItemOrder {
+  return Object.values(ITEM_ORDERS).includes(value as ItemOrder)
+    ? value as ItemOrder
+    : fallback;
+}
+
+export function normalizeLegacyItemSort(
+  value: unknown,
+): LegacyItemSort | undefined {
+  return Object.values(ITEMS_SORT_ORDERS).includes(value as LegacyItemSort)
+    ? value as LegacyItemSort
+    : undefined;
+}
+
+export function itemSortDefinition(value: unknown): ItemSortDefinition {
+  return ITEM_SORT_DEFINITIONS[normalizeItemSort(value)];
+}
+
+export function encodeItemCursor(timestamp: number, id: string): string {
+  return encodeUtf8Base64Url(JSON.stringify([Math.trunc(timestamp), id]));
+}
+
+export function decodeItemCursor(value: unknown): ItemCursor | undefined {
+  if (typeof value !== "string" || !value) {
+    return undefined;
+  }
+  const decoded = decodeUtf8Base64Url(value);
+  if (!decoded) {
+    return undefined;
+  }
+  try {
+    const tuple = JSON.parse(decoded);
+    if (
+      !Array.isArray(tuple) || tuple.length !== 2 ||
+      !Number.isFinite(tuple[0]) || typeof tuple[1] !== "string" || !tuple[1]
+    ) {
+      return undefined;
+    }
+    return {id: tuple[1], timestamp: tuple[0]};
+  } catch {
+    return undefined;
+  }
+}
+
+export function resolveItemPaginationSettings(
+  settings: ItemPaginationSettings = {},
+  defaults: ItemPaginationDefaults = {},
+): {itemsOrder: ItemOrder; itemsSort: ItemSort} {
+  const fallbackSort = normalizeItemSort(defaults.sort);
+  const fallbackOrder = normalizeItemOrder(defaults.order);
+  const hasCanonicalSort = Object.values(ITEM_SORTS).includes(
+    settings.itemsSort as ItemSort,
+  );
+  const legacySort = normalizeLegacyItemSort(settings.itemsSortOrder);
+
+  if (!hasCanonicalSort && legacySort) {
+    return {
+      itemsOrder: legacySort === ITEMS_SORT_ORDERS.OLDEST_FIRST
+        ? ITEM_ORDERS.ASC
+        : ITEM_ORDERS.DESC,
+      itemsSort: ITEM_SORTS.PUBLISHED_AT,
+    };
+  }
+
+  return {
+    itemsOrder: normalizeItemOrder(settings.itemsOrder, fallbackOrder),
+    itemsSort: normalizeItemSort(settings.itemsSort, fallbackSort),
+  };
+}
+
+export function resolveItemPagination(
+  searchParams: URLSearchParams,
+  defaults: ItemPaginationDefaults = {},
+): ResolvedItemPagination {
+  const requestedSort = searchParams.get("sort");
+  const legacySort = normalizeLegacyItemSort(requestedSort);
+  const mode = legacySort ? "legacy" : "canonical";
+  const sort = mode === "legacy"
+    ? ITEM_SORTS.PUBLISHED_AT
+    : normalizeItemSort(requestedSort, normalizeItemSort(defaults.sort));
+  const order = mode === "legacy"
+    ? legacySort === ITEMS_SORT_ORDERS.OLDEST_FIRST
+      ? ITEM_ORDERS.ASC
+      : ITEM_ORDERS.DESC
+    : normalizeItemOrder(
+      searchParams.get("order"),
+      normalizeItemOrder(defaults.order),
+    );
+  const definition = itemSortDefinition(sort);
+  const nextValue = searchParams.get("next_cursor");
+  const prevValue = searchParams.get("prev_cursor");
+  const decodeCursor = (value: string | null) => {
+    if (!value) {
+      return undefined;
+    }
+    if (mode === "legacy") {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : undefined;
+    }
+    return decodeItemCursor(value);
+  };
+  const nextCursor = decodeCursor(nextValue);
+  const prevCursor = searchParams.has("next_cursor")
+    ? undefined
+    : decodeCursor(prevValue);
+
+  return {
+    ...definition,
+    legacySort,
+    mode,
+    nextCursor,
+    order,
+    prevCursor,
+  };
+}
+
+export function applyItemPaginationParams(
+  searchParams: URLSearchParams,
+  {
+    legacySort,
+    nextCursor,
+    order,
+    prevCursor,
+    sort,
+  }: ItemPaginationUrlOptions,
+): URLSearchParams {
+  searchParams.delete("next_cursor");
+  searchParams.delete("prev_cursor");
+  if (nextCursor !== undefined) {
+    searchParams.set("next_cursor", String(nextCursor));
+  } else if (prevCursor !== undefined) {
+    searchParams.set("prev_cursor", String(prevCursor));
+  }
+
+  const normalizedLegacySort = normalizeLegacyItemSort(legacySort);
+  if (normalizedLegacySort) {
+    searchParams.set("sort", normalizedLegacySort);
+    searchParams.delete("order");
+  } else {
+    searchParams.set("sort", normalizeItemSort(sort));
+    searchParams.set("order", normalizeItemOrder(order));
+  }
+  return searchParams;
+}
+
+export function buildItemPaginationUrl(
+  baseUrl: string,
+  options: ItemPaginationUrlOptions,
+): string {
+  const url = new URL(baseUrl);
+  applyItemPaginationParams(url.searchParams, options);
+  return url.toString();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,12 @@ export interface FeedSettings {
     currentPolicy?: "public" | "passcode" | "offline";
   };
   apiSettings?: {
-    apps?: Array<{token?: string}>;
+    apps?: Array<{
+      createdAtMs?: number;
+      id?: string;
+      name?: string;
+      token?: string;
+    }>;
     enabled?: boolean;
   };
   subscribeMethods?: {
@@ -28,16 +33,18 @@ export interface FeedSettings {
 
 export interface FeedItem extends JsonObject {
   id?: string;
+  pubDateMs?: number;
   status?: number;
   title?: string;
+  updatedAtMs?: number;
 }
 
 export interface FeedContent extends JsonObject {
   channel?: JsonObject;
   item?: FeedItem;
   items?: FeedItem[];
-  items_next_cursor?: number;
-  items_prev_cursor?: number;
+  items_next_cursor?: number | string;
+  items_prev_cursor?: number | string;
   items_sort_order?: string;
   settings?: FeedSettings;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface FeedSettings {
 }
 
 export interface FeedItem extends JsonObject {
+  createdAtMs?: number;
   id?: string;
   pubDateMs?: number;
   status?: number;
@@ -44,7 +45,9 @@ export interface FeedContent extends JsonObject {
   item?: FeedItem;
   items?: FeedItem[];
   items_next_cursor?: number | string;
+  items_order?: "asc" | "desc";
   items_prev_cursor?: number | string;
+  items_sort?: "created_at" | "published_at" | "updated_at";
   items_sort_order?: string;
   settings?: FeedSettings;
 }

--- a/tests/unit/client/AdminSettingsScroll.test.ts
+++ b/tests/unit/client/AdminSettingsScroll.test.ts
@@ -1,0 +1,63 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+import {
+  scrollToAdminSettingsHash,
+  scrollToAdminSettingsSection,
+} from "@/client/AdminSettingsScroll";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function installElements({scrollable}: {scrollable: boolean}) {
+  const scrollTo = vi.fn();
+  const scrollIntoView = vi.fn();
+  const scrollRoot = {
+    clientHeight: scrollable ? 500 : 1_000,
+    getBoundingClientRect: () => ({top: 50}),
+    scrollHeight: 1_000,
+    scrollTo,
+    scrollTop: 100,
+  };
+  const section = {
+    getBoundingClientRect: () => ({top: 350}),
+    scrollIntoView,
+  };
+  vi.stubGlobal("document", {
+    getElementById: vi.fn((id: string) => {
+      if (id === "admin-page-content") return scrollRoot;
+      if (id === "web-settings") return section;
+      return null;
+    }),
+  });
+  return {scrollIntoView, scrollTo};
+}
+
+describe("admin settings hash scrolling", () => {
+  it("scrolls the desktop admin content panel to the requested section", () => {
+    const {scrollIntoView, scrollTo} = installElements({scrollable: true});
+
+    expect(scrollToAdminSettingsHash("#web-settings")).toBe(true);
+    expect(scrollTo).toHaveBeenCalledWith({behavior: "auto", top: 376});
+    expect(scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it("uses document scrolling when the admin content panel is not scrollable", () => {
+    const {scrollIntoView, scrollTo} = installElements({scrollable: false});
+
+    expect(scrollToAdminSettingsSection("web-settings")).toBe(true);
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: "auto",
+      block: "start",
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("ignores unknown settings hashes", () => {
+    const {scrollIntoView, scrollTo} = installElements({scrollable: true});
+
+    expect(scrollToAdminSettingsHash("#missing-section")).toBe(false);
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/components/admin-access-settings.test.ts
+++ b/tests/unit/components/admin-access-settings.test.ts
@@ -1,0 +1,79 @@
+import React from "react";
+import {renderToStaticMarkup} from "react-dom/server";
+import {describe, expect, it, vi} from "vitest";
+
+import AccessSettingsApp from "@/components/admin/settings/AccessSettingsApp";
+import {SETTINGS_CATEGORIES} from "@/shared/Constants";
+
+function props(onSubmit = vi.fn(async (
+  _event: unknown,
+  _type: unknown,
+  _bundle: unknown,
+) => true)) {
+  return {
+    feed: {
+      settings: {
+        [SETTINGS_CATEGORIES.ACCESS]: {currentPolicy: "public"},
+      },
+    },
+    onSubmit,
+    setChanged: vi.fn(),
+    submitForType: null,
+    submitting: false,
+  };
+}
+
+function installSynchronousSetState(app: AccessSettingsApp) {
+  app.setState = ((update: any, callback?: () => void) => {
+    const changedState = typeof update === "function"
+      ? update(app.state, app.props)
+      : update;
+    app.state = {...app.state, ...changedState};
+    callback?.();
+  }) as typeof app.setState;
+}
+
+describe("access control settings", () => {
+  it("omits the manual Update action", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(AccessSettingsApp, props()),
+    );
+
+    expect(output).toContain("Access control");
+    expect(output).not.toContain('data-slot="card-action"');
+    expect(output).not.toContain(">Update</button>");
+  });
+
+  it("immediately saves a newly selected policy", async () => {
+    const onSubmit = vi.fn(async (
+      _event: unknown,
+      _type: unknown,
+      _bundle: unknown,
+    ) => true);
+    const settingsProps = props(onSubmit);
+    const app = new AccessSettingsApp(settingsProps);
+    installSynchronousSetState(app);
+
+    app.onUpdateAccess("offline");
+    await Promise.resolve();
+
+    expect(app.state.access.currentPolicy).toBe("offline");
+    expect(settingsProps.setChanged).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({preventDefault: expect.any(Function)}),
+      SETTINGS_CATEGORIES.ACCESS,
+      {currentPolicy: "offline"},
+    );
+  });
+
+  it("disables policy changes while a save is in progress", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(AccessSettingsApp, {
+        ...props(),
+        submitting: true,
+      }),
+    );
+
+    expect(output).toContain("disabled");
+  });
+});

--- a/tests/unit/components/admin-api-settings.test.ts
+++ b/tests/unit/components/admin-api-settings.test.ts
@@ -1,0 +1,34 @@
+import React from "react";
+import {renderToStaticMarkup} from "react-dom/server";
+import {describe, expect, it} from "vitest";
+
+import ApiSettingsApp from "@/components/admin/settings/ApiSettingsApp";
+
+describe("admin API settings", () => {
+  it("renders the standalone auto-saving controls without a section header or update button", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(ApiSettingsApp, {
+        feed: {
+          settings: {
+            apiSettings: {
+              apps: [{
+                createdAtMs: 1_800_000_000_000,
+                id: "default-app",
+                name: "Default",
+                token: "saved-api-token",
+              }],
+              enabled: true,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(output).toContain("API enabled");
+    expect(output).toContain("saved-api-token");
+    expect(output).not.toContain("Changes save automatically");
+    expect(output).toContain("API documentation");
+    expect(output).not.toContain('data-slot="card-header"');
+    expect(output).not.toContain(">Update</button>");
+  });
+});

--- a/tests/unit/components/admin-dashboard-shell.test.ts
+++ b/tests/unit/components/admin-dashboard-shell.test.ts
@@ -36,6 +36,10 @@ function sidebarData(): AdminSidebarData {
       name: "Home",
       url: "/admin/",
     }],
+    newItem: {
+      disabled: false,
+      url: "/admin/items/new/",
+    },
     publicLinks: {
       json: "https://feed.example.com/json/",
       rss: "https://feed.example.com/rss/",
@@ -65,6 +69,8 @@ describe("admin dashboard shell models", () => {
     expect(output).toContain(
       "gap-3 rounded-xl px-3 py-2 text-base font-medium",
     );
+    expect(output).toContain("Add new item");
+    expect(output).toContain('href="/admin/items/new/"');
   });
 
   it("opens public access from the channel button instead of a dropdown", () => {

--- a/tests/unit/components/admin-items-list.test.ts
+++ b/tests/unit/components/admin-items-list.test.ts
@@ -3,7 +3,8 @@ import {renderToStaticMarkup} from "react-dom/server";
 import {afterEach, describe, expect, it, vi} from "vitest";
 
 import AllItemsApp from "@/components/admin/items/AllItemsApp";
-import {ITEMS_SORT_ORDERS, STATUSES} from "@/shared/Constants";
+import {STATUSES} from "@/shared/Constants";
+import {ITEM_LIST_SORT_ORDERS} from "@/shared/ItemList";
 import type {FeedItem} from "@/types";
 
 const ITEMS: FeedItem[] = [
@@ -18,17 +19,19 @@ const ITEMS: FeedItem[] = [
     pubDateMs: Date.UTC(2026, 7, 4, 17, 0),
     status: STATUSES.PUBLISHED,
     title: "A published item",
+    updatedAtMs: Date.UTC(2026, 7, 4, 18, 0),
   },
   {
     id: "item-very-long",
     pubDateMs: Date.UTC(2026, 7, 3, 17, 0),
     status: STATUSES.PUBLISHED,
     title: "An intentionally very long item title that should remain constrained to the title column instead of expanding the table",
+    updatedAtMs: Date.UTC(2026, 7, 3, 18, 0),
   },
 ];
 
 function renderItemsList(
-  search = "?status=published&sort=newest_first",
+  search = "?status=published&sort=updated_desc",
   items: FeedItem[] = ITEMS,
 ) {
   vi.stubGlobal("window", {
@@ -43,7 +46,7 @@ function renderItemsList(
       feedContent: {
         items,
         items_next_cursor: 123,
-        items_sort_order: ITEMS_SORT_ORDERS.NEWEST_FIRST,
+        items_sort_order: ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
         settings: {
           webGlobalSettings: {
             publicBucketUrl: "https://media.example.com/",
@@ -57,7 +60,7 @@ function renderItemsList(
 afterEach(() => vi.unstubAllGlobals());
 
 describe("admin items list", () => {
-  it("renders the requested filters and four-column layout", () => {
+  it("renders the requested filters and five-column layout", () => {
     const output = renderItemsList();
 
     expect(output.indexOf(">All items</a>")).toBeLessThan(
@@ -69,11 +72,21 @@ describe("admin items list", () => {
     expect(output.indexOf(">Unlisted</a>")).toBeLessThan(
       output.indexOf(">Unpublished</a>"),
     );
-    expect(output.match(/<th\b/gu)).toHaveLength(4);
+    expect(output.match(/<th\b/gu)).toHaveLength(5);
     expect(output).toContain(">Title</th>");
     expect(output).toContain("Published at");
+    expect(output).toContain("Updated at");
     expect(output).toContain(">Media</th>");
     expect(output).toContain(">Actions</th>");
+  });
+
+  it("keeps the active filter visibly selected in dark mode", () => {
+    const output = renderItemsList("?status=unlisted&sort=updated_desc");
+
+    expect(output).toMatch(
+      /aria-current="page"[^>]+dark:bg-brand-light\/20[^>]+>Unlisted<\/a>/u,
+    );
+    expect(output.match(/aria-current="page"/gu)).toHaveLength(1);
   });
 
   it("links the title and renders status, public page, media, and edit action", () => {
@@ -100,16 +113,19 @@ describe("admin items list", () => {
 
     expect(output).toContain('aria-sort="descending"');
     expect(output).toContain(
-      "?status=published&amp;sort=oldest_first",
+      "?status=published&amp;sort=updated_asc",
     );
     expect(output).toContain(
-      "?status=published&amp;next_cursor=123&amp;sort=newest_first",
+      "?status=published&amp;sort=newest_first",
+    );
+    expect(output).toContain(
+      "?status=published&amp;next_cursor=123&amp;sort=updated_desc",
     );
   });
 
   it("keeps the empty-state create action text white", () => {
     const output = renderItemsList(
-      "?status=unlisted&sort=newest_first",
+      "?status=unlisted&sort=updated_desc",
       [],
     );
 

--- a/tests/unit/components/admin-items-list.test.ts
+++ b/tests/unit/components/admin-items-list.test.ts
@@ -4,11 +4,12 @@ import {afterEach, describe, expect, it, vi} from "vitest";
 
 import AllItemsApp from "@/components/admin/items/AllItemsApp";
 import {STATUSES} from "@/shared/Constants";
-import {ITEM_LIST_SORT_ORDERS} from "@/shared/ItemList";
+import {ITEM_ORDERS, ITEM_SORTS} from "@/shared/ItemPagination";
 import type {FeedItem} from "@/types";
 
 const ITEMS: FeedItem[] = [
   {
+    createdAtMs: Date.UTC(2026, 7, 4, 16, 0),
     id: "item-123",
     image: "images/item-123.png",
     mediaFile: {
@@ -22,6 +23,7 @@ const ITEMS: FeedItem[] = [
     updatedAtMs: Date.UTC(2026, 7, 4, 18, 0),
   },
   {
+    createdAtMs: Date.UTC(2026, 7, 3, 16, 0),
     id: "item-very-long",
     pubDateMs: Date.UTC(2026, 7, 3, 17, 0),
     status: STATUSES.PUBLISHED,
@@ -31,7 +33,7 @@ const ITEMS: FeedItem[] = [
 ];
 
 function renderItemsList(
-  search = "?status=published&sort=updated_desc",
+  search = "?status=published&sort=updated_at&order=desc",
   items: FeedItem[] = ITEMS,
 ) {
   vi.stubGlobal("window", {
@@ -45,8 +47,9 @@ function renderItemsList(
     React.createElement(AllItemsApp, {
       feedContent: {
         items,
-        items_next_cursor: 123,
-        items_sort_order: ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
+        items_next_cursor: "cursor_value",
+        items_order: ITEM_ORDERS.DESC,
+        items_sort: ITEM_SORTS.UPDATED_AT,
         settings: {
           webGlobalSettings: {
             publicBucketUrl: "https://media.example.com/",
@@ -60,7 +63,7 @@ function renderItemsList(
 afterEach(() => vi.unstubAllGlobals());
 
 describe("admin items list", () => {
-  it("renders the requested filters and five-column layout", () => {
+  it("renders the requested filters and six-column layout", () => {
     const output = renderItemsList();
 
     expect(output.indexOf(">All items</a>")).toBeLessThan(
@@ -72,16 +75,19 @@ describe("admin items list", () => {
     expect(output.indexOf(">Unlisted</a>")).toBeLessThan(
       output.indexOf(">Unpublished</a>"),
     );
-    expect(output.match(/<th\b/gu)).toHaveLength(5);
+    expect(output.match(/<th\b/gu)).toHaveLength(6);
     expect(output).toContain(">Title</th>");
     expect(output).toContain("Published at");
+    expect(output).toContain("Created at");
     expect(output).toContain("Updated at");
     expect(output).toContain(">Media</th>");
     expect(output).toContain(">Actions</th>");
   });
 
   it("keeps the active filter visibly selected in dark mode", () => {
-    const output = renderItemsList("?status=unlisted&sort=updated_desc");
+    const output = renderItemsList(
+      "?status=unlisted&sort=updated_at&order=desc",
+    );
 
     expect(output).toMatch(
       /aria-current="page"[^>]+dark:bg-brand-light\/20[^>]+>Unlisted<\/a>/u,
@@ -113,19 +119,22 @@ describe("admin items list", () => {
 
     expect(output).toContain('aria-sort="descending"');
     expect(output).toContain(
-      "?status=published&amp;sort=updated_asc",
+      "?status=published&amp;sort=updated_at&amp;order=asc",
     );
     expect(output).toContain(
-      "?status=published&amp;sort=newest_first",
+      "?status=published&amp;sort=published_at&amp;order=desc",
     );
     expect(output).toContain(
-      "?status=published&amp;next_cursor=123&amp;sort=updated_desc",
+      "?status=published&amp;sort=created_at&amp;order=desc",
+    );
+    expect(output).toContain(
+      "?status=published&amp;next_cursor=cursor_value&amp;sort=updated_at&amp;order=desc",
     );
   });
 
   it("keeps the empty-state create action text white", () => {
     const output = renderItemsList(
-      "?status=unlisted&sort=updated_desc",
+      "?status=unlisted&sort=updated_at&order=desc",
       [],
     );
 

--- a/tests/unit/components/admin-settings-sidebar.test.ts
+++ b/tests/unit/components/admin-settings-sidebar.test.ts
@@ -1,0 +1,59 @@
+import React from "react";
+import {renderToStaticMarkup} from "react-dom/server";
+import {describe, expect, it} from "vitest";
+
+import AdminSettingsSidebar from "@/components/admin/settings/AdminSettingsSidebar";
+
+const deployment = {
+  deployedAt: "2026-08-04T12:00:00.000Z",
+  protected: true,
+};
+
+describe("admin settings sidebar", () => {
+  it("renders the back fallback, search, and anchored section navigation", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(AdminSettingsSidebar, {
+        data: {
+          backUrl: "/admin/",
+          deployment,
+          sectionsUrl: "/admin/settings/",
+        },
+      }),
+    );
+
+    expect(output).toContain('aria-label="Go to Home"');
+    expect(output).toContain('href="/admin/"');
+    expect(output).toContain("Home");
+    expect(output).not.toContain("history.back");
+    expect(output).toContain('placeholder="Search settings..."');
+    expect(output).toContain('href="/admin/settings/#tracking-urls"');
+    expect(output).toContain('href="/admin/settings/#access-control"');
+    expect(output).toContain('href="/admin/settings/#subscribe-methods"');
+    expect(output).toContain('href="/admin/settings/#web-settings"');
+    expect(output).toContain("Global settings");
+    expect(output).not.toContain("Web settings");
+    expect(output).toContain('href="/admin/settings/#custom-code"');
+    expect(output).toContain("/assets/brands/microfeed/horizontal-logo.png");
+    expect(output).toContain(
+      "/assets/brands/microfeed/horizontal-logo-dark.png",
+    );
+  });
+
+  it("keeps Custom code active on nested editor routes", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(AdminSettingsSidebar, {
+        data: {
+          activeSection: "custom-code",
+          backUrl: "/admin/",
+          deployment,
+          sectionsUrl: "/admin/settings/",
+        },
+      }),
+    );
+
+    expect(output).toContain(
+      'aria-current="location" class="relative flex min-h-11 items-center gap-3 rounded-xl px-3 py-2 text-base font-medium outline-none transition-colors bg-sidebar-accent',
+    );
+    expect(output).toContain('href="/admin/settings/#custom-code"');
+  });
+});

--- a/tests/unit/components/admin-subscribe-settings.test.ts
+++ b/tests/unit/components/admin-subscribe-settings.test.ts
@@ -1,0 +1,255 @@
+import React from "react";
+import {renderToStaticMarkup} from "react-dom/server";
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+import SubscribeSettingsApp, {
+  reorderSubscribeMethods,
+  subscribeMethodsBundle,
+} from "@/components/admin/settings/SubscribeSettingsApp";
+import {SETTINGS_CATEGORIES} from "@/shared/Constants";
+
+const methods = [
+  {
+    editable: false,
+    enabled: true,
+    id: "rss",
+    image: "/rss.png",
+    name: "RSS",
+    type: "rss",
+  },
+  {
+    editable: true,
+    enabled: true,
+    id: "custom",
+    image: "/custom.png",
+    name: "Podcast app",
+    type: "custom",
+    url: "https://example.com/podcast",
+  },
+];
+
+function props(onSubmit = vi.fn(async (
+  _event: unknown,
+  _type: unknown,
+  _bundle: unknown,
+) => true)) {
+  return {
+    feed: {
+      settings: {
+        [SETTINGS_CATEGORIES.SUBSCRIBE_METHODS]: {methods},
+      },
+    },
+    onSubmit,
+    setChanged: vi.fn(),
+    submitForType: null,
+    submitting: false,
+  };
+}
+
+function installSynchronousSetState(app: SubscribeSettingsApp) {
+  app.setState = ((update: any, callback?: () => void) => {
+    const changedState = typeof update === "function"
+      ? update(app.state, app.props)
+      : update;
+    app.state = {...app.state, ...changedState};
+    callback?.();
+  }) as typeof app.setState;
+}
+
+async function flushSaveQueue() {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function savedBundle(
+  onSubmit: ReturnType<typeof vi.fn<(event: unknown, type: unknown, bundle: any) => Promise<boolean>>>,
+  index: number,
+) {
+  return onSubmit.mock.calls[index]![2];
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("subscribe method settings", () => {
+  it("centers the add action and omits the section Update button", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(SubscribeSettingsApp, props()),
+    );
+
+    expect(output).toContain('class="flex justify-center"');
+    expect(output).toContain("Add new subscribe method");
+    expect(output).toContain('aria-label="Drag to change the order of RSS"');
+    expect(output).toContain("size-11 object-contain");
+    expect(output).not.toContain('aria-label="Move RSS up"');
+    expect(output).not.toContain('data-slot="card-action"');
+    expect(output).not.toContain(">Update</button>");
+  });
+
+  it("shows immediate deletion copy with an Undo action", () => {
+    const app = new SubscribeSettingsApp(props());
+    app.state = {
+      ...app.state,
+      methodsDict: {
+        methods: [methods[0], {...methods[1], deleted: true}],
+      },
+    };
+    const output = renderToStaticMarkup(app.render());
+
+    expect(output).toContain("Deleted.</span>");
+    expect(output).toContain(">Undo</button>");
+    expect(output).not.toContain("sync up and actually delete");
+  });
+
+  it("removes deleted methods and transient flags from the saved bundle", () => {
+    expect(subscribeMethodsBundle({
+      label: "Subscribe",
+      methods: [methods[0], {...methods[1], deleted: true}],
+    })).toEqual({
+      label: "Subscribe",
+      methods: [methods[0]],
+    });
+  });
+
+  it("reorders methods before or after the row under the drag handle", () => {
+    expect(reorderSubscribeMethods(methods, "rss", "custom", "after")
+      .map(({id}) => id)).toEqual(["custom", "rss"]);
+    expect(reorderSubscribeMethods(methods, "custom", "rss", "before")
+      .map(({id}) => id)).toEqual(["custom", "rss"]);
+    expect(reorderSubscribeMethods(methods, "rss", "rss", "after")).toBe(methods);
+  });
+
+  it("highlights the row and insertion edge under a dragged method", () => {
+    const app = new SubscribeSettingsApp(props());
+    app.state = {
+      ...app.state,
+      dragOverMethodId: "custom",
+      dragOverPosition: "before",
+      draggedMethodId: "rss",
+    };
+    const output = renderToStaticMarkup(app.render());
+
+    expect(output).toContain("bg-brand-light/8 ring-1 ring-inset ring-brand-light/40");
+    expect(output).toContain("before:top-0 before:h-0.5");
+  });
+
+  it("renders an elevated method preview that follows the pointer", () => {
+    const app = new SubscribeSettingsApp(props());
+    app.state = {
+      ...app.state,
+      dragPreview: {
+        left: 120,
+        offsetX: 20,
+        offsetY: 16,
+        top: 240,
+        width: 640,
+      },
+      draggedMethodId: "rss",
+    };
+    const output = renderToStaticMarkup(app.render());
+
+    expect(output).toContain("pointer-events-none fixed z-[100]");
+    expect(output).toContain("shadow-2xl ring-2 ring-brand-light/20");
+    expect(output).toContain("left:120px");
+    expect(output).toContain("top:240px");
+    expect(output).toContain("width:640px");
+  });
+
+  it("always clears the floating preview on a window-level pointer release", () => {
+    const windowTarget = new EventTarget();
+    vi.stubGlobal("window", windowTarget);
+    const app = new SubscribeSettingsApp(props());
+    installSynchronousSetState(app);
+    app.beginDragging("rss", {
+      clientX: 140,
+      clientY: 260,
+      currentTarget: {
+        closest: () => ({
+          getBoundingClientRect: () => ({
+            height: 80,
+            left: 100,
+            top: 220,
+            width: 640,
+          }),
+        }),
+      },
+      pointerId: 7,
+    } as unknown as React.PointerEvent<HTMLButtonElement>);
+    expect(app.state.dragPreview).not.toBeNull();
+
+    windowTarget.dispatchEvent(Object.assign(new Event("pointerup"), {
+      pointerId: 7,
+    }));
+
+    expect(app.state.dragPreview).toBeNull();
+    expect(app.state.draggedMethodId).toBeNull();
+  });
+
+  it("immediately saves visibility, order, additions, deletion, and undo", async () => {
+    const onSubmit = vi.fn(async (
+      _event: unknown,
+      _type: unknown,
+      _bundle: unknown,
+    ) => true);
+    const app = new SubscribeSettingsApp(props(onSubmit));
+    installSynchronousSetState(app);
+
+    app.updateMethodByAttr("rss", "enabled", false);
+    await flushSaveQueue();
+    expect(savedBundle(onSubmit, 0).methods[0].enabled).toBe(false);
+
+    app.moveCard({preventDefault: vi.fn()}, 0, 1);
+    await flushSaveQueue();
+    expect(savedBundle(onSubmit, 1).methods.map(({id}: any) => id)).toEqual([
+      "custom",
+      "rss",
+    ]);
+
+    app.addNewMethod({
+      editable: true,
+      enabled: true,
+      id: "new",
+      name: "New app",
+      type: "custom",
+      url: "https://example.com/new",
+    });
+    await flushSaveQueue();
+    expect(savedBundle(onSubmit, 2).methods.at(-1).id).toBe("new");
+
+    app.updateMethodByAttr("custom", "deleted", true);
+    await flushSaveQueue();
+    expect(savedBundle(onSubmit, 3).methods.map(({id}: any) => id)).toEqual([
+      "rss",
+      "new",
+    ]);
+
+    app.updateMethodByAttr("custom", "deleted", false);
+    await flushSaveQueue();
+    expect(savedBundle(onSubmit, 4).methods.map(({id}: any) => id)).toEqual([
+      "custom",
+      "rss",
+      "new",
+    ]);
+  });
+
+  it("automatically saves editable text after typing pauses", async () => {
+    vi.useFakeTimers();
+    const onSubmit = vi.fn(async (
+      _event: unknown,
+      _type: unknown,
+      _bundle: unknown,
+    ) => true);
+    const app = new SubscribeSettingsApp(props(onSubmit));
+    installSynchronousSetState(app);
+
+    app.updateMethodByAttr("custom", "name", "Renamed app", false);
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(600);
+    await Promise.resolve();
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(savedBundle(onSubmit, 0).methods[1].name).toBe("Renamed app");
+  });
+});

--- a/tests/unit/components/admin-tracking-settings.test.ts
+++ b/tests/unit/components/admin-tracking-settings.test.ts
@@ -1,0 +1,46 @@
+import React from "react";
+import {renderToStaticMarkup} from "react-dom/server";
+import {describe, expect, it, vi} from "vitest";
+
+import TrackingSettingsApp from "@/components/admin/settings/TrackingSettingsApp";
+import {SETTINGS_CATEGORIES} from "@/shared/Constants";
+
+function props() {
+  return {
+    feed: {
+      settings: {
+        [SETTINGS_CATEGORIES.ANALYTICS]: {
+          urls: ["https://op3.dev/e/"],
+        },
+      },
+    },
+    onSubmit: vi.fn(),
+    setChanged: vi.fn(),
+    submitForType: null,
+    submitting: false,
+  };
+}
+
+describe("tracking URL settings", () => {
+  it("does not show an Update action before the textarea changes", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(TrackingSettingsApp, props()),
+    );
+
+    expect(output).not.toContain('data-slot="card-action"');
+    expect(output).not.toContain(">Update</button>");
+  });
+
+  it("shows the Update action at the bottom after the textarea changes", () => {
+    const app = new TrackingSettingsApp(props());
+    app.state = {
+      ...app.state,
+      trackingUrls: "https://op3.dev/e/\nhttps://pdst.fm/e/",
+    };
+    const output = renderToStaticMarkup(app.render());
+
+    expect(output).not.toContain('data-slot="card-action"');
+    expect(output).toContain('class="mt-5 flex justify-end"');
+    expect(output).toContain(">Update</button>");
+  });
+});

--- a/tests/unit/feed-pagination-builders.test.ts
+++ b/tests/unit/feed-pagination-builders.test.ts
@@ -1,0 +1,100 @@
+import {readFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+
+import {describe, expect, it} from "vitest";
+
+import FeedPublicJsonBuilder from "@/server/feed/FeedPublicJsonBuilder";
+import FeedPublicRssBuilder from "@/server/feed/FeedPublicRssBuilder";
+import {ITEMS_SORT_ORDERS} from "@/shared/Constants";
+import {encodeItemCursor, ITEM_ORDERS, ITEM_SORTS} from "@/shared/ItemPagination";
+
+const baseUrl = "https://feed.example.com";
+const request = new Request(`${baseUrl}/json/`);
+
+function publicJson(
+  pagination: Record<string, unknown>,
+  pageRequest: Request = request,
+) {
+  return new FeedPublicJsonBuilder(
+    {
+      channel: {title: "Pagination feed"},
+      items: [],
+      settings: {},
+      ...pagination,
+    },
+    baseUrl,
+    pageRequest,
+  ).getJsonData() as any;
+}
+
+describe("public feed pagination links", () => {
+  it("emits canonical metadata and escaped JSON and RSS links", () => {
+    const nextCursor = encodeItemCursor(1_800_000_000_123, "item-a");
+    const prevCursor = encodeItemCursor(1_700_000_000_000, "item-b");
+    const json = publicJson({
+      items_next_cursor: nextCursor,
+      items_order: ITEM_ORDERS.ASC,
+      items_prev_cursor: prevCursor,
+      items_sort: ITEM_SORTS.UPDATED_AT,
+    });
+
+    expect(json.next_url).toBe(
+      `${baseUrl}/json/?next_cursor=${nextCursor}&sort=updated_at&order=asc`,
+    );
+    expect(json._microfeed).toMatchObject({
+      items_next_cursor: nextCursor,
+      items_order: "asc",
+      items_prev_cursor: prevCursor,
+      items_sort: "updated_at",
+      next_url: json.next_url,
+      prev_url:
+        `${baseUrl}/json/?prev_cursor=${prevCursor}&sort=updated_at&order=asc`,
+    });
+    expect(json._microfeed.items_sort_order).toBeUndefined();
+
+    const rss = new FeedPublicRssBuilder(json, baseUrl).getRssData();
+    expect(rss).toContain(
+      `next_cursor=${nextCursor}&amp;sort=updated_at&amp;order=asc`,
+    );
+    expect(rss).toContain(
+      `prev_cursor=${prevCursor}&amp;sort=updated_at&amp;order=asc`,
+    );
+  });
+
+  it("emits only deprecated sort metadata for explicit legacy mode", () => {
+    const json = publicJson({
+      items_next_cursor: 1_800_000_000_123,
+      items_sort_order: ITEMS_SORT_ORDERS.NEWEST_FIRST,
+    });
+
+    expect(json.next_url).toBe(
+      `${baseUrl}/json/?next_cursor=1800000000123&sort=newest_first`,
+    );
+    expect(json._microfeed.items_sort_order).toBe("newest_first");
+    expect(json._microfeed.items_sort).toBeUndefined();
+    expect(json._microfeed.items_order).toBeUndefined();
+  });
+
+  it("uses generated pagination URLs in the default web theme", async () => {
+    const filename = fileURLToPath(new URL(
+      "../../src/server/themes/defaults/web_feed.html",
+      import.meta.url,
+    ));
+    const theme = await readFile(filename, "utf8");
+
+    expect(theme).toContain('href="{{_microfeed.next_url}}"');
+    expect(theme).toContain('href="{{_microfeed.prev_url}}"');
+    expect(theme).not.toContain("sort={{_microfeed.items_sort_order}}");
+
+    const nextCursor = encodeItemCursor(1_800_000_000_123, "item-a");
+    const webJson = publicJson({
+      items_next_cursor: nextCursor,
+      items_order: ITEM_ORDERS.DESC,
+      items_sort: ITEM_SORTS.PUBLISHED_AT,
+    }, new Request(`${baseUrl}/`));
+    expect(webJson.next_url).toContain(`${baseUrl}/json/`);
+    expect(webJson._microfeed.next_url).toBe(
+      `${baseUrl}/?next_cursor=${nextCursor}&sort=published_at&order=desc`,
+    );
+  });
+});

--- a/tests/unit/item-timestamp-migration.test.ts
+++ b/tests/unit/item-timestamp-migration.test.ts
@@ -1,0 +1,67 @@
+import {readFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+import path from "node:path";
+import {DatabaseSync} from "node:sqlite";
+
+import {describe, expect, it} from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+async function migration(filename: string): Promise<string> {
+  return readFile(path.join(repositoryRoot, "migrations", filename), "utf8");
+}
+
+describe("item timestamp normalization migration", () => {
+  it("normalizes SQLite and mixed timestamp formats to indexed RFC 3339 text", async () => {
+    const database = new DatabaseSync(":memory:");
+    database.exec(await migration("0001_initial.sql"));
+    const insert = database.prepare(
+      "INSERT INTO items " +
+        "(id, status, data, pub_date, created_at, updated_at) " +
+        "VALUES (?, 1, '{}', ?, ?, ?)",
+    );
+    insert.run(
+      "legacy-item",
+      "2026-08-04T12:00:00.000Z",
+      "2026-08-04 10:00:00",
+      "2026-08-04 13:00:00",
+    );
+    insert.run(
+      "mixed-item",
+      "2026-08-04T11:00:00.000Z",
+      "2026-08-04 11:00:00",
+      "2026-08-04T12:00:00.123Z",
+    );
+
+    const normalization = await migration(
+      "0005_normalize_item_timestamps.sql",
+    );
+    database.exec(normalization);
+    database.exec(normalization);
+
+    expect(database.prepare(
+      "SELECT id, created_at, updated_at FROM items ORDER BY id",
+    ).all()).toEqual([
+      {
+        created_at: "2026-08-04T10:00:00.000Z",
+        id: "legacy-item",
+        updated_at: "2026-08-04T13:00:00.000Z",
+      },
+      {
+        created_at: "2026-08-04T11:00:00.000Z",
+        id: "mixed-item",
+        updated_at: "2026-08-04T12:00:00.123Z",
+      },
+    ]);
+
+    const queryPlan = database.prepare(
+      "EXPLAIN QUERY PLAN " +
+        "SELECT id FROM items WHERE created_at < ? " +
+        "ORDER BY created_at DESC, id DESC LIMIT 3",
+    ).all("2026-08-05T00:00:00.000Z");
+    expect(queryPlan.some((row) =>
+      String(row.detail).includes("items_created_at")
+    )).toBe(true);
+    database.close();
+  });
+});

--- a/tests/unit/manage-cli/snapshot.test.ts
+++ b/tests/unit/manage-cli/snapshot.test.ts
@@ -851,6 +851,37 @@ describe("remote restore baseline repair", () => {
     })).not.toThrow();
   });
 
+  it("accepts the canonical automatic settings bootstrap rows", () => {
+    const canonicalBootstrapRows = bootstrapSettingRows.map((row) =>
+      row.category === "webGlobalSettings"
+        ? {
+            ...row,
+            data: JSON.stringify({
+              favicon: {
+                contentType: "image/png",
+                url: "/assets/default/favicon.png",
+              },
+              itemsOrder: "desc",
+              itemsPerPage: 20,
+              itemsSort: "published_at",
+              publicBucketUrl: "/media/",
+            }),
+          }
+        : row
+    );
+
+    expect(() => validateRemoteRestoreBaselineRepair({
+      ...valid,
+      applicationRowCounts: {
+        ...valid.applicationRowCounts,
+        channels: 1,
+        settings: 5,
+      },
+      bootstrapChannelRows,
+      bootstrapSettingRows: canonicalBootstrapRows,
+    })).not.toThrow();
+  });
+
   const initialPasswordSetup = {
     createdAt: "2026-08-02T20:00:00.000Z",
     email: "owner@example.com",

--- a/tests/unit/shared/ItemList.test.ts
+++ b/tests/unit/shared/ItemList.test.ts
@@ -1,9 +1,14 @@
 import {describe, expect, it} from "vitest";
 
-import {ITEMS_SORT_ORDERS, STATUSES} from "@/shared/Constants";
+import {STATUSES} from "@/shared/Constants";
 import {
   buildItemsListUrl,
+  decodeItemListCursor,
+  encodeItemListCursor,
+  ITEM_LIST_SORT_ORDERS,
   itemQueryForStatusFilter,
+  itemListSortDefinition,
+  normalizeItemListSortOrder,
   normalizeItemStatusFilter,
 } from "@/shared/ItemList";
 
@@ -32,14 +37,45 @@ describe("admin item list filters", () => {
   it("keeps the filter and sort order in pagination links", () => {
     expect(buildItemsListUrl({
       nextCursor: 123,
-      sortOrder: ITEMS_SORT_ORDERS.OLDEST_FIRST,
+      sortOrder: ITEM_LIST_SORT_ORDERS.UPDATED_ASC,
       statusFilter: "unlisted",
-    })).toBe("?status=unlisted&next_cursor=123&sort=oldest_first");
+    })).toBe("?status=unlisted&next_cursor=123&sort=updated_asc");
 
     expect(buildItemsListUrl({
       prevCursor: 456,
-      sortOrder: ITEMS_SORT_ORDERS.NEWEST_FIRST,
+      sortOrder: ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
       statusFilter: "all",
     })).toBe("?prev_cursor=456&sort=newest_first");
+  });
+
+  it("defaults the admin list to the most recently updated items", () => {
+    expect(normalizeItemListSortOrder(undefined)).toBe("updated_desc");
+    expect(itemListSortDefinition("updated_desc")).toEqual({
+      column: "updated_at",
+      descending: true,
+      order: "updated_desc",
+      timestampKey: "updatedAtMs",
+    });
+    expect(itemListSortDefinition("oldest_first")).toMatchObject({
+      column: "pub_date",
+      descending: false,
+      timestampKey: "pubDateMs",
+    });
+  });
+
+  it("round-trips tied timestamp cursors with an item id", () => {
+    const cursor = encodeItemListCursor(1_800_000_000_123, "item_abc-123");
+    expect(cursor).toBe("1800000000123:item_abc-123");
+    expect(decodeItemListCursor(cursor)).toEqual({
+      id: "item_abc-123",
+      timestamp: 1_800_000_000_123,
+    });
+    expect(buildItemsListUrl({
+      nextCursor: cursor,
+      sortOrder: ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
+      statusFilter: "all",
+    })).toBe(
+      "?next_cursor=1800000000123%3Aitem_abc-123&sort=updated_desc",
+    );
   });
 });

--- a/tests/unit/shared/ItemList.test.ts
+++ b/tests/unit/shared/ItemList.test.ts
@@ -1,16 +1,20 @@
 import {describe, expect, it} from "vitest";
 
-import {STATUSES} from "@/shared/Constants";
+import {ITEMS_SORT_ORDERS, STATUSES} from "@/shared/Constants";
 import {
   buildItemsListUrl,
-  decodeItemListCursor,
-  encodeItemListCursor,
-  ITEM_LIST_SORT_ORDERS,
   itemQueryForStatusFilter,
-  itemListSortDefinition,
-  normalizeItemListSortOrder,
   normalizeItemStatusFilter,
 } from "@/shared/ItemList";
+import {
+  buildItemPaginationUrl,
+  decodeItemCursor,
+  encodeItemCursor,
+  ITEM_ORDERS,
+  ITEM_SORTS,
+  resolveItemPagination,
+  resolveItemPaginationSettings,
+} from "@/shared/ItemPagination";
 
 describe("admin item list filters", () => {
   it("normalizes known filters and falls back to all items", () => {
@@ -34,48 +38,126 @@ describe("admin item list filters", () => {
     });
   });
 
-  it("keeps the filter and sort order in pagination links", () => {
+  it("keeps the filter, sort key, and order in pagination links", () => {
     expect(buildItemsListUrl({
-      nextCursor: 123,
-      sortOrder: ITEM_LIST_SORT_ORDERS.UPDATED_ASC,
+      nextCursor: "cursor_value",
+      order: ITEM_ORDERS.ASC,
+      sort: ITEM_SORTS.UPDATED_AT,
       statusFilter: "unlisted",
-    })).toBe("?status=unlisted&next_cursor=123&sort=updated_asc");
-
+    })).toBe(
+      "?status=unlisted&next_cursor=cursor_value&sort=updated_at&order=asc",
+    );
     expect(buildItemsListUrl({
-      prevCursor: 456,
-      sortOrder: ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC,
+      order: ITEM_ORDERS.DESC,
+      prevCursor: "previous_value",
+      sort: ITEM_SORTS.CREATED_AT,
       statusFilter: "all",
-    })).toBe("?prev_cursor=456&sort=newest_first");
+    })).toBe(
+      "?prev_cursor=previous_value&sort=created_at&order=desc",
+    );
   });
+});
 
-  it("defaults the admin list to the most recently updated items", () => {
-    expect(normalizeItemListSortOrder(undefined)).toBe("updated_desc");
-    expect(itemListSortDefinition("updated_desc")).toEqual({
-      column: "updated_at",
-      descending: true,
-      order: "updated_desc",
-      timestampKey: "updatedAtMs",
-    });
-    expect(itemListSortDefinition("oldest_first")).toMatchObject({
-      column: "pub_date",
-      descending: false,
-      timestampKey: "pubDateMs",
-    });
-  });
+describe("item pagination contract", () => {
+  it("round-trips unpadded Base64URL timestamp and ID cursors", () => {
+    const cursor = encodeItemCursor(1_800_000_000_123, "item_abc-123");
 
-  it("round-trips tied timestamp cursors with an item id", () => {
-    const cursor = encodeItemListCursor(1_800_000_000_123, "item_abc-123");
-    expect(cursor).toBe("1800000000123:item_abc-123");
-    expect(decodeItemListCursor(cursor)).toEqual({
+    expect(cursor).toMatch(/^[A-Za-z0-9_-]+$/u);
+    expect(cursor).not.toContain("=");
+    expect(decodeItemCursor(cursor)).toEqual({
       id: "item_abc-123",
       timestamp: 1_800_000_000_123,
     });
-    expect(buildItemsListUrl({
-      nextCursor: cursor,
-      sortOrder: ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
-      statusFilter: "all",
+    expect(decodeItemCursor("not+a+base64url+cursor")).toBeUndefined();
+  });
+
+  it("resolves canonical defaults and ignores malformed or mismatched cursors", () => {
+    const defaults = resolveItemPagination(new URLSearchParams(), {
+      order: ITEM_ORDERS.DESC,
+      sort: ITEM_SORTS.UPDATED_AT,
+    });
+    expect(defaults).toMatchObject({
+      column: "updated_at",
+      mode: "canonical",
+      order: "desc",
+      sort: "updated_at",
+      timestampKey: "updatedAtMs",
+    });
+
+    const numericCursor = resolveItemPagination(new URLSearchParams({
+      next_cursor: "1800000000123",
+      order: "asc",
+      sort: "created_at",
+    }));
+    expect(numericCursor.nextCursor).toBeUndefined();
+
+    const obsoleteSort = resolveItemPagination(new URLSearchParams({
+      sort: "updated_desc",
+    }));
+    expect(obsoleteSort).toMatchObject({
+      mode: "canonical",
+      order: "desc",
+      sort: "published_at",
+    });
+  });
+
+  it("gives next cursor precedence and requires the cursor mode to match", () => {
+    const cursor = encodeItemCursor(1_800_000_000_123, "item-a");
+    const canonical = resolveItemPagination(new URLSearchParams({
+      next_cursor: cursor,
+      prev_cursor: encodeItemCursor(1_700_000_000_000, "item-b"),
+      sort: "updated_at",
+    }));
+    expect(canonical.nextCursor).toEqual({
+      id: "item-a",
+      timestamp: 1_800_000_000_123,
+    });
+    expect(canonical.prevCursor).toBeUndefined();
+
+    const malformedNext = resolveItemPagination(new URLSearchParams({
+      next_cursor: "invalid",
+      prev_cursor: cursor,
+      sort: "updated_at",
+    }));
+    expect(malformedNext.nextCursor).toBeUndefined();
+    expect(malformedNext.prevCursor).toBeUndefined();
+  });
+
+  it("keeps explicit legacy requests numeric and ignores order", () => {
+    const legacy = resolveItemPagination(new URLSearchParams({
+      next_cursor: "1800000000123",
+      order: "asc",
+      sort: ITEMS_SORT_ORDERS.NEWEST_FIRST,
+    }));
+    expect(legacy).toMatchObject({
+      legacySort: "newest_first",
+      mode: "legacy",
+      nextCursor: 1_800_000_000_123,
+      order: "desc",
+      sort: "published_at",
+    });
+    expect(resolveItemPagination(new URLSearchParams({
+      next_cursor: encodeItemCursor(1_800_000_000_123, "item-a"),
+      sort: ITEMS_SORT_ORDERS.OLDEST_FIRST,
+    })).nextCursor).toBeUndefined();
+  });
+
+  it("maps legacy settings but produces canonical, escaped URLs", () => {
+    expect(resolveItemPaginationSettings({
+      itemsSortOrder: ITEMS_SORT_ORDERS.OLDEST_FIRST,
+    })).toEqual({itemsOrder: "asc", itemsSort: "published_at"});
+    expect(resolveItemPaginationSettings({
+      itemsOrder: "desc",
+      itemsSort: "created_at",
+      itemsSortOrder: ITEMS_SORT_ORDERS.OLDEST_FIRST,
+    })).toEqual({itemsOrder: "desc", itemsSort: "created_at"});
+
+    expect(buildItemPaginationUrl("https://feed.example/json/", {
+      nextCursor: "a_cursor-with-symbols",
+      order: ITEM_ORDERS.ASC,
+      sort: ITEM_SORTS.CREATED_AT,
     })).toBe(
-      "?next_cursor=1800000000123%3Aitem_abc-123&sort=updated_desc",
+      "https://feed.example/json/?next_cursor=a_cursor-with-symbols&sort=created_at&order=asc",
     );
   });
 });

--- a/tests/unit/shared/admin-navigation.test.ts
+++ b/tests/unit/shared/admin-navigation.test.ts
@@ -14,8 +14,8 @@ describe("getAdminNavigationItems", () => {
     expect(items.map(({id, url}) => [id, url])).toEqual([
       [NAV_ITEMS.ADMIN_HOME, "/studio/"],
       [NAV_ITEMS.EDIT_CHANNEL, "/studio/channels/primary/"],
-      [NAV_ITEMS.NEW_ITEM, "/studio/items/new/"],
       [NAV_ITEMS.ALL_ITEMS, "/studio/items/list/"],
+      [NAV_ITEMS.API, "/studio/api/"],
       [NAV_ITEMS.SETTINGS, "/studio/settings/"],
     ]);
     expect(items.filter((item) => item.active).map((item) => item.id)).toEqual([

--- a/tests/unit/shared/admin-settings-navigation.test.ts
+++ b/tests/unit/shared/admin-settings-navigation.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from "vitest";
+
+import {
+  ADMIN_SETTINGS_SECTIONS,
+  filterAdminSettingsSections,
+} from "@/shared/AdminSettingsNavigation";
+
+describe("admin settings navigation", () => {
+  it("keeps section links in page order with their labels and distinct icons", () => {
+    expect(ADMIN_SETTINGS_SECTIONS.map(({id, name, icon}) => [id, name, icon])).toEqual([
+      ["tracking-urls", "Tracking URLs", "activity"],
+      ["access-control", "Access control", "shield"],
+      ["subscribe-methods", "Subscribe methods", "rss"],
+      ["web-settings", "Global settings", "globe"],
+      ["custom-code", "Custom code", "code"],
+    ]);
+  });
+
+  it("filters sections case-insensitively and restores all on an empty query", () => {
+    expect(filterAdminSettingsSections("SUBSCRIBE").map(({id}) => id)).toEqual([
+      "subscribe-methods",
+    ]);
+    expect(filterAdminSettingsSections("GLOBAL").map(({id}) => id)).toEqual([
+      "web-settings",
+    ]);
+    expect(filterAdminSettingsSections("  ")).toBe(ADMIN_SETTINGS_SECTIONS);
+  });
+});

--- a/tests/unit/source-architecture.test.ts
+++ b/tests/unit/source-architecture.test.ts
@@ -157,6 +157,53 @@ describe("source architecture", () => {
     await expect(readFile(route, "utf8")).resolves.toContain(
       "<CustomCodeEditorApp",
     );
+    const routeSource = await readFile(route, "utf8");
+    expect(routeSource).toContain("settingsNavigation");
+    expect(routeSource).toContain('settingsActiveSection="custom-code"');
+  });
+
+  it("keeps API settings on their standalone auto-saving page", async () => {
+    const [apiRoute, apiSettings, settingsPage] = await Promise.all([
+      readFile(
+        path.join(
+          repositoryRoot,
+          "src",
+          "pages",
+          "[adminPath]",
+          "api",
+          "index.astro",
+        ),
+        "utf8",
+      ),
+      readFile(
+        path.join(
+          repositoryRoot,
+          "src",
+          "components",
+          "admin",
+          "settings",
+          "ApiSettingsApp",
+          "index.tsx",
+        ),
+        "utf8",
+      ),
+      readFile(
+        path.join(
+          repositoryRoot,
+          "src",
+          "components",
+          "admin",
+          "settings",
+          "SettingsApp.tsx",
+        ),
+        "utf8",
+      ),
+    ]);
+
+    expect(apiRoute).toContain("<ApiSettingsApp");
+    expect(apiSettings).toContain("onCheckedChange={(enabled) => saveBundle");
+    expect(apiSettings).not.toContain("<SettingsBase");
+    expect(settingsPage).not.toContain("ApiSettingsApp");
   });
 
   it("keeps the items list free of a redundant page card", async () => {
@@ -195,9 +242,15 @@ describe("source architecture", () => {
       /\.dark \{[\s\S]*?--admin-canvas: #171721;[\s\S]*?--sidebar: #171721;/u,
     );
     expect(adminShell).toContain("flex-1 bg-background");
+    expect(adminShell).toContain("lg:h-svh lg:min-h-0");
+    expect(adminShell).toContain("lg:flex-col lg:overflow-hidden");
+    expect(adminShell).toContain('class="lg:h-full lg:overflow-hidden"');
+    expect(adminShell).toContain(
+      "lg:flex-1 lg:overscroll-contain lg:overflow-y-auto",
+    );
   });
 
-  it("keeps edit action rails top-aligned and the toaster in the shell", async () => {
+  it("keeps edit action rails below the shell edge and the toaster in the shell", async () => {
     const [channelEditor, itemEditor, adminPageApp, adminShell, sonner] = await Promise.all([
       readFile(
         path.join(repositoryRoot, "src", "components", "admin", "channel", "EditChannelApp", "index.tsx"),
@@ -215,8 +268,8 @@ describe("source architecture", () => {
       readFile(path.join(repositoryRoot, "src", "components", "ui", "sonner.tsx"), "utf8"),
     ]);
 
-    expect(channelEditor).toContain("xl:sticky xl:top-0");
-    expect(itemEditor).toContain("xl:sticky xl:top-0");
+    expect(channelEditor).toContain("xl:sticky xl:top-4");
+    expect(itemEditor).toContain("xl:sticky xl:top-4");
     expect(channelEditor).toContain("showToast('No changes to save.', 'info')");
     expect(itemEditor).toContain("'Add some item details before creating it.'");
     expect(channelEditor).not.toContain("submitting || !changed");

--- a/tests/unit/source-architecture.test.ts
+++ b/tests/unit/source-architecture.test.ts
@@ -40,6 +40,54 @@ async function contentsUnder(directory: string): Promise<string> {
 }
 
 describe("source architecture", () => {
+  it("points OpenAPI key guidance to the standalone admin API page", async () => {
+    const openApi = await readFile(
+      path.join(repositoryRoot, "src", "server", "openapi", "openapi.yaml"),
+      "utf8",
+    );
+
+    expect(openApi).toContain(
+      "API key at {{baseUrl}}{{adminBasePath}}api/.",
+    );
+    expect(openApi).toContain(
+      'Get API Key on {{baseUrl}}{{adminBasePath}}api/',
+    );
+    expect(openApi).not.toContain(
+      'Get API Key on {{baseUrl}}{{adminBasePath}}settings/',
+    );
+    expect(openApi).toContain("- published_at");
+    expect(openApi).toContain("- created_at");
+    expect(openApi).toContain("- updated_at");
+    expect(openApi).toContain("name: order");
+    expect(openApi).toContain("name: prev_cursor");
+    expect(openApi).toContain("unpadded Base64URL");
+    expect(openApi).toContain("deprecated: true");
+    expect(openApi).not.toContain("updated_desc");
+    expect(openApi).not.toContain("updated_asc");
+  });
+
+  it("saves only canonical public feed sorting settings", async () => {
+    const settingsSource = await readFile(
+      path.join(
+        repositoryRoot,
+        "src",
+        "components",
+        "admin",
+        "settings",
+        "WebGlobalSettingsApp",
+        "index.tsx",
+      ),
+      "utf8",
+    );
+
+    expect(settingsSource).toContain("itemsOrder,");
+    expect(settingsSource).toContain("itemsSort,");
+    expect(settingsSource).not.toContain("itemsSortOrder");
+    expect(settingsSource).toContain("Published at");
+    expect(settingsSource).toContain("Created at");
+    expect(settingsSource).toContain("Updated at");
+  });
+
   it("has no legacy source roots or references", async () => {
     for (const directory of legacyRoots) {
       await expect(

--- a/tests/worker/items-list.test.ts
+++ b/tests/worker/items-list.test.ts
@@ -1,0 +1,97 @@
+import {env} from "cloudflare:workers";
+import {describe, expect, it} from "vitest";
+
+import FeedDb, {getFetchItemsParams} from "@/server/feed/FeedDb";
+import {STATUSES} from "@/shared/Constants";
+import {ITEM_LIST_SORT_ORDERS} from "@/shared/ItemList";
+
+const ITEMS = [
+  {
+    id: "item-a",
+    pubDate: "2026-08-04T10:00:00.000Z",
+    title: "Published first",
+    updatedAt: "2026-08-04T13:00:00.000Z",
+  },
+  {
+    id: "item-b",
+    pubDate: "2026-08-04T12:00:00.000Z",
+    title: "Published last",
+    updatedAt: "2026-08-04T11:00:00.000Z",
+  },
+  {
+    id: "item-c",
+    pubDate: "2026-08-04T11:00:00.000Z",
+    title: "Updated last",
+    updatedAt: "2026-08-04T12:00:00.000Z",
+  },
+  {
+    id: "item-d",
+    pubDate: "2026-08-04T09:00:00.000Z",
+    title: "Updated at the same time",
+    updatedAt: "2026-08-04T12:00:00.000Z",
+  },
+];
+
+describe("admin item list timestamps", () => {
+  it("sorts and paginates by updated_at while retaining published sorting", async () => {
+    const database = new FeedDb(
+      env,
+      new Request("https://feed.example.com/admin/items/list/"),
+    );
+    await database.getContent();
+    await env.FEED_DB.batch(ITEMS.map((item) =>
+      env.FEED_DB.prepare(
+        "INSERT INTO items (id, status, data, pub_date, updated_at) VALUES (?, ?, ?, ?, ?)",
+      ).bind(
+        item.id,
+        STATUSES.PUBLISHED,
+        JSON.stringify({title: item.title}),
+        item.pubDate,
+        item.updatedAt,
+      )
+    ));
+
+    const updatedPage = await database.getContent({
+      fromUrl: {sortOrder: ITEM_LIST_SORT_ORDERS.UPDATED_DESC},
+      limit: 2,
+      queryKwargs: {"status__!=": STATUSES.DELETED},
+    });
+    expect(updatedPage.items.map(({id}: {id: string}) => id)).toEqual([
+      "item-a",
+      "item-c",
+    ]);
+    expect(updatedPage.items_sort_order).toBe("updated_desc");
+    expect(updatedPage.items_next_cursor).toBe(
+      `${Date.parse("2026-08-04T12:00:00.000Z")}:item-c`,
+    );
+
+    const nextRequest = new Request(
+      "https://feed.example.com/admin/items/list/?" +
+        new URLSearchParams({
+          next_cursor: updatedPage.items_next_cursor,
+          sort: ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
+        }),
+    );
+    const nextUpdatedPage = await database.getContent(getFetchItemsParams(
+      nextRequest,
+      {"status__!=": STATUSES.DELETED},
+      2,
+    ));
+    expect(nextUpdatedPage.items.map(({id}: {id: string}) => id)).toEqual([
+      "item-d",
+      "item-b",
+    ]);
+
+    const publishedPage = await database.getContent({
+      fromUrl: {sortOrder: ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC},
+      limit: 4,
+      queryKwargs: {"status__!=": STATUSES.DELETED},
+    });
+    expect(publishedPage.items.map(({id}: {id: string}) => id)).toEqual([
+      "item-b",
+      "item-c",
+      "item-a",
+      "item-d",
+    ]);
+  });
+});

--- a/tests/worker/items-list.test.ts
+++ b/tests/worker/items-list.test.ts
@@ -2,96 +2,226 @@ import {env} from "cloudflare:workers";
 import {describe, expect, it} from "vitest";
 
 import FeedDb, {getFetchItemsParams} from "@/server/feed/FeedDb";
-import {STATUSES} from "@/shared/Constants";
-import {ITEM_LIST_SORT_ORDERS} from "@/shared/ItemList";
+import {ITEMS_SORT_ORDERS, STATUSES} from "@/shared/Constants";
+import {
+  decodeItemCursor,
+  ITEM_ORDERS,
+  ITEM_SORTS,
+  type ItemOrder,
+  type ItemSort,
+} from "@/shared/ItemPagination";
 
 const ITEMS = [
   {
-    id: "item-a",
+    createdAt: "2026-08-04T10:00:00.000Z",
+    id: "pagination-a",
     pubDate: "2026-08-04T10:00:00.000Z",
-    title: "Published first",
+    title: "Item A",
     updatedAt: "2026-08-04T13:00:00.000Z",
   },
   {
-    id: "item-b",
+    createdAt: "2026-08-04T11:00:00.000Z",
+    id: "pagination-b",
     pubDate: "2026-08-04T12:00:00.000Z",
-    title: "Published last",
+    title: "Item B",
     updatedAt: "2026-08-04T11:00:00.000Z",
   },
   {
-    id: "item-c",
+    createdAt: "2026-08-04T11:00:00.000Z",
+    id: "pagination-c",
     pubDate: "2026-08-04T11:00:00.000Z",
-    title: "Updated last",
+    title: "Item C",
     updatedAt: "2026-08-04T12:00:00.000Z",
   },
   {
-    id: "item-d",
+    createdAt: "2026-08-04T12:00:00.000Z",
+    id: "pagination-d",
     pubDate: "2026-08-04T09:00:00.000Z",
-    title: "Updated at the same time",
+    title: "Item D",
     updatedAt: "2026-08-04T12:00:00.000Z",
+  },
+  {
+    createdAt: "2026-08-04T13:00:00.000Z",
+    id: "pagination-e",
+    pubDate: "2026-08-04T11:00:00.000Z",
+    title: "Item E",
+    updatedAt: "2026-08-04T10:00:00.000Z",
   },
 ];
 
-describe("admin item list timestamps", () => {
-  it("sorts and paginates by updated_at while retaining published sorting", async () => {
+const COLUMN_BY_SORT = {
+  [ITEM_SORTS.CREATED_AT]: "createdAt",
+  [ITEM_SORTS.PUBLISHED_AT]: "pubDate",
+  [ITEM_SORTS.UPDATED_AT]: "updatedAt",
+} as const;
+
+async function databaseWithItems() {
+  const database = new FeedDb(
+    env,
+    new Request("https://feed.example.com/admin/items/list/"),
+  );
+  await database.getContent();
+  await env.FEED_DB.prepare(
+    "DELETE FROM items WHERE id LIKE 'pagination-%' OR id = 'canonical-write'",
+  ).run();
+  await env.FEED_DB.batch(ITEMS.map((item) =>
+    env.FEED_DB.prepare(
+      "INSERT INTO items (id, status, data, pub_date, created_at, updated_at) " +
+        "VALUES (?, ?, ?, ?, ?, ?)",
+    ).bind(
+      item.id,
+      STATUSES.PUBLISHED,
+      JSON.stringify({title: item.title}),
+      item.pubDate,
+      item.createdAt,
+      item.updatedAt,
+    )
+  ));
+  return database;
+}
+
+function expectedIds(sort: ItemSort, order: ItemOrder): string[] {
+  const column = COLUMN_BY_SORT[sort];
+  const direction = order === ITEM_ORDERS.ASC ? 1 : -1;
+  return [...ITEMS].sort((left, right) => {
+    const timestampDifference = Date.parse(left[column]) - Date.parse(right[column]);
+    return direction * (
+      timestampDifference || left.id.localeCompare(right.id)
+    );
+  }).map(({id}) => id);
+}
+
+async function page(
+  database: FeedDb,
+  searchParams: Record<string, string>,
+) {
+  const request = new Request(
+    `https://feed.example.com/admin/items/list/?${new URLSearchParams(searchParams)}`,
+  );
+  return database.getContent(getFetchItemsParams(
+    request,
+    {"status__!=": STATUSES.DELETED},
+    2,
+  ));
+}
+
+describe("deterministic item pagination", () => {
+  it("writes canonical item timestamps instead of SQLite defaults", async () => {
     const database = new FeedDb(
       env,
       new Request("https://feed.example.com/admin/items/list/"),
     );
     await database.getContent();
-    await env.FEED_DB.batch(ITEMS.map((item) =>
-      env.FEED_DB.prepare(
-        "INSERT INTO items (id, status, data, pub_date, updated_at) VALUES (?, ?, ?, ?, ?)",
-      ).bind(
-        item.id,
-        STATUSES.PUBLISHED,
-        JSON.stringify({title: item.title}),
-        item.pubDate,
-        item.updatedAt,
-      )
-    ));
+    await env.FEED_DB.prepare(
+      "DELETE FROM items WHERE id = ?",
+    ).bind("canonical-write").run();
 
-    const updatedPage = await database.getContent({
-      fromUrl: {sortOrder: ITEM_LIST_SORT_ORDERS.UPDATED_DESC},
-      limit: 2,
-      queryKwargs: {"status__!=": STATUSES.DELETED},
+    await database.putContent({
+      item: {
+        id: "canonical-write",
+        pubDateMs: Date.parse("2026-08-04T12:00:00.000Z"),
+        status: STATUSES.PUBLISHED,
+        title: "Canonical timestamps",
+      },
     });
-    expect(updatedPage.items.map(({id}: {id: string}) => id)).toEqual([
-      "item-a",
-      "item-c",
-    ]);
-    expect(updatedPage.items_sort_order).toBe("updated_desc");
-    expect(updatedPage.items_next_cursor).toBe(
-      `${Date.parse("2026-08-04T12:00:00.000Z")}:item-c`,
-    );
 
-    const nextRequest = new Request(
-      "https://feed.example.com/admin/items/list/?" +
-        new URLSearchParams({
-          next_cursor: updatedPage.items_next_cursor,
-          sort: ITEM_LIST_SORT_ORDERS.UPDATED_DESC,
-        }),
+    const row = await env.FEED_DB.prepare(
+      "SELECT created_at, updated_at FROM items WHERE id = ?",
+    ).bind("canonical-write").first<{
+      created_at: string;
+      updated_at: string;
+    }>();
+    expect(row?.created_at).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u,
     );
-    const nextUpdatedPage = await database.getContent(getFetchItemsParams(
-      nextRequest,
-      {"status__!=": STATUSES.DELETED},
-      2,
-    ));
-    expect(nextUpdatedPage.items.map(({id}: {id: string}) => id)).toEqual([
-      "item-d",
-      "item-b",
-    ]);
+    expect(row?.updated_at).toBe(row?.created_at);
+    await env.FEED_DB.prepare(
+      "DELETE FROM items WHERE id = ?",
+    ).bind("canonical-write").run();
+  });
 
-    const publishedPage = await database.getContent({
-      fromUrl: {sortOrder: ITEM_LIST_SORT_ORDERS.PUBLISHED_DESC},
-      limit: 4,
-      queryKwargs: {"status__!=": STATUSES.DELETED},
+  it("navigates both directions for every canonical key and order with ties", async () => {
+    const database = await databaseWithItems();
+
+    for (const sort of Object.values(ITEM_SORTS)) {
+      for (const order of Object.values(ITEM_ORDERS)) {
+        const forwardPages: string[][] = [];
+        const seenIds: string[] = [];
+        let response = await page(database, {order, sort});
+
+        while (true) {
+          const ids = response.items.map(({id}: {id: string}) => id);
+          expect(ids).not.toHaveLength(0);
+          forwardPages.push(ids);
+          seenIds.push(...ids);
+          expect(response.items_sort).toBe(sort);
+          expect(response.items_order).toBe(order);
+          expect(response.items_sort_order).toBeUndefined();
+          if (!response.items_next_cursor) break;
+          expect(decodeItemCursor(response.items_next_cursor)).toBeDefined();
+          response = await page(database, {
+            next_cursor: response.items_next_cursor,
+            order,
+            sort,
+          });
+        }
+
+        expect(seenIds).toEqual(expectedIds(sort, order));
+        expect(new Set(seenIds).size).toBe(ITEMS.length);
+
+        for (let index = forwardPages.length - 2; index >= 0; index -= 1) {
+          expect(response.items_prev_cursor).toBeDefined();
+          response = await page(database, {
+            order,
+            prev_cursor: response.items_prev_cursor,
+            sort,
+          });
+          expect(response.items.map(({id}: {id: string}) => id)).toEqual(
+            forwardPages[index],
+          );
+        }
+        expect(response.items_prev_cursor).toBeUndefined();
+      }
+    }
+  });
+
+  it("keeps explicit legacy sorting numeric and ignores order", async () => {
+    const database = await databaseWithItems();
+    const firstPage = await page(database, {
+      order: ITEM_ORDERS.ASC,
+      sort: ITEMS_SORT_ORDERS.NEWEST_FIRST,
     });
-    expect(publishedPage.items.map(({id}: {id: string}) => id)).toEqual([
-      "item-b",
-      "item-c",
-      "item-a",
-      "item-d",
+
+    expect(firstPage.items.map(({id}: {id: string}) => id)).toEqual([
+      "pagination-b",
+      "pagination-c",
     ]);
+    expect(firstPage.items_next_cursor).toBe(
+      Date.parse("2026-08-04T11:00:00.000Z"),
+    );
+    expect(firstPage.items_sort_order).toBe(ITEMS_SORT_ORDERS.NEWEST_FIRST);
+    expect(firstPage.items_sort).toBeUndefined();
+    expect(firstPage.items_order).toBeUndefined();
+  });
+
+  it("falls back to the first page for malformed or mode-mismatched cursors", async () => {
+    const database = await databaseWithItems();
+    const expected = expectedIds(ITEM_SORTS.UPDATED_AT, ITEM_ORDERS.DESC)
+      .slice(0, 2);
+    const malformed = await page(database, {
+      next_cursor: "malformed",
+      order: ITEM_ORDERS.DESC,
+      prev_cursor: "also-malformed",
+      sort: ITEM_SORTS.UPDATED_AT,
+    });
+    const numeric = await page(database, {
+      next_cursor: String(Date.parse("2026-08-04T12:00:00.000Z")),
+      order: ITEM_ORDERS.DESC,
+      sort: ITEM_SORTS.UPDATED_AT,
+    });
+
+    expect(malformed.items.map(({id}: {id: string}) => id)).toEqual(expected);
+    expect(numeric.items.map(({id}: {id: string}) => id)).toEqual(expected);
+    expect(malformed.items_prev_cursor).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Rework the admin navigation and settings experience with a dedicated API page, section navigation, automatic saves, and improved item-management controls.
- Replace item pagination across the admin list, web feed, RSS, JSON Feed, and API with deterministic `sort`/`order` keyset pagination using timestamp-and-item-ID cursors.
- Preserve explicit `newest_first`/`oldest_first` compatibility while migrating saved feed settings to canonical sort keys.
- Normalize existing item timestamps through a D1 migration and write new `created_at`/`updated_at` values in a consistent RFC 3339 format so every supported sort key paginates reliably.
- Update OpenAPI documentation, default theme pagination links, bootstrap validation, and regression coverage.

## Related issue

N/A

## Testing

- [x] `git diff --check`
- [x] `yarn check`
- [x] Focused worker pagination tests for tied timestamps, forward/backward navigation, malformed cursors, and all canonical sort keys
- [x] Migration regression tests for normalization, idempotency, and indexed timestamp queries

## Screenshots

N/A — the visible admin changes were iterated and reviewed in the Codex task.

## Risks

- Applies a one-time D1 migration that normalizes existing `items.created_at` and `items.updated_at` values to RFC 3339 UTC strings. The migration is idempotent and retains the existing timestamp indexes.
- Explicit legacy `sort=newest_first|oldest_first` requests remain supported with numeric cursors; canonical requests use Base64URL timestamp-and-ID cursors.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
