### PR TITLE
Prevent radio labels from scrolling the admin shell

### DIFF
--- a/src/components/admin/shared/AdminRadioGroup/index.tsx
+++ b/src/components/admin/shared/AdminRadioGroup/index.tsx
@@ -1,6 +1,4 @@
-import {useId, type ReactNode} from "react";
-
-import {Label} from "@/components/ui/label";
+import {useId, type MouseEvent, type ReactNode} from "react";
 import {
   RadioGroup,
   RadioGroupItem,
@@ -84,14 +82,35 @@ export default function AdminRadioGroup({
       >
         {options.map((option) => {
           const optionId = `${generatedId}-${option.value}`;
+          const optionLabelId = `${optionId}-label`;
+          const optionDescriptionId = `${optionId}-description`;
           const guidedDisabled = Boolean(
             !disabled && option.disabled && option.onDisabledClick,
           );
           const optionDisabled = Boolean(disabled || option.disabled);
+          const selectFromOption = (event: MouseEvent<HTMLDivElement>) => {
+            const target = event.target;
+            if (
+              target instanceof Element &&
+              target.closest("button, a, input, select, textarea")
+            ) {
+              return;
+            }
+
+            event.currentTarget
+              .querySelector<HTMLButtonElement>(
+                '[data-slot="radio-group-item"]',
+              )
+              ?.click();
+          };
           const radio = (
             <RadioGroupItem
               id={optionId}
               value={option.value}
+              aria-labelledby={optionLabelId}
+              aria-describedby={
+                option.description ? optionDescriptionId : undefined
+              }
               aria-disabled={optionDisabled || undefined}
               disabled={optionDisabled && !guidedDisabled}
               className={cn(
@@ -103,12 +122,13 @@ export default function AdminRadioGroup({
 
           if (variant === "cards") {
             return (
-              <Label
+              <div
                 key={option.value}
-                htmlFor={optionId}
+                data-slot="radio-option"
                 data-disabled={optionDisabled || undefined}
+                onClick={selectFromOption}
                 className={cn(
-                  "gap-4 rounded-[14px] border bg-card p-4 has-[[data-slot=radio-group-item][data-checked]]:border-brand-light has-[[data-slot=radio-group-item][data-checked]]:ring-1 has-[[data-slot=radio-group-item][data-checked]]:ring-brand-light/20",
+                  "flex gap-4 rounded-[14px] border bg-card p-4 text-sm leading-none font-medium select-none has-[[data-slot=radio-group-item][data-checked]]:border-brand-light has-[[data-slot=radio-group-item][data-checked]]:ring-1 has-[[data-slot=radio-group-item][data-checked]]:ring-brand-light/20",
                   alignment === "start" ? "items-start" : "items-center",
                   optionDisabled
                     ? "cursor-not-allowed opacity-60"
@@ -117,24 +137,30 @@ export default function AdminRadioGroup({
               >
                 {radio}
                 <span className="flex min-w-0 flex-col gap-1">
-                  <span className="text-sm font-semibold">{option.label}</span>
+                  <span id={optionLabelId} className="text-sm font-semibold">
+                    {option.label}
+                  </span>
                   {option.description && (
-                    <span className="text-xs font-normal text-muted-foreground">
+                    <span
+                      id={optionDescriptionId}
+                      className="text-xs font-normal text-muted-foreground"
+                    >
                       {option.description}
                     </span>
                   )}
                 </span>
-              </Label>
+              </div>
             );
           }
 
           return (
-            <Label
+            <div
               key={option.value}
-              htmlFor={optionId}
+              data-slot="radio-option"
               data-disabled={optionDisabled || undefined}
+              onClick={selectFromOption}
               className={cn(
-                "gap-1.5",
+                "flex gap-1.5 text-sm leading-none font-medium select-none",
                 alignment === "start" ? "items-start" : "items-center",
                 optionDisabled
                   ? "cursor-not-allowed opacity-60"
@@ -143,8 +169,8 @@ export default function AdminRadioGroup({
               )}
             >
               {radio}
-              <span>{option.label}</span>
-            </Label>
+              <span id={optionLabelId}>{option.label}</span>
+            </div>
           );
         })}
       </RadioGroup>

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -17,6 +17,8 @@ function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
   return (
     <RadioPrimitive.Root
       data-slot="radio-group-item"
+      nativeButton
+      render={<button type="button" />}
       className={cn(
         "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-foreground bg-white outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:ring-2 focus-visible:ring-brand-light focus-visible:ring-offset-2 focus-visible:ring-offset-background data-disabled:cursor-not-allowed data-disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-2 aria-invalid:ring-destructive/20 data-checked:border-brand-light data-checked:bg-brand-light",
         className

--- a/tests/unit/components/admin-ui-controls.test.ts
+++ b/tests/unit/components/admin-ui-controls.test.ts
@@ -209,6 +209,12 @@ describe("admin UI controls", () => {
 
     expect(output).toContain('data-slot="radio-group"');
     expect(output).toContain('aria-label="Access policy"');
+    expect(output).toContain('<button');
+    expect(output).toContain('type="button"');
+    expect(output).toContain('data-slot="radio-option"');
+    expect(output).not.toContain("<label");
+    expect(output).toMatch(/aria-labelledby="[^"]+-label"/u);
+    expect(output).toMatch(/aria-describedby="[^"]+-description"/u);
     expect(output).toContain('data-checked=""');
     expect(output).toContain("border-foreground");
     expect(output).toContain("data-checked:border-brand-light");
@@ -235,7 +241,8 @@ describe("admin UI controls", () => {
       }),
     );
 
-    expect(output).toContain("gap-1.5 items-center");
+    expect(output).toContain("gap-1.5");
+    expect(output).toContain("items-center");
     expect(output).not.toContain("mt-1");
   });
 


### PR DESCRIPTION
## Summary

- render shared admin radio controls as visible native buttons
- replace native label-to-hidden-input focus behavior with accessible labelled radio options
- keep full option rows clickable without shifting the fixed-height admin shell
- add regression assertions for the shared radio markup

This fixes the channel editor bug where changing `<itunes:type>` from episodic to serial and back could shift the whole page upward and leave the inner panel unable to scroll to its bottom.

## Related issue

None.

## Testing

- [ ] `yarn check` — blocked by the existing `main` OpenAPI lint error because server URL `/api/v1/` has a trailing slash
- [x] `git diff --check`
- [x] `yarn typecheck`
- [x] `yarn test` — 367 unit tests and 44 Worker tests passed
- [x] `yarn build`
- [x] focused admin UI controls test — 12 passed
- [x] browser regression at 1024×720: episodic → serial → episodic kept window scroll at 0 and the admin panel remained scrollable

## Screenshots

The reported before state is documented in the task. The corrected behavior was verified interactively at the matching desktop breakpoint.

## Risks

Low. The change updates the shared admin radio option wrapper, so focused markup, accessibility, disabled-state, type-check, and full test coverage were run.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was not required because no command or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.