### PR TITLE
Improve admin image upload management

### DIFF
--- a/src/client/ImageUploadUtils.ts
+++ b/src/client/ImageUploadUtils.ts
@@ -1,0 +1,13 @@
+export function queueReplacedImageUrl(
+  imageUrls: string[],
+  imageUrl: unknown,
+): string[] {
+  if (typeof imageUrl !== "string") {
+    return imageUrls;
+  }
+  const normalizedImageUrl = imageUrl.trim();
+  if (!normalizedImageUrl || imageUrls.includes(normalizedImageUrl)) {
+    return imageUrls;
+  }
+  return [...imageUrls, normalizedImageUrl];
+}

--- a/src/client/requests.ts
+++ b/src/client/requests.ts
@@ -1,10 +1,18 @@
 import axios from 'axios';
 import {ADMIN_URLS} from "@/shared/StringUtils";
+import type {ImageMetadataTarget} from "@/types";
 
 const axiosPost = (url: any, bodyDict: any) => {
   return axios.post(url, bodyDict, {
   });
 };
+
+const deleteImage = (
+  imageUrl: string,
+  target?: ImageMetadataTarget,
+) => axios.delete(ADMIN_URLS.ajaxR2Ops(), {
+  data: {imageUrl, target},
+});
 
 function uploadFile(file: any, cdnFilename: any, onProgress: any, onUploaded: any, onFailure: any, onR2OpsFailure: any) {
   const { size, type } = file;
@@ -55,6 +63,7 @@ function uploadFile(file: any, cdnFilename: any, onProgress: any, onUploaded: an
 
 const Requests = {
   axiosPost,
+  deleteImage,
   upload: uploadFile,
 };
 

--- a/src/components/admin/channel/EditChannelApp/index.tsx
+++ b/src/components/admin/channel/EditChannelApp/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/client/BrowserUtils";
 import type {FeedContent, OnboardingResult} from "@/types";
 import {Button} from "@/components/ui/button";
+import {queueReplacedImageUrl} from "@/client/ImageUploadUtils";
 
 const SUBMIT_STATUS__START = 1;
 
@@ -86,6 +87,7 @@ export default class EditChannelApp extends React.Component<Props, any> {
       channel,
       submitStatus: null,
       changed: false,
+      replacedImageUrls: [],
     }
   }
 
@@ -130,12 +132,19 @@ export default class EditChannelApp extends React.Component<Props, any> {
       return;
     }
     this.onUpdateChannelMetaToFeed(() => {
-      const {feed} = this.state;
+      const {feed, replacedImageUrls} = this.state;
       this.setState({submitStatus: SUBMIT_STATUS__START});
-      Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {channel: feed.channel})
+      Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {
+        channel: feed.channel,
+        deleteImageUrls: replacedImageUrls,
+      })
         .then((response: any) => {
           console.log(response);
-          this.setState({submitStatus: null, changed: false}, () => {
+          this.setState({
+            submitStatus: null,
+            changed: false,
+            replacedImageUrls: [],
+          }, () => {
             showToast('Updated!', 'success');
           });
         })
@@ -179,7 +188,28 @@ export default class EditChannelApp extends React.Component<Props, any> {
                   mediaStorageReady={mediaStorageReady}
                   publicBucketUrl={publicBucketUrl}
                   currentImageUrl={channel.image}
-                  onImageUploaded={(cdnUrl: any) => this.onUpdateChannelMeta('image', cdnUrl)}
+                  imageMetadataTarget={{id: channel.id, type: 'channel'}}
+                  onImageDeleted={() => this.setState((prevState: any) => ({
+                    channel: {
+                      ...prevState.channel,
+                      image: undefined,
+                    },
+                  }))}
+                  onImageUploaded={(
+                    cdnUrl: any,
+                    _contentType: any,
+                    replacedImageUrl: unknown,
+                  ) => this.setState((prevState: any) => ({
+                    changed: true,
+                    channel: {
+                      ...prevState.channel,
+                      image: cdnUrl,
+                    },
+                    replacedImageUrls: queueReplacedImageUrl(
+                      prevState.replacedImageUrls,
+                      replacedImageUrl,
+                    ),
+                  }))}
                 />
               </div>
               <div className="grid flex-1 grid-cols-1 gap-3">

--- a/src/components/admin/items/EditItemApp/index.tsx
+++ b/src/components/admin/items/EditItemApp/index.tsx
@@ -46,6 +46,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import {queueReplacedImageUrl} from "@/client/ImageUploadUtils";
 
 const SUBMIT_STATUS__START = 1;
 
@@ -95,6 +96,7 @@ export default class EditItemApp extends React.Component<Props, any> {
 
       userChangedLink: false,
       changed: false,
+      replacedImageUrls: [],
     };
   }
 
@@ -177,7 +179,13 @@ export default class EditItemApp extends React.Component<Props, any> {
 
   onSubmit(e: any) {
     e.preventDefault();
-    const {item, itemId, action, changed} = this.state;
+    const {
+      item,
+      itemId,
+      action,
+      changed,
+      replacedImageUrls,
+    } = this.state;
     if (!changed) {
       showToast(
         action === 'edit'
@@ -188,9 +196,16 @@ export default class EditItemApp extends React.Component<Props, any> {
       return;
     }
     this.setState({submitStatus: SUBMIT_STATUS__START});
-    Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {item: {id: itemId, ...item}})
+    Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {
+      deleteImageUrls: replacedImageUrls,
+      item: {id: itemId, ...item},
+    })
       .then(() => {
-        this.setState({submitStatus: null, changed: false}, () => {
+        this.setState({
+          submitStatus: null,
+          changed: false,
+          replacedImageUrls: [],
+        }, () => {
           if (action === 'edit') {
             showToast('Updated!', 'success');
           } else {
@@ -267,7 +282,33 @@ export default class EditItemApp extends React.Component<Props, any> {
                   mediaStorageReady={mediaStorageReady}
                   publicBucketUrl={publicBucketUrl}
                   currentImageUrl={item.image}
-                  onImageUploaded={(cdnUrl: any) => this.onUpdateItemMeta({'image': cdnUrl})}
+                  imageMetadataTarget={action === 'edit'
+                    ? {id: itemId, type: 'item'}
+                    : undefined}
+                  onImageDeleted={() => {
+                    if (action === 'edit') {
+                      this.setState((prevState: any) => ({
+                        item: {
+                          ...prevState.item,
+                          image: undefined,
+                        },
+                      }));
+                    } else {
+                      this.onUpdateItemMeta({image: undefined});
+                    }
+                  }}
+                  onImageUploaded={(
+                    cdnUrl: any,
+                    _contentType: any,
+                    replacedImageUrl: unknown,
+                  ) => this.setState((prevState: any) => ({
+                    changed: true,
+                    item: {...prevState.item, image: cdnUrl},
+                    replacedImageUrls: queueReplacedImageUrl(
+                      prevState.replacedImageUrls,
+                      replacedImageUrl,
+                    ),
+                  }))}
                 />
               </div>
               <div className="ml-8 flex-1">

--- a/src/components/admin/settings/SettingsApp.tsx
+++ b/src/components/admin/settings/SettingsApp.tsx
@@ -57,11 +57,19 @@ export default class SettingsApp extends React.Component<Props, any> {
     this.setState({changed: true});
   }
 
-  async onSubmit(e: any, bundleKey: any, bundle: any) {
+  async onSubmit(
+    e: any,
+    bundleKey: any,
+    bundle: any,
+    deleteImageUrls: string[] = [],
+  ) {
     e.preventDefault();
     this.setState({submitForType: bundleKey, submitStatus: SUBMIT_STATUS__START});
     try {
-      await Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {settings: {[bundleKey]: bundle}});
+      await Requests.axiosPost(ADMIN_URLS.ajaxFeed(), {
+        deleteImageUrls,
+        settings: {[bundleKey]: bundle},
+      });
       this.setState({submitStatus: null, submitForType: null, changed: false}, () => {
         showToast('Updated!', 'success');
       });

--- a/src/components/admin/settings/WebGlobalSettingsApp/index.tsx
+++ b/src/components/admin/settings/WebGlobalSettingsApp/index.tsx
@@ -24,6 +24,7 @@ import {
   normalizePublicBucketUrl,
   resolvePublicBucketUrl,
 } from "@/shared/StringUtils";
+import {queueReplacedImageUrl} from "@/client/ImageUploadUtils";
 
 export default class WebGlobalSettingsApp extends React.Component<any, any> {
   constructor(props: any) {
@@ -62,6 +63,7 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
       itemsPerPage,
       itemsOrder,
       itemsSort,
+      replacedImageUrls: [],
     };
   }
 
@@ -75,6 +77,7 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
       itemsPerPage,
       itemsOrder,
       itemsSort,
+      replacedImageUrls,
     } = this.state;
     const {submitting, submitForType, setChanged} = this.props;
     return (<SettingsBase
@@ -82,7 +85,7 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
       submitting={submitting}
       submitForType={submitForType}
       currentType={currentType}
-      onSubmit={(e: any) => {
+      onSubmit={async (e: any) => {
         const normalizedPublicBucketUrl =
           normalizePublicBucketUrl(publicBucketUrl);
         if (
@@ -97,13 +100,16 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
           );
           return;
         }
-        this.props.onSubmit(e, currentType, {
+        const saved = await this.props.onSubmit(e, currentType, {
           favicon,
           publicBucketUrl: normalizedPublicBucketUrl,
           itemsOrder,
           itemsSort,
           itemsPerPage,
-        });
+        }, replacedImageUrls);
+        if (saved) {
+          this.setState({replacedImageUrls: []});
+        }
       }}
     >
       <div className="grid grid-cols-1 gap-4">
@@ -212,6 +218,7 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
               mediaType="favicon"
               publicBucketUrl={publicBucketUrl}
               currentImageUrl={favicon.url}
+              imageMetadataTarget={{type: 'favicon'}}
               imageSizeNotOkayFunc={(width: any, height: any) => {
                 return (width > 256 && height > 256) || (width < 48 && height < 48);
               }}
@@ -225,12 +232,21 @@ export default class WebGlobalSettingsApp extends React.Component<any, any> {
                 }
                 return '';
               }}
-              onImageUploaded={(cdnUrl: any, contentType: any) => this.setState({
+              onImageUploaded={(
+                cdnUrl: any,
+                contentType: any,
+                replacedImageUrl: unknown,
+              ) => this.setState((prevState: any) => ({
                 favicon: {
                   url: cdnUrl,
                   contentType,
                 },
-              }, () => setChanged())}
+                replacedImageUrls: queueReplacedImageUrl(
+                  prevState.replacedImageUrls,
+                  replacedImageUrl,
+                ),
+              }), () => setChanged())}
+              onImageDeleted={() => this.setState({favicon: {}})}
             />
           </div>
         </details>

--- a/src/components/admin/shared/AdminImagePreviewDialog/index.tsx
+++ b/src/components/admin/shared/AdminImagePreviewDialog/index.tsx
@@ -1,0 +1,69 @@
+import {
+  ExternalLinkIcon,
+  XIcon,
+} from "lucide-react";
+
+import {Button} from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface AdminImagePreviewDialogProps {
+  alt?: string;
+  imageUrl: string;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+}
+
+export default function AdminImagePreviewDialog({
+  alt = "Uploaded image",
+  imageUrl,
+  onOpenChange,
+  open,
+}: AdminImagePreviewDialogProps) {
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent
+        className="inset-0 top-0 left-0 flex h-dvh w-dvw max-w-none translate-x-0 translate-y-0 items-center justify-center rounded-none border-0 bg-black/80 p-6 text-white ring-0 sm:max-w-none"
+        showCloseButton={false}
+      >
+        <DialogTitle className="sr-only">Image preview</DialogTitle>
+        <DialogDescription className="sr-only">
+          Full-screen preview of the uploaded image.
+        </DialogDescription>
+        <div className="absolute top-4 right-4 z-10 flex gap-2">
+          <a
+            className="inline-flex h-10 cursor-pointer items-center justify-center gap-2 rounded-[10px] border border-white/30 bg-black/30 px-4 text-sm font-medium !text-white shadow-xs transition-all hover:-translate-y-0.5 hover:border-white/60 hover:bg-white/15 hover:!text-white hover:shadow-lg focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-white/30 [&_svg]:size-4 [&_svg]:text-white"
+            href={imageUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            <ExternalLinkIcon aria-hidden="true" />
+            Open
+          </a>
+          <DialogClose
+            render={(
+              <Button
+                className="border-white/30 bg-black/30 !text-white transition-all hover:-translate-y-0.5 hover:border-white/60 hover:bg-white/15 hover:!text-white hover:shadow-lg [&_svg]:text-white"
+                type="button"
+                variant="outline"
+              />
+            )}
+          >
+            <XIcon aria-hidden="true" />
+            Close
+          </DialogClose>
+        </div>
+        <img
+          alt={alt}
+          className="max-h-[calc(100dvh-3rem)] max-w-[calc(100dvw-3rem)] object-contain"
+          src={imageUrl}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/admin/shared/AdminImageUploaderApp/index.tsx
+++ b/src/components/admin/shared/AdminImageUploaderApp/index.tsx
@@ -8,13 +8,37 @@ import {
   resolvePublicBucketUrl,
   urlJoinWithRelative,
 } from '@/shared/StringUtils';
+import type {ImageMetadataTarget} from "@/types";
 import AdminDialog from "../AdminDialog";
 import FileUploader from "../AdminFileUploader";
-import {CloudUploadIcon} from "lucide-react";
-import ExternalLink from "../ExternalLink";
+import {
+  CloudUploadIcon,
+  ExternalLinkIcon,
+  PencilIcon,
+  RefreshCwIcon,
+  Trash2Icon,
+} from "lucide-react";
 import {showToast} from "@/client/ToastUtils";
 import MediaStorageUnavailableDialog from "../MediaStorageUnavailableDialog";
 import {Button} from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import AdminImagePreviewDialog from "../AdminImagePreviewDialog";
 
 const UPLOAD_STATUS__START = 1;
 
@@ -32,16 +56,15 @@ function EmptyImage({fileTypes}: any) {
   </div>);
 }
 
-function PreviewImage({url}: any) {
-  return (<div className="relative flex justify-center">
+function PreviewImage({url}: {url: string}) {
+  return (<div className="relative flex h-full w-full justify-center overflow-hidden rounded-md">
     <img
+      alt="Uploaded image"
       src={url}
-      className={clsx('lh-upload-image-size object-cover', 'gradient-mask-b-20')}
+      className="h-full w-full object-cover"
     />
-    <div className="absolute bottom-4 text-sm font-normal text-brand-light">
-      <em>
-        Click or drag here to change image
-      </em>
+    <div className="absolute right-2 bottom-2 flex size-10 items-center justify-center rounded-lg border bg-background text-foreground shadow-md">
+      <PencilIcon aria-hidden="true" className="size-5" />
     </div>
   </div>);
 }
@@ -57,12 +80,15 @@ function isInvalidImage(): string | null {
 }
 
 export default class AdminImageUploaderApp extends React.Component<any, any> {
+  private inputFile: HTMLInputElement | null = null;
+
   constructor(props: any) {
     super(props);
 
     this.onFileUploadClick = this.onFileUploadClick.bind(this);
     this.onFileUpload = this.onFileUpload.bind(this);
     this.onFileUploadToR2 = this.onFileUploadToR2.bind(this);
+    this.onDeleteImage = this.onDeleteImage.bind(this);
     this.showMediaStorageUnavailable =
       this.showMediaStorageUnavailable.bind(this);
 
@@ -80,7 +106,10 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
       publicBucketUrl,
 
       showModal: false,
+      showDeleteConfirm: false,
+      showPreview: false,
       showMediaStorageUnavailable: false,
+      deleting: false,
       previewImageUrl: null,
       cropper: null,
       cdnFilename: null,
@@ -98,6 +127,12 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
   }
 
   componentDidUpdate(previousProps: any) {
+    if (
+      previousProps.currentImageUrl !== this.props.currentImageUrl &&
+      this.props.currentImageUrl !== this.state.currentImageUrl
+    ) {
+      this.setState({currentImageUrl: this.props.currentImageUrl || null});
+    }
     if (
       previousProps.publicBucketUrl !== this.props.publicBucketUrl &&
       this.props.publicBucketUrl !== this.state.publicBucketUrl
@@ -120,8 +155,8 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
     }
   }
 
-  onFileUploadClick(e: any) {
-    e.preventDefault();
+  onFileUploadClick(e?: {preventDefault?: () => void}) {
+    e?.preventDefault?.();
     if (this.props.mediaStorageReady === false) {
       this.showMediaStorageUnavailable();
       return;
@@ -135,6 +170,35 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
     }
 
     this.inputFile.click();
+  }
+
+  async onDeleteImage() {
+    const {currentImageUrl, deleting} = this.state;
+    if (!currentImageUrl || deleting) {
+      return;
+    }
+    this.setState({deleting: true});
+    try {
+      await Requests.deleteImage(
+        currentImageUrl,
+        this.props.imageMetadataTarget as ImageMetadataTarget | undefined,
+      );
+      await this.props.onImageDeleted?.();
+      this.setState({
+        currentImageUrl: null,
+        deleting: false,
+        showDeleteConfirm: false,
+        showPreview: false,
+      }, () => showToast('Image deleted.', 'success'));
+    } catch (error: any) {
+      this.setState({deleting: false}, () => {
+        if (!error.response) {
+          showToast('Network error. Please refresh the page and try again.', 'error');
+        } else {
+          showToast('Failed to delete this image. Please try again.', 'error');
+        }
+      });
+    }
   }
 
   onFileUpload(file: any) {
@@ -194,7 +258,12 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
           progressText: `${Number(percentage * 100.0).toFixed(2)}%`,
         });
       }, (cdnUrl: any) => {
-        this.props.onImageUploaded(cdnUrl, blob.type || 'image/png');
+        const replacedImageUrl = this.state.currentImageUrl;
+        this.props.onImageUploaded(
+          cdnUrl,
+          blob.type || 'image/png',
+          replacedImageUrl,
+        );
         cropper.destroy();
         if (previewImageUrl) {
           URL.revokeObjectURL(previewImageUrl);
@@ -227,7 +296,9 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
   }
 
   render() {
-    const {uploadStatus, currentImageUrl, progressText, showModal,
+    const {uploadStatus, currentImageUrl, deleting, progressText, showModal,
+      showDeleteConfirm,
+      showPreview,
       showMediaStorageUnavailable, publicBucketUrl, previewImageUrl,
       imageWidth, imageHeight} = this.state;
     const absoluteImageUrl =  currentImageUrl ? urlJoinWithRelative(publicBucketUrl, currentImageUrl) : null;
@@ -241,7 +312,91 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
       `Image too small: ${parseInt(imageWidth)} x ${parseInt(imageHeight)} pixels. ` +
       "If it's for a podcast image, Apple Podcasts requires the image to have 1400 x 1400 to 3000 x 3000 pixels.";
     return (<div className="lh-upload-wrapper">
-      <FileUploader
+      {absoluteImageUrl ? <>
+        <input
+          accept=".png,.jpg,.jpeg"
+          className="hidden"
+          disabled={uploading || !mediaStorageReady}
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0];
+            event.currentTarget.value = '';
+            if (file) {
+              this.onFileUpload(file);
+            }
+          }}
+          ref={(element) => {
+            this.inputFile = element;
+          }}
+          type="file"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            render={(
+              <button
+                aria-label="Manage uploaded image"
+                className="lh-upload-image-size relative overflow-hidden rounded-md border-2 border-dashed border-brand-light outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-brand-light focus-visible:ring-offset-2"
+                disabled={uploading || deleting}
+                type="button"
+              />
+            )}
+          >
+            <PreviewImage url={absoluteImageUrl} />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem onClick={this.onFileUploadClick}>
+              <RefreshCwIcon aria-hidden="true" />
+              Replace
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => this.setState({showPreview: true})}>
+              <ExternalLinkIcon aria-hidden="true" />
+              Preview
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              disabled={deleting}
+              onClick={() => this.setState({showDeleteConfirm: true})}
+              variant="destructive"
+            >
+              <Trash2Icon aria-hidden="true" />
+              {deleting ? 'Deleting...' : 'Delete'}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <AdminImagePreviewDialog
+          imageUrl={absoluteImageUrl}
+          onOpenChange={(open) => this.setState({showPreview: open})}
+          open={showPreview}
+        />
+        <AlertDialog
+          onOpenChange={(open) => {
+            if (!deleting) {
+              this.setState({showDeleteConfirm: open});
+            }
+          }}
+          open={showDeleteConfirm}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this image?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This removes the image from this page and requests permanent
+                deletion of its uploaded file. This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={deleting}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                disabled={deleting}
+                onClick={this.onDeleteImage}
+                type="button"
+                variant="destructive"
+              >
+                {deleting ? 'Deleting...' : 'Delete image'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </> : <FileUploader
         handleChange={this.onFileUpload}
         name="imageUploader"
         types={fileTypes}
@@ -252,13 +407,9 @@ export default class AdminImageUploaderApp extends React.Component<any, any> {
         classes="lh-upload-fileinput lh-upload-fileinput-image"
       >
         <div className="lh-upload-image-size lh-upload-box">
-          {absoluteImageUrl ? <PreviewImage url={absoluteImageUrl}/> :
-            <EmptyImage fileTypes={fileTypes} />}
+          <EmptyImage fileTypes={fileTypes} />
         </div>
-      </FileUploader>
-      {absoluteImageUrl && <div className="text-sm flex justify-center mt-1">
-        <ExternalLink linkClass="text-helper-color text-xs" text="preview image" url={absoluteImageUrl} />
-      </div>}
+      </FileUploader>}
       <MediaStorageUnavailableDialog
         dashboardUrl={this.props.mediaStorage?.dashboardUrl}
         onOpenChange={(open) => this.setState({

--- a/src/pages/[adminPath]/ajax/feed.ts
+++ b/src/pages/[adminPath]/ajax/feed.ts
@@ -1,13 +1,30 @@
-import {env} from "cloudflare:workers";
+import {env, waitUntil} from "cloudflare:workers";
 import type {APIRoute} from "astro";
 
 import FeedDb from "@/server/feed/FeedDb";
+import {scheduleBestEffortMediaDeletion} from "@/server/media/deletions";
+import {mediaBucket} from "@/server/media/storage";
 import {jsonResponse} from "../../../server/http";
 import type {FeedContent} from "../../../types";
 
-export const POST: APIRoute = async ({request}) => {
+export async function updateAdminFeed(
+  request: Request,
+  runtimeEnv: Env,
+  schedule: (promise: Promise<unknown>) => void,
+): Promise<Response> {
   const updatedFeed = await request.json() as FeedContent;
-  const database = new FeedDb(env, request);
+  const deleteImageUrls = Array.isArray(updatedFeed.deleteImageUrls)
+    ? updatedFeed.deleteImageUrls
+    : [];
+  const database = new FeedDb(runtimeEnv, request);
   await database.putContent(updatedFeed);
+  scheduleBestEffortMediaDeletion(
+    mediaBucket(runtimeEnv),
+    deleteImageUrls,
+    schedule,
+  );
   return jsonResponse({});
-};
+}
+
+export const POST: APIRoute = async ({request}) =>
+  updateAdminFeed(request, env, waitUntil);

--- a/src/pages/[adminPath]/ajax/r2-ops.ts
+++ b/src/pages/[adminPath]/ajax/r2-ops.ts
@@ -1,7 +1,12 @@
-import {env} from "cloudflare:workers";
+import {env, waitUntil} from "cloudflare:workers";
 import type {APIRoute} from "astro";
 
 import {jsonResponse} from "../../../server/http";
+import FeedDb from "@/server/feed/FeedDb";
+import {
+  parseDeleteImageRequest,
+  scheduleBestEffortMediaDeletion,
+} from "@/server/media/deletions";
 import {createSignedUpload} from "@/server/media/uploads";
 import {
   mediaBucket,
@@ -23,3 +28,41 @@ export const POST: APIRoute = async ({request}) => {
     );
   }
 };
+
+export async function deleteAdminImage(
+  request: Request,
+  runtimeEnv: Env,
+  schedule: (promise: Promise<unknown>) => void,
+): Promise<Response> {
+  let rawInput: unknown;
+  try {
+    rawInput = await request.json();
+  } catch {
+    return jsonResponse({error: "Invalid image deletion request."}, {status: 400});
+  }
+  const input = parseDeleteImageRequest(rawInput);
+  if (!input) {
+    return jsonResponse({error: "Invalid image deletion request."}, {status: 400});
+  }
+
+  try {
+    const storedImageUrl = input.target
+      ? await new FeedDb(runtimeEnv, request).removeImageMetadata(input.target)
+      : null;
+    const keys = scheduleBestEffortMediaDeletion(
+      mediaBucket(runtimeEnv),
+      [input.imageUrl, storedImageUrl],
+      schedule,
+    );
+    return jsonResponse({deletedKeys: keys.length});
+  } catch (error) {
+    console.error(JSON.stringify({
+      error: error instanceof Error ? error.message : String(error),
+      message: "Failed to remove image metadata",
+    }));
+    return jsonResponse({error: "Failed to remove image metadata."}, {status: 500});
+  }
+}
+
+export const DELETE: APIRoute = async ({request}) =>
+  deleteAdminImage(request, env, waitUntil);

--- a/src/server/feed/FeedDb.ts
+++ b/src/server/feed/FeedDb.ts
@@ -15,6 +15,7 @@ import {
   type ResolvedItemPagination,
 } from "@/shared/ItemPagination";
 import FeedPublicJsonBuilder from "./FeedPublicJsonBuilder";
+import type {ImageMetadataTarget} from "@/types";
 
 /**
  * support url query parameters:
@@ -465,7 +466,8 @@ export default class FeedDb {
           data: JSON.stringify(settings[category]),
         }).run();
     } catch (error) {
-      console.log('Failed to upsert', error);
+      console.error('Failed to upsert setting', error);
+      throw error;
     }
     console.log('Done', res);
   }
@@ -488,7 +490,8 @@ export default class FeedDb {
       res = await this.getUpsertSql(
         'items', 'id', {id}, {...keyValuePairs}).run();
     } catch (error) {
-      console.log('Failed to upsert', error);
+      console.error('Failed to upsert item', error);
+      throw error;
     }
     console.log('Done!', res);
   }
@@ -506,6 +509,58 @@ export default class FeedDb {
     if (item) {
       await this._putItemToContent(item);
     }
+  }
+
+  async removeImageMetadata(
+    target: ImageMetadataTarget,
+  ): Promise<string | null> {
+    const timestamp = new Date().toISOString();
+    let select;
+    let update;
+    if (target.type === "channel") {
+      if (target.id) {
+        select = this.FEED_DB.prepare(
+          "SELECT json_extract(data, '$.image') AS image_url " +
+            "FROM channels WHERE id = ? LIMIT 1",
+        ).bind(target.id);
+        update = this.FEED_DB.prepare(
+          "UPDATE channels SET updated_at = ?, " +
+            "data = json_remove(data, '$.image') WHERE id = ?",
+        ).bind(timestamp, target.id);
+      } else {
+        select = this.FEED_DB.prepare(
+          "SELECT json_extract(data, '$.image') AS image_url " +
+            "FROM channels WHERE is_primary = 1 LIMIT 1",
+        );
+        update = this.FEED_DB.prepare(
+          "UPDATE channels SET updated_at = ?, " +
+            "data = json_remove(data, '$.image') WHERE is_primary = 1",
+        ).bind(timestamp);
+      }
+    } else if (target.type === "item") {
+      select = this.FEED_DB.prepare(
+        "SELECT json_extract(data, '$.image') AS image_url " +
+          "FROM items WHERE id = ? LIMIT 1",
+      ).bind(target.id);
+      update = this.FEED_DB.prepare(
+        "UPDATE items SET updated_at = ?, " +
+          "data = json_remove(data, '$.image') WHERE id = ?",
+      ).bind(timestamp, target.id);
+    } else {
+      const category = SETTINGS_CATEGORIES.WEB_GLOBAL_SETTINGS;
+      select = this.FEED_DB.prepare(
+        "SELECT json_extract(data, '$.favicon.url') AS image_url " +
+          "FROM settings WHERE category = ? LIMIT 1",
+      ).bind(category);
+      update = this.FEED_DB.prepare(
+        "UPDATE settings SET updated_at = ?, " +
+          "data = json_remove(data, '$.favicon') WHERE category = ?",
+      ).bind(timestamp, category);
+    }
+
+    const [selected] = await this.FEED_DB.batch([select, update]);
+    const imageUrl = selected.results[0]?.image_url;
+    return typeof imageUrl === "string" ? imageUrl : null;
   }
 
   async getPublicJsonData(

--- a/src/server/media/deletions.ts
+++ b/src/server/media/deletions.ts
@@ -1,0 +1,105 @@
+import {normalizeObjectKey} from "@/server/media/uploads";
+import type {
+  DeleteImageRequest,
+  ImageMetadataTarget,
+} from "@/types";
+
+const MANAGED_MEDIA_PREFIXES = new Set([
+  "development",
+  "preview",
+  "production",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseImageMetadataTarget(
+  value: unknown,
+): ImageMetadataTarget | null {
+  if (!isRecord(value) || typeof value.type !== "string") {
+    return null;
+  }
+  if (value.type === "favicon") {
+    return {type: "favicon"};
+  }
+  if (value.type === "channel") {
+    return typeof value.id === "string" && value.id.trim()
+      ? {id: value.id.trim(), type: "channel"}
+      : {type: "channel"};
+  }
+  if (
+    value.type === "item" &&
+    typeof value.id === "string" &&
+    value.id.trim()
+  ) {
+    return {id: value.id.trim(), type: value.type};
+  }
+  return null;
+}
+
+export function parseDeleteImageRequest(
+  value: unknown,
+): DeleteImageRequest | null {
+  if (
+    !isRecord(value) ||
+    typeof value.imageUrl !== "string" ||
+    !value.imageUrl.trim()
+  ) {
+    return null;
+  }
+  if (value.target === undefined) {
+    return {imageUrl: value.imageUrl.trim()};
+  }
+  const target = parseImageMetadataTarget(value.target);
+  return target
+    ? {imageUrl: value.imageUrl.trim(), target}
+    : null;
+}
+
+export function managedMediaObjectKey(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+
+  let path = value.trim();
+  if (/^[a-z][a-z\d+.-]*:\/\//iu.test(path)) {
+    return null;
+  }
+  path = path.replace(/^\/+media\//u, "");
+  const key = normalizeObjectKey(path);
+  const prefix = key?.split("/", 1)[0];
+  if (!key || !prefix || !MANAGED_MEDIA_PREFIXES.has(prefix)) {
+    return null;
+  }
+  return key;
+}
+
+export function scheduleBestEffortMediaDeletion(
+  bucket: Pick<R2Bucket, "delete"> | null,
+  imageUrls: unknown[],
+  schedule: (promise: Promise<unknown>) => void,
+): string[] {
+  if (!bucket) {
+    return [];
+  }
+  const keys = [...new Set(
+    imageUrls
+      .map((imageUrl) => managedMediaObjectKey(imageUrl))
+      .filter((key): key is string => Boolean(key)),
+  )];
+  if (keys.length === 0) {
+    return [];
+  }
+
+  schedule(
+    bucket.delete(keys).catch((error: unknown) => {
+      console.error(JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+        keyCount: keys.length,
+        message: "Best-effort R2 image deletion failed",
+      }));
+    }),
+  );
+  return keys;
+}

--- a/src/server/media/storage.ts
+++ b/src/server/media/storage.ts
@@ -5,7 +5,7 @@ function isR2Bucket(value: unknown): value is R2Bucket {
   if (!value || typeof value !== "object") {
     return false;
   }
-  return ["get", "head", "put"].every(
+  return ["delete", "get", "head", "put"].every(
     (method) => typeof Reflect.get(value, method) === "function",
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface FeedItem extends JsonObject {
 
 export interface FeedContent extends JsonObject {
   channel?: JsonObject;
+  deleteImageUrls?: string[];
   item?: FeedItem;
   items?: FeedItem[];
   items_next_cursor?: number | string;
@@ -93,6 +94,16 @@ export interface UploadRequest {
   key: string;
   size?: number;
   type?: string;
+}
+
+export type ImageMetadataTarget =
+  | {id?: string; type: "channel"}
+  | {id: string; type: "item"}
+  | {type: "favicon"};
+
+export interface DeleteImageRequest {
+  imageUrl: string;
+  target?: ImageMetadataTarget;
 }
 
 export interface SignedUpload {

--- a/tests/unit/client/image-upload-utils.test.ts
+++ b/tests/unit/client/image-upload-utils.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from "vitest";
+
+import {queueReplacedImageUrl} from "@/client/ImageUploadUtils";
+
+describe("image upload utilities", () => {
+  it("queues each replaced image once", () => {
+    const original = ["production/images/original.png"];
+
+    expect(queueReplacedImageUrl(original, " production/images/second.png "))
+      .toEqual([
+        "production/images/original.png",
+        "production/images/second.png",
+      ]);
+    expect(queueReplacedImageUrl(original, original[0])).toBe(original);
+    expect(queueReplacedImageUrl(original, undefined)).toBe(original);
+  });
+});

--- a/tests/unit/components/admin-image-uploader.test.ts
+++ b/tests/unit/components/admin-image-uploader.test.ts
@@ -1,0 +1,177 @@
+import React from "react";
+import {renderToStaticMarkup} from "react-dom/server";
+import {beforeEach, describe, expect, it, vi} from "vitest";
+
+import Requests from "@/client/requests";
+import AdminFileUploader from "@/components/admin/shared/AdminFileUploader";
+import AdminImageUploaderApp from "@/components/admin/shared/AdminImageUploaderApp";
+import {AlertDialog} from "@/components/ui/alert-dialog";
+import {DropdownMenu} from "@/components/ui/dropdown-menu";
+
+vi.mock("@/client/ToastUtils", () => ({showToast: vi.fn()}));
+
+function uploaderProps(overrides: Record<string, unknown> = {}) {
+  return {
+    currentImageUrl: "production/images/channel.png",
+    feed: {settings: {webGlobalSettings: {publicBucketUrl: "/media/"}}},
+    imageMetadataTarget: {id: "channel-1", type: "channel"},
+    mediaStorageReady: true,
+    onImageDeleted: vi.fn(),
+    onImageUploaded: vi.fn(),
+    publicBucketUrl: "/media/",
+    ...overrides,
+  };
+}
+
+function useSynchronousState(component: AdminImageUploaderApp) {
+  component.setState = ((update: unknown, callback?: () => void) => {
+    const nextState = typeof update === "function"
+      ? update(component.state, component.props)
+      : update;
+    component.state = {...component.state, ...nextState};
+    callback?.();
+  }) as typeof component.setState;
+}
+
+function textContent(value: React.ReactNode): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map(textContent).join(" ");
+  }
+  if (React.isValidElement<{children?: React.ReactNode}>(value)) {
+    return textContent(value.props.children);
+  }
+  return "";
+}
+
+function findElement(
+  value: React.ReactNode,
+  predicate: (element: React.ReactElement<any>) => boolean,
+): React.ReactElement<any> | undefined {
+  for (const child of React.Children.toArray(value)) {
+    if (!React.isValidElement<any>(child)) {
+      continue;
+    }
+    if (predicate(child)) {
+      return child;
+    }
+    const nested = findElement(child.props.children, predicate);
+    if (nested) {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+describe("admin image uploader", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubGlobal("window", {location: {hostname: "localhost"}});
+  });
+
+  it("keeps the direct uploader for an empty image", () => {
+    const component = new AdminImageUploaderApp(uploaderProps({
+      currentImageUrl: undefined,
+    }));
+    const tree = component.render();
+    const firstChild = React.Children.toArray(tree.props.children)[0] as
+      React.ReactElement;
+
+    expect(firstChild.type).toBe(AdminFileUploader);
+    expect(renderToStaticMarkup(firstChild)).toContain(
+      "Click or drag here to upload image",
+    );
+  });
+
+  it("replaces the preview link with image actions", () => {
+    const component = new AdminImageUploaderApp(uploaderProps());
+    const tree = component.render();
+    const fragment = React.Children.toArray(tree.props.children)[0] as
+      React.ReactElement<{children: React.ReactNode}>;
+    const menu = React.Children.toArray(fragment.props.children).find(
+      (child) => React.isValidElement(child) && child.type === DropdownMenu,
+    );
+
+    expect(menu).toBeTruthy();
+    expect(textContent(menu)).toContain("Replace");
+    expect(textContent(menu)).toContain("Preview");
+    expect(textContent(menu)).toContain("Delete");
+    expect(textContent(tree)).not.toContain("preview image");
+  });
+
+  it("removes persisted metadata through the delete endpoint", async () => {
+    const props = uploaderProps();
+    const component = new AdminImageUploaderApp(props);
+    useSynchronousState(component);
+    const deleteImage = vi.spyOn(Requests, "deleteImage")
+      .mockResolvedValue({} as Awaited<ReturnType<typeof Requests.deleteImage>>);
+
+    await component.onDeleteImage();
+
+    expect(deleteImage).toHaveBeenCalledWith(
+      "production/images/channel.png",
+      {id: "channel-1", type: "channel"},
+    );
+    expect(props.onImageDeleted).toHaveBeenCalledOnce();
+    expect(component.state.currentImageUrl).toBeNull();
+  });
+
+  it("requires confirmation before deleting an image", () => {
+    const component = new AdminImageUploaderApp(uploaderProps());
+    useSynchronousState(component);
+    const deleteImage = vi.spyOn(Requests, "deleteImage");
+    const initialTree = component.render();
+    const deleteMenuItem = findElement(
+      initialTree,
+      (element) => typeof element.props.onClick === "function" &&
+        textContent(element).trim() === "Delete",
+    );
+
+    expect(deleteMenuItem).toBeTruthy();
+    deleteMenuItem!.props.onClick();
+
+    const confirmation = findElement(
+      component.render(),
+      (element) => element.type === AlertDialog,
+    );
+    expect(deleteImage).not.toHaveBeenCalled();
+    expect(component.state.showDeleteConfirm).toBe(true);
+    expect(confirmation?.props.open).toBe(true);
+    expect(textContent(confirmation)).toContain("Delete this image?");
+    expect(textContent(confirmation)).toContain("Delete image");
+  });
+
+  it("reports the replaced image after a successful upload", () => {
+    const props = uploaderProps();
+    const component = new AdminImageUploaderApp(props);
+    useSynchronousState(component);
+    const blob = new Blob(["image"], {type: "image/png"});
+    component.state = {
+      ...component.state,
+      cdnFilename: "images/replacement.png",
+      cropper: {
+        destroy: vi.fn(),
+        disable: vi.fn(),
+        getCroppedCanvas: () => ({
+          toBlob: (callback: (value: Blob) => void) => callback(blob),
+        }),
+      },
+    };
+    vi.spyOn(Requests, "upload").mockImplementation((
+      _file,
+      _filename,
+      _onProgress,
+      onUploaded,
+    ) => onUploaded("production/images/replacement.png"));
+
+    component.onFileUploadToR2();
+
+    expect(props.onImageUploaded).toHaveBeenCalledWith(
+      "production/images/replacement.png",
+      "image/png",
+      "production/images/channel.png",
+    );
+  });
+});

--- a/tests/unit/components/admin-ui-controls.test.ts
+++ b/tests/unit/components/admin-ui-controls.test.ts
@@ -4,6 +4,7 @@ import {describe, expect, it, vi} from "vitest";
 
 import AdminCopyableUrl from "@/components/admin/shared/AdminCopyableUrl";
 import AdminDialog from "@/components/admin/shared/AdminDialog";
+import AdminImagePreviewDialog from "@/components/admin/shared/AdminImagePreviewDialog";
 import AdminPublicAccess, {
   publicAccessItems,
 } from "@/components/admin/shared/AdminPublicAccess";
@@ -128,6 +129,39 @@ describe("admin UI controls", () => {
     dialog.props.onOpenChange(false, eventDetails);
     expect(eventDetails.cancel).toHaveBeenCalledOnce();
     expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("renders the reusable full-screen image preview controls", () => {
+    const onOpenChange = vi.fn();
+    const dialog = AdminImagePreviewDialog({
+      imageUrl: "https://media.example.com/production/images/item.png",
+      onOpenChange,
+      open: true,
+    });
+    const content = dialog.props.children as React.ReactElement<any>;
+    const children = React.Children.toArray(
+      content.props.children,
+    ) as React.ReactElement<any>[];
+    const controls = children[2]!;
+    const [openLink, closeButton] = React.Children.toArray(
+      controls.props.children,
+    ) as React.ReactElement<any>[];
+    const image = children[3]!;
+
+    expect(dialog.props.open).toBe(true);
+    expect(content.props.showCloseButton).toBe(false);
+    expect(content.props.className).toContain("h-dvh");
+    expect(openLink!.props.href).toBe(
+      "https://media.example.com/production/images/item.png",
+    );
+    expect(openLink!.props.target).toBe("_blank");
+    expect(openLink!.props.className).toContain("!text-white");
+    expect(openLink!.props.className).toContain("hover:bg-white/15");
+    expect(closeButton!.props.children).toContain("Close");
+    const closeControl = closeButton!.props.render as React.ReactElement<any>;
+    expect(closeControl.props.className).toContain("!text-white");
+    expect(closeControl.props.className).toContain("hover:bg-white/15");
+    expect(image.props.className).toContain("object-contain");
   });
 
   it("associates a checked switch with its visible label", () => {

--- a/tests/unit/server/media-deletions.test.ts
+++ b/tests/unit/server/media-deletions.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it, vi} from "vitest";
+
+import {
+  managedMediaObjectKey,
+  parseDeleteImageRequest,
+  scheduleBestEffortMediaDeletion,
+} from "@/server/media/deletions";
+
+describe("managed image deletion", () => {
+  it("accepts only supported metadata targets", () => {
+    expect(parseDeleteImageRequest({
+      imageUrl: "production/images/item.png",
+      target: {id: "item-1", type: "item"},
+    })).toEqual({
+      imageUrl: "production/images/item.png",
+      target: {id: "item-1", type: "item"},
+    });
+    expect(parseDeleteImageRequest({
+      imageUrl: "production/images/favicon.png",
+      target: {type: "favicon"},
+    })).toEqual({
+      imageUrl: "production/images/favicon.png",
+      target: {type: "favicon"},
+    });
+    expect(parseDeleteImageRequest({
+      imageUrl: "/assets/default/channel-image.png",
+      target: {type: "channel"},
+    })).toEqual({
+      imageUrl: "/assets/default/channel-image.png",
+      target: {type: "channel"},
+    });
+    expect(parseDeleteImageRequest({
+      imageUrl: "production/images/item.png",
+      target: {type: "item"},
+    })).toBeNull();
+    expect(parseDeleteImageRequest({imageUrl: ""})).toBeNull();
+  });
+
+  it("resolves only project-managed R2 object URLs", () => {
+    expect(managedMediaObjectKey("production/images/channel.png")).toBe(
+      "production/images/channel.png",
+    );
+    expect(managedMediaObjectKey(
+      "https://media.example.com/preview/images/item.png",
+    )).toBeNull();
+    expect(managedMediaObjectKey(
+      "/media/development/images/favicon.png",
+    )).toBe("development/images/favicon.png");
+    expect(managedMediaObjectKey("/assets/default/favicon.png")).toBeNull();
+    expect(managedMediaObjectKey("images/unscoped.png")).toBeNull();
+  });
+
+  it("deduplicates keys and schedules deletion without awaiting it", async () => {
+    const deleteObject = vi.fn().mockResolvedValue(undefined);
+    const scheduled: Promise<unknown>[] = [];
+    const keys = scheduleBestEffortMediaDeletion(
+      {delete: deleteObject},
+      [
+        "production/images/item.png",
+        "/media/production/images/item.png",
+        "/assets/default/channel-image.png",
+      ],
+      (promise) => scheduled.push(promise),
+    );
+
+    expect(keys).toEqual(["production/images/item.png"]);
+    expect(deleteObject).toHaveBeenCalledWith(["production/images/item.png"]);
+    expect(scheduled).toHaveLength(1);
+    await Promise.all(scheduled);
+  });
+});

--- a/tests/worker/media.test.ts
+++ b/tests/worker/media.test.ts
@@ -7,6 +7,8 @@ import {
   OPTIONS as uploadOptions,
   PUT as uploadMedia,
 } from "../../src/pages/media-upload/[...key]";
+import {deleteAdminImage} from "../../src/pages/[adminPath]/ajax/r2-ops";
+import {updateAdminFeed} from "../../src/pages/[adminPath]/ajax/feed";
 import {getMediaResponse} from "@/server/media/media";
 import {
   createSignedUpload,
@@ -134,6 +136,177 @@ describe("signed Worker uploads", () => {
     const preflight = await uploadOptions({} as any);
     expect(preflight.status).toBe(204);
     expect(preflight.headers.get("access-control-allow-origin")).toBe("*");
+  });
+});
+
+describe("replacement image cleanup", () => {
+  it("deletes the prior image only after item metadata saves", async () => {
+    const suffix = crypto.randomUUID();
+    const itemId = `replacement-${suffix}`;
+    const oldKey = `production/images/${suffix}-old.png`;
+    const newKey = `production/images/${suffix}-new.png`;
+    await env.MEDIA_BUCKET.put(oldKey, "old");
+    const scheduled: Promise<unknown>[] = [];
+
+    const response = await updateAdminFeed(
+      new Request("https://feed.example.com/admin/ajax/feed/", {
+        body: JSON.stringify({
+          deleteImageUrls: [oldKey],
+          item: {
+            id: itemId,
+            image: newKey,
+            pubDateMs: Date.now(),
+            status: 1,
+            title: "Replacement image",
+          },
+        }),
+        headers: {"content-type": "application/json"},
+        method: "POST",
+      }),
+      env,
+      (promise) => scheduled.push(promise),
+    );
+
+    expect(response.status).toBe(200);
+    expect(scheduled).toHaveLength(1);
+    const storedItem = await env.FEED_DB.prepare(
+      "SELECT json_extract(data, '$.image') AS image_url FROM items " +
+        "WHERE id = ? LIMIT 1",
+    ).bind(itemId).first<{image_url: string}>();
+    expect(storedItem?.image_url).toBe(newKey);
+    await Promise.all(scheduled);
+    expect(await env.MEDIA_BUCKET.head(oldKey)).toBeNull();
+  });
+
+  it("does not schedule cleanup when metadata cannot be saved", async () => {
+    const oldKey = `production/images/${crypto.randomUUID()}-old.png`;
+    await env.MEDIA_BUCKET.put(oldKey, "old");
+    const scheduled: Promise<unknown>[] = [];
+
+    await expect(updateAdminFeed(
+      new Request("https://feed.example.com/admin/ajax/feed/", {
+        body: JSON.stringify({
+          deleteImageUrls: [oldKey],
+          item: {id: "invalid-item", status: 1},
+        }),
+        headers: {"content-type": "application/json"},
+        method: "POST",
+      }),
+      env,
+      (promise) => scheduled.push(promise),
+    )).rejects.toThrow();
+
+    expect(scheduled).toHaveLength(0);
+    expect(await env.MEDIA_BUCKET.head(oldKey)).not.toBeNull();
+  });
+});
+
+describe("admin image deletion", () => {
+  async function deleteImage(input: unknown) {
+    const scheduled: Promise<unknown>[] = [];
+    const response = await deleteAdminImage(
+      new Request("https://feed.example.com/admin/ajax/r2-ops/", {
+        body: JSON.stringify(input),
+        method: "DELETE",
+      }),
+      env,
+      (promise) => scheduled.push(promise),
+    );
+    return {
+      response,
+      waitForDeletion: () => Promise.all(scheduled),
+    };
+  }
+
+  it("removes saved metadata before deleting channel, item, and favicon objects", async () => {
+    const request = new Request("https://feed.example.com/admin/");
+    const database = new FeedDb(env, request);
+    await database.getContent();
+    const content = await database.getContent();
+    const channelKey = "production/images/channel-delete.png";
+    const itemKey = "production/images/item-delete.png";
+    const faviconKey = "production/images/favicon-delete.png";
+    await Promise.all([
+      env.MEDIA_BUCKET.put(channelKey, "channel"),
+      env.MEDIA_BUCKET.put(itemKey, "item"),
+      env.MEDIA_BUCKET.put(faviconKey, "favicon"),
+    ]);
+    await database.putContent({
+      channel: {...content.channel, image: channelKey},
+      item: {
+        id: "delete-image-item",
+        image: itemKey,
+        pubDateMs: Date.now(),
+        status: 1,
+        title: "Delete this image",
+      },
+      settings: {
+        webGlobalSettings: {
+          ...content.settings.webGlobalSettings,
+          favicon: {contentType: "image/png", url: faviconKey},
+        },
+      },
+    });
+
+    const channelDeletion = await deleteImage({
+      imageUrl: channelKey,
+      target: {type: "channel"},
+    });
+    expect(channelDeletion.response.status).toBe(200);
+    expect((await database.getContent()).channel.image).toBeUndefined();
+    await channelDeletion.waitForDeletion();
+    expect(await env.MEDIA_BUCKET.head(channelKey)).toBeNull();
+
+    const itemDeletion = await deleteImage({
+      imageUrl: itemKey,
+      target: {id: "delete-image-item", type: "item"},
+    });
+    expect(itemDeletion.response.status).toBe(200);
+    const itemRow = await env.FEED_DB.prepare(
+      "SELECT data FROM items WHERE id = ?",
+    ).bind("delete-image-item").first<{data: string}>();
+    expect(JSON.parse(itemRow?.data ?? "{}").image).toBeUndefined();
+    await itemDeletion.waitForDeletion();
+    expect(await env.MEDIA_BUCKET.head(itemKey)).toBeNull();
+
+    const faviconDeletion = await deleteImage({
+      imageUrl: faviconKey,
+      target: {type: "favicon"},
+    });
+    expect(faviconDeletion.response.status).toBe(200);
+    expect(
+      (await database.getContent()).settings.webGlobalSettings.favicon,
+    ).toBeUndefined();
+    await faviconDeletion.waitForDeletion();
+    expect(await env.MEDIA_BUCKET.head(faviconKey)).toBeNull();
+  });
+
+  it("deletes an unsaved new-item upload without creating item metadata", async () => {
+    const key = "development/images/unsaved-item.png";
+    await env.MEDIA_BUCKET.put(key, "item");
+    const countBefore = await env.FEED_DB.prepare(
+      "SELECT COUNT(*) AS count FROM items",
+    ).first<{count: number}>();
+
+    const deletion = await deleteImage({imageUrl: key});
+    expect(deletion.response.status).toBe(200);
+    const count = await env.FEED_DB.prepare(
+      "SELECT COUNT(*) AS count FROM items",
+    ).first<{count: number}>();
+    expect(count?.count).toBe(countBefore?.count);
+    await deletion.waitForDeletion();
+    expect(await env.MEDIA_BUCKET.head(key)).toBeNull();
+  });
+
+  it("rejects malformed image deletion requests", async () => {
+    const deletion = await deleteImage({
+      imageUrl: "production/images/item.png",
+      target: {type: "item"},
+    });
+    expect(deletion.response.status).toBe(400);
+    await expect(deletion.response.json()).resolves.toMatchObject({
+      error: "Invalid image deletion request.",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- replace the separate image preview link with an image action menu for channel images, item images, and favicons
- add Replace, full-screen Preview, and confirmed Delete actions through reusable admin components
- remove deleted image metadata and schedule best-effort R2 cleanup without extending the user-facing request
- queue replaced image objects and delete them only after the new channel, item, or favicon metadata saves successfully
- keep the original object queued when metadata saving fails so a later retry can clean it up

This reduces visual clutter, adds missing image deletion support, and prevents replaced uploads from accumulating in R2.

## Related issue

N/A.

## Testing

- [x] `yarn check`
- [x] `git diff --check`
- [x] focused component and utility tests: 21 passed
- [x] focused Worker media tests: 11 passed

## Screenshots

The interaction follows the screenshots supplied during development. No after screenshot is attached to this draft; reusable component rendering and action states are covered by focused tests.

## Risks

R2 deletion is intentionally best effort. Metadata updates complete first, while object deletion runs through the Worker execution context and logs failures without breaking the saved admin change. Only project-managed development, preview, and production object paths are eligible for deletion.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed, or no documentation change was required.
- [x] No secrets, private configuration, production data, or generated files are included.