### PR TITLE
Add headless access control mode

### DIFF
--- a/src/components/admin/settings/AccessSettingsApp/index.tsx
+++ b/src/components/admin/settings/AccessSettingsApp/index.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import AdminRadioGroup from "@/components/admin/shared/AdminRadioGroup";
 import SettingsBase from '../SettingsBase';
-import {SETTINGS_CATEGORIES} from "@/shared/Constants";
+import {
+  CHANNEL_STATUSES,
+  CHANNEL_STATUSES_DICT,
+  SETTINGS_CATEGORIES,
+} from "@/shared/Constants";
+import type {AccessPolicy} from "@/types";
 
 export default class AccessSettingsApp extends React.Component<any, any> {
   constructor(props: any) {
@@ -21,7 +26,7 @@ export default class AccessSettingsApp extends React.Component<any, any> {
     };
   }
 
-  onUpdateAccess(currentPolicy: string) {
+  onUpdateAccess(currentPolicy: AccessPolicy) {
     const access = {...this.state.access, currentPolicy};
     this.setState({access}, () => {
       this.props.setChanged();
@@ -46,18 +51,23 @@ export default class AccessSettingsApp extends React.Component<any, any> {
         disabled={submitting}
         name="access-policy"
         value={access.currentPolicy}
-        onValueChange={(value) => this.onUpdateAccess(value)}
+        onValueChange={(value) => this.onUpdateAccess(value as AccessPolicy)}
         variant="cards"
         options={[
           {
-            value: "public",
-            label: "Public",
-            description: "Make the entire site publicly accessible, including all non-Admin web pages, rss feed and json feed.",
+            value: CHANNEL_STATUSES.PUBLIC,
+            label: CHANNEL_STATUSES_DICT[CHANNEL_STATUSES.PUBLIC].name,
+            description: CHANNEL_STATUSES_DICT[CHANNEL_STATUSES.PUBLIC].description,
           },
           {
-            value: "offline",
-            label: "Offline",
-            description: "Make the entire site offline. All non-Admin web pages, rss feed and json feed will be 404-ed.",
+            value: CHANNEL_STATUSES.HEADLESS,
+            label: CHANNEL_STATUSES_DICT[CHANNEL_STATUSES.HEADLESS].name,
+            description: CHANNEL_STATUSES_DICT[CHANNEL_STATUSES.HEADLESS].description,
+          },
+          {
+            value: CHANNEL_STATUSES.OFFLINE,
+            label: CHANNEL_STATUSES_DICT[CHANNEL_STATUSES.OFFLINE].name,
+            description: CHANNEL_STATUSES_DICT[CHANNEL_STATUSES.OFFLINE].description,
           },
         ]}
       />

--- a/src/pages/i/[slug]/index.astro
+++ b/src/pages/i/[slug]/index.astro
@@ -5,7 +5,7 @@ import {CODE_TYPES, STATUSES} from "@/shared/Constants";
 import {getIdFromSlug, PUBLIC_URLS} from "@/shared/StringUtils";
 import Theme from "@/server/themes/Theme";
 import PublicLayout from "../../../layouts/PublicLayout.astro";
-import {loadPublishedFeed, shouldHidePublicFeed} from "@/server/feed/feed";
+import {loadPublishedFeed, shouldHidePublicWeb} from "@/server/feed/feed";
 
 const itemId = getIdFromSlug(Astro.params.slug ?? "");
 if (!itemId) {
@@ -22,14 +22,14 @@ const loaded = await loadPublishedFeed(env, Astro.request, {
   },
 });
 const item = loaded.publicFeed.items[0];
-const offline = shouldHidePublicFeed(loaded.content);
-if (!offline && !loaded.onboarding.requiredOk) {
+const hidePublicWeb = shouldHidePublicWeb(loaded.content);
+if (!hidePublicWeb && !loaded.onboarding.requiredOk) {
   return Astro.redirect(
     new URL(`/${env.MICROFEED_ADMIN_PATH || "admin"}/`, Astro.url),
     302,
   );
 }
-const unavailable = !item || offline;
+const unavailable = !item || hidePublicWeb;
 if (unavailable) {
   Astro.response.status = 404;
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,10 +4,10 @@ import {env} from "cloudflare:workers";
 import {CODE_TYPES} from "@/shared/Constants";
 import Theme from "@/server/themes/Theme";
 import PublicLayout from "../layouts/PublicLayout.astro";
-import {loadPublishedFeed, shouldHidePublicFeed} from "@/server/feed/feed";
+import {loadPublishedFeed, shouldHidePublicWeb} from "@/server/feed/feed";
 
 const loaded = await loadPublishedFeed(env, Astro.request);
-const unavailable = shouldHidePublicFeed(loaded.content);
+const unavailable = shouldHidePublicWeb(loaded.content);
 if (!unavailable && !loaded.onboarding.requiredOk) {
   return Astro.redirect(
     new URL(`/${env.MICROFEED_ADMIN_PATH || "admin"}/`, Astro.url),

--- a/src/server/feed/feed.ts
+++ b/src/server/feed/feed.ts
@@ -1,5 +1,5 @@
 import OnboardingChecker from "@/server/feed/OnboardingUtils";
-import {STATUSES} from "@/shared/Constants";
+import {CHANNEL_STATUSES, STATUSES} from "@/shared/Constants";
 import FeedCrudManager from "@/server/feed/FeedCrudManager";
 import FeedDb, {getFetchItemsParams} from "@/server/feed/FeedDb";
 import {mediaBucket} from "@/server/media/storage";
@@ -89,6 +89,12 @@ export function createFeedCrud(
   return new FeedCrudManager(content, database, request);
 }
 
-export function shouldHidePublicFeed(content: FeedContent): boolean {
-  return content.settings?.access?.currentPolicy === "offline";
+export function isPublicFeedOffline(content: FeedContent): boolean {
+  return content.settings?.access?.currentPolicy === CHANNEL_STATUSES.OFFLINE;
+}
+
+export function shouldHidePublicWeb(content: FeedContent): boolean {
+  const currentPolicy = content.settings?.access?.currentPolicy;
+  return currentPolicy === CHANNEL_STATUSES.HEADLESS ||
+    currentPolicy === CHANNEL_STATUSES.OFFLINE;
 }

--- a/src/server/feed/responses.ts
+++ b/src/server/feed/responses.ts
@@ -6,11 +6,15 @@ import {STATUSES} from "@/shared/Constants";
 import FeedPublicRssBuilder from "@/server/feed/FeedPublicRssBuilder";
 import Theme from "@/server/themes/Theme";
 import type {FeedContent} from "@/types";
-import {loadPublishedFeed, shouldHidePublicFeed} from "./feed";
+import {
+  isPublicFeedOffline,
+  loadPublishedFeed,
+  shouldHidePublicWeb,
+} from "./feed";
 import {jsonResponse} from "@/server/http";
 
 function feedUnavailable(content: FeedContent): Response | null {
-  if (shouldHidePublicFeed(content)) {
+  if (isPublicFeedOffline(content)) {
     return new Response("Not Found", {status: 404, statusText: "Not Found"});
   }
   return null;
@@ -136,9 +140,8 @@ export async function sitemapResponse(request: Request): Promise<Response> {
   const loaded = await loadPublishedFeed(env, request, {
     limit: -1,
   });
-  const unavailable = feedUnavailable(loaded.content);
-  if (unavailable) {
-    return unavailable;
+  if (shouldHidePublicWeb(loaded.content)) {
+    return new Response("Not Found", {status: 404, statusText: "Not Found"});
   }
   const redirect = onboardingRedirect(request, loaded.onboarding.requiredOk);
   if (redirect) {

--- a/src/shared/Constants.ts
+++ b/src/shared/Constants.ts
@@ -203,14 +203,19 @@ export const NAV_ITEMS_DICT = {
 
 export const CHANNEL_STATUSES = {
   PUBLIC: 'public',
+  HEADLESS: 'headless',
   OFFLINE: 'offline',
   PASSCODE: 'passcode',
-};
+} as const;
 
 export const CHANNEL_STATUSES_DICT = {
   [CHANNEL_STATUSES.PUBLIC]: {
     name: 'Public',
     description: 'Make the entire site publicly accessible, including all non-Admin web pages, rss feed and json feed.',
+  },
+  [CHANNEL_STATUSES.HEADLESS]: {
+    name: 'Headless',
+    description: 'Keep RSS, JSON Feed, APIs, and media available, but return 404 for the website home page, item pages, and sitemap.xml.',
   },
   [CHANNEL_STATUSES.OFFLINE]: {
     name: 'Offline',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
 export type JsonObject = Record<string, unknown>;
 
+export type AccessPolicy = "public" | "headless" | "passcode" | "offline";
+
 export interface FeedSettings {
   access?: {
-    currentPolicy?: "public" | "passcode" | "offline";
+    currentPolicy?: AccessPolicy;
   };
   apiSettings?: {
     apps?: Array<{

--- a/tests/unit/components/admin-access-settings.test.ts
+++ b/tests/unit/components/admin-access-settings.test.ts
@@ -34,12 +34,15 @@ function installSynchronousSetState(app: AccessSettingsApp) {
 }
 
 describe("access control settings", () => {
-  it("omits the manual Update action", () => {
+  it("shows Public, Headless, and Offline without a manual Update action", () => {
     const output = renderToStaticMarkup(
       React.createElement(AccessSettingsApp, props()),
     );
 
     expect(output).toContain("Access control");
+    expect(output.indexOf("Public")).toBeLessThan(output.indexOf("Headless"));
+    expect(output.indexOf("Headless")).toBeLessThan(output.indexOf("Offline"));
+    expect(output).toContain("Keep RSS, JSON Feed, APIs, and media available");
     expect(output).not.toContain('data-slot="card-action"');
     expect(output).not.toContain(">Update</button>");
   });
@@ -54,15 +57,15 @@ describe("access control settings", () => {
     const app = new AccessSettingsApp(settingsProps);
     installSynchronousSetState(app);
 
-    app.onUpdateAccess("offline");
+    app.onUpdateAccess("headless");
     await Promise.resolve();
 
-    expect(app.state.access.currentPolicy).toBe("offline");
+    expect(app.state.access.currentPolicy).toBe("headless");
     expect(settingsProps.setChanged).toHaveBeenCalledOnce();
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({preventDefault: expect.any(Function)}),
       SETTINGS_CATEGORIES.ACCESS,
-      {currentPolicy: "offline"},
+      {currentPolicy: "headless"},
     );
   });
 

--- a/tests/unit/server/feed-access.test.ts
+++ b/tests/unit/server/feed-access.test.ts
@@ -1,0 +1,30 @@
+import {describe, expect, it} from "vitest";
+
+import {
+  isPublicFeedOffline,
+  shouldHidePublicWeb,
+} from "@/server/feed/feed";
+import type {AccessPolicy, FeedContent} from "@/types";
+
+function contentWithPolicy(currentPolicy?: AccessPolicy): FeedContent {
+  return currentPolicy
+    ? {settings: {access: {currentPolicy}}}
+    : {settings: {}};
+}
+
+describe("public access policies", () => {
+  it.each([
+    [undefined, false, false],
+    ["public", false, false],
+    ["headless", false, true],
+    ["offline", true, true],
+  ] as const)(
+    "resolves %s feed and web visibility",
+    (currentPolicy, feedOffline, webHidden) => {
+      const content = contentWithPolicy(currentPolicy);
+
+      expect(isPublicFeedOffline(content)).toBe(feedOffline);
+      expect(shouldHidePublicWeb(content)).toBe(webHidden);
+    },
+  );
+});

--- a/tests/worker/media.test.ts
+++ b/tests/worker/media.test.ts
@@ -15,7 +15,11 @@ import {
   UPLOAD_TTL_SECONDS,
   verifySignedUpload,
 } from "@/server/media/uploads";
-import {jsonFeedResponse} from "@/server/feed/responses";
+import {
+  jsonFeedResponse,
+  rssFeedResponse,
+  sitemapResponse,
+} from "@/server/feed/responses";
 
 describe("signed Worker uploads", () => {
   it("signs a 15-minute upload and rejects expiry or tampering", async () => {
@@ -433,15 +437,85 @@ describe("R2 media responses", () => {
     expect(rows?.count).toBe(1);
   });
 
-  it("preserves offline access rules for public feed routes", async () => {
-    const request = new Request("https://feed.example.com/json/");
+  it("keeps feeds and their web-link metadata available in headless mode", async () => {
+    const origin = "https://feed.example.com";
+    const itemId = "Headless001";
+    const request = new Request(`${origin}/json/`);
     const database = new FeedDb(env, request);
-    const content = await database.getContent();
-    content.settings.access.currentPolicy = "offline";
-    await database.putContent(content);
-    const response = await jsonFeedResponse(
-      request,
-    );
-    expect(response.status).toBe(404);
+    await database.getContent();
+    await database.putContent({
+      item: {
+        id: itemId,
+        pubDateMs: Date.now(),
+        status: 1,
+        title: "Headless item",
+      },
+      settings: {access: {currentPolicy: "headless"}},
+    });
+
+    try {
+      const jsonResponse = await jsonFeedResponse(request);
+      expect(jsonResponse.status).toBe(200);
+      const json = await jsonResponse.json() as {
+        home_page_url?: string;
+        items: Array<{id?: string; _microfeed?: {web_url?: string}}>;
+      };
+      const item = json.items.find(({id}) => id === itemId);
+      expect(json.home_page_url).toBe(origin);
+      expect(item?._microfeed?.web_url).toContain(`/i/headless-item-${itemId}/`);
+
+      const rssResponse = await rssFeedResponse(
+        new Request(`${origin}/rss/`),
+      );
+      expect(rssResponse.status).toBe(200);
+      const rss = await rssResponse.text();
+      expect(rss).toContain(`${origin}/`);
+      expect(rss).toContain(`/i/headless-item-${itemId}/`);
+
+      const itemJsonResponse = await jsonFeedResponse(
+        new Request(`${origin}/i/${itemId}/json/`),
+        true,
+        itemId,
+      );
+      expect(itemJsonResponse.status).toBe(200);
+      const itemRssResponse = await rssFeedResponse(
+        new Request(`${origin}/i/${itemId}/rss/`),
+        itemId,
+      );
+      expect(itemRssResponse.status).toBe(200);
+
+      const sitemap = await sitemapResponse(
+        new Request(`${origin}/sitemap.xml`),
+      );
+      expect(sitemap.status).toBe(404);
+    } finally {
+      await database.putContent({
+        settings: {access: {currentPolicy: "public"}},
+      });
+    }
+  });
+
+  it("preserves offline access rules for public routes", async () => {
+    const origin = "https://feed.example.com";
+    const request = new Request(`${origin}/json/`);
+    const database = new FeedDb(env, request);
+    await database.getContent();
+    await database.putContent({
+      settings: {access: {currentPolicy: "offline"}},
+    });
+
+    try {
+      expect((await jsonFeedResponse(request)).status).toBe(404);
+      expect((await rssFeedResponse(
+        new Request(`${origin}/rss/`),
+      )).status).toBe(404);
+      expect((await sitemapResponse(
+        new Request(`${origin}/sitemap.xml`),
+      )).status).toBe(404);
+    } finally {
+      await database.putContent({
+        settings: {access: {currentPolicy: "public"}},
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- add a Headless access policy between Public and Offline in admin settings
- persist the policy as `currentPolicy: "headless"` through the existing D1 settings JSON with no migration
- return 404 for the public home page, item HTML pages, and sitemap while keeping RSS, JSON Feed, per-item feeds, APIs, and media available
- preserve existing home and item web-link metadata in RSS and JSON responses
- split web visibility from the existing Offline feed-availability check

This lets microfeed run as a feed/API-first CMS without exposing generated web pages.

## Related issue

N/A.

## Testing

- [x] `yarn check`
- [x] `git diff --check`
- [x] focused UI and access-policy unit tests: 7 passed
- [x] focused Worker route tests: 12 passed

## Screenshots

No screenshot attached. The visible change is one additional Headless card between Public and Offline in Settings / Access control.

## Risks

No migration is required. Existing Public and Offline values keep their behavior. Headless intentionally leaves feed web-link metadata unchanged even though those HTML URLs return 404.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed, or no documentation change was required.
- [x] No secrets, private configuration, production data, or generated files are included.