### PR TITLE
Improve rich editor media and editing behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@astrojs/react": "^6.0.2",
     "@base-ui/react": "^1.6.0",
     "@clack/prompts": "^1.7.0",
-    "@enzedonline/quill-blot-formatter2": "^3.2.0",
     "@fontsource-variable/geist": "^5.3.0",
     "@scalar/api-reference-react": "^0.9.60",
     "@tanstack/react-table": "^8.5.28",

--- a/src/client/RichEditorHtml.ts
+++ b/src/client/RichEditorHtml.ts
@@ -1,0 +1,45 @@
+import {stripTransientRichEditorAttributes} from "./RichEditorMedia";
+
+function escapeHtmlText(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+export function semanticCodeBlockHtml(lines: readonly string[]): string {
+  return `<pre><code>${escapeHtmlText(lines.join("\n"))}</code></pre>`;
+}
+
+export function shouldReplaceRichEditorHtml(
+  nextValue: string,
+  currentValue: string,
+  lastEmittedValue: string | null,
+): boolean {
+  if (lastEmittedValue !== null && nextValue === lastEmittedValue) {
+    return false;
+  }
+  if (!nextValue && currentValue === "<p><br></p>") {
+    return false;
+  }
+  return nextValue !== currentValue;
+}
+
+export function serializeRichEditorHtml(editorRoot: HTMLElement): string {
+  const clone = editorRoot.cloneNode(true) as HTMLElement;
+
+  clone.querySelectorAll<HTMLElement>(".ql-code-block-container")
+    .forEach((container) => {
+      const lines = Array.from(container.children)
+        .filter((child) => child.classList.contains("ql-code-block"))
+        .map((line) => line.textContent ?? "");
+      const template = clone.ownerDocument.createElement("template");
+      template.innerHTML = semanticCodeBlockHtml(lines);
+      const semanticCodeBlock = template.content.firstElementChild;
+      if (semanticCodeBlock) {
+        container.replaceWith(semanticCodeBlock);
+      }
+    });
+
+  return stripTransientRichEditorAttributes(clone.innerHTML);
+}

--- a/src/client/RichEditorMedia.ts
+++ b/src/client/RichEditorMedia.ts
@@ -1,0 +1,204 @@
+export const RICH_EDITOR_MEDIA_STYLE_FORMAT = "mediaStyle";
+export const RICH_EDITOR_MEDIA_TITLE_FORMAT = "mediaTitle";
+export const RICH_EDITOR_LEGACY_VIDEO_FORMAT = "legacyVideo";
+
+export type RichEditorMediaType = "image" | "video";
+
+export function richEditorMediaEmbedFormat(
+  mediaType: RichEditorMediaType,
+  uploadedFile: boolean,
+): RichEditorMediaType | typeof RICH_EDITOR_LEGACY_VIDEO_FORMAT {
+  return mediaType === "video" && !uploadedFile
+    ? RICH_EDITOR_LEGACY_VIDEO_FORMAT
+    : mediaType;
+}
+
+export interface RichEditorMediaSettings {
+  alt: string;
+  height: string;
+  style: string;
+  title: string;
+  width: string;
+}
+
+const TRANSIENT_MEDIA_CLASSES = new Set([
+  "rich-editor-media-dragging",
+  "rich-editor-media-drop-after",
+  "rich-editor-media-drop-before",
+  "rich-editor-media-selected",
+]);
+const OBSOLETE_NATIVE_VIDEO_CLASSES = new Set([
+  "ql-native-video",
+  "ql-video",
+]);
+const DEFAULT_VIDEO_ASPECT_RATIO = "16 / 9";
+const FALLBACK_DIMENSION_PATTERN =
+  /^(?:auto|min-content|max-content|fit-content|0|(?:\d+(?:\.\d+)?|\.\d+)(?:%|px|em|rem|vw|vh|vmin|vmax|ch|ex|cm|mm|in|pt|pc))$/iu;
+
+export function stripTransientRichEditorAttributes(html: string): string {
+  const withoutObsoleteNativeVideoClasses = html.replace(
+    /<video\b[^>]*>/giu,
+    (videoTag) => videoTag.replace(
+      /\sclass=("([^"]*)"|'([^']*)')/iu,
+      (_match, quotedValue: string, doubleQuoted: string, singleQuoted: string) => {
+        const quote = quotedValue[0];
+        const classNames = (doubleQuoted ?? singleQuoted ?? "")
+          .split(/\s+/u)
+          .filter((className) => (
+            className && !OBSOLETE_NATIVE_VIDEO_CLASSES.has(className)
+          ));
+        return classNames.length > 0
+          ? ` class=${quote}${classNames.join(" ")}${quote}`
+          : "";
+      },
+    ),
+  );
+
+  return withoutObsoleteNativeVideoClasses
+    .replace(
+      /\sdata-blot-formatter-id=(?:"[^"]*"|'[^']*')/giu,
+      "",
+    )
+    .replace(/\sdraggable=(?:"true"|'true')/giu, "")
+    .replace(
+      /\sclass=("([^"]*)"|'([^']*)')/giu,
+      (_match, quotedValue: string, doubleQuoted: string, singleQuoted: string) => {
+        const quote = quotedValue[0];
+        const classNames = (doubleQuoted ?? singleQuoted ?? "")
+          .split(/\s+/u)
+          .filter((className) => (
+            className && !TRANSIENT_MEDIA_CLASSES.has(className)
+          ));
+        return classNames.length > 0
+          ? ` class=${quote}${classNames.join(" ")}${quote}`
+          : "";
+      },
+    );
+}
+
+export function isValidMediaDimension(
+  value: string,
+  property: "height" | "width",
+): boolean {
+  const normalized = value.trim();
+  if (!normalized) {
+    return true;
+  }
+
+  if (typeof CSS !== "undefined" && typeof CSS.supports === "function") {
+    return CSS.supports(property, normalized);
+  }
+
+  return FALLBACK_DIMENSION_PATTERN.test(normalized);
+}
+
+function userStyle(element: HTMLElement): string {
+  const style = element.ownerDocument.createElement("div").style;
+  style.cssText = element.getAttribute("style") ?? "";
+  style.removeProperty("width");
+  style.removeProperty("height");
+  style.removeProperty("--resize-width");
+  return style.cssText;
+}
+
+export function readRichEditorMediaSettings(
+  element: HTMLElement,
+): RichEditorMediaSettings {
+  return {
+    alt: element.getAttribute("alt") ?? "",
+    height: element.getAttribute("height") ?? element.style.height,
+    style: userStyle(element),
+    title: element.getAttribute("title") ?? "",
+    width: element.getAttribute("width") ?? element.style.width,
+  };
+}
+
+function setOptionalAttribute(
+  element: HTMLElement,
+  attribute: string,
+  value: string,
+) {
+  const normalized = value.trim();
+  if (normalized) {
+    element.setAttribute(attribute, normalized);
+  } else {
+    element.removeAttribute(attribute);
+  }
+}
+
+export function applyRichEditorMediaSettings(
+  element: HTMLElement,
+  mediaType: RichEditorMediaType,
+  settings: RichEditorMediaSettings,
+) {
+  element.style.cssText = settings.style.trim();
+  element.style.removeProperty("width");
+  element.style.removeProperty("height");
+
+  setOptionalAttribute(element, "width", settings.width);
+  const height = settings.height.trim();
+  const width = settings.width.trim();
+  const usesAutomaticVideoHeight =
+    mediaType === "video" && height.toLowerCase() === "auto";
+  if (usesAutomaticVideoHeight) {
+    element.removeAttribute("height");
+  } else {
+    setOptionalAttribute(element, "height", height);
+  }
+
+  if (mediaType === "video") {
+    if (width) {
+      element.style.width = width;
+    }
+    if (height) {
+      element.style.height = height;
+    }
+    if (
+      element.tagName === "IFRAME" &&
+      usesAutomaticVideoHeight &&
+      !element.style.getPropertyValue("aspect-ratio")
+    ) {
+      element.style.aspectRatio = DEFAULT_VIDEO_ASPECT_RATIO;
+    }
+  }
+
+  if (width) {
+    element.style.setProperty("--resize-width", width);
+    element.dataset.relativeSize = String(width.endsWith("%"));
+  } else {
+    element.style.removeProperty("--resize-width");
+    delete element.dataset.relativeSize;
+  }
+
+  if (mediaType === "image") {
+    setOptionalAttribute(element, "alt", settings.alt);
+  }
+  setOptionalAttribute(element, "title", settings.title);
+
+  if (!element.style.cssText) {
+    element.removeAttribute("style");
+  }
+}
+
+export function findRichEditorMediaElement(
+  target: EventTarget | null,
+  editorRoot: HTMLElement,
+): HTMLElement | null {
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+
+  const mediaElement = target.closest<HTMLElement>(
+    "img, video, iframe.ql-video",
+  );
+
+  return mediaElement && editorRoot.contains(mediaElement)
+    ? mediaElement
+    : null;
+}
+
+export function richEditorMediaType(
+  element: HTMLElement,
+): RichEditorMediaType {
+  return element.tagName === "IMG" ? "image" : "video";
+}

--- a/src/client/RichEditorToolbar.ts
+++ b/src/client/RichEditorToolbar.ts
@@ -1,0 +1,28 @@
+const RICH_EDITOR_TOOLBAR_LABELS = [
+  [".ql-header", "Text style"],
+  ["button.ql-bold", "Bold"],
+  ["button.ql-italic", "Italic"],
+  ["button.ql-underline", "Underline"],
+  ["button.ql-blockquote", "Block quote"],
+  ["button.ql-code", "Inline code"],
+  ["button.ql-code-block", "Code block"],
+  ['button.ql-list[value="ordered"]', "Numbered list"],
+  ['button.ql-list[value="bullet"]', "Bulleted list"],
+  ['button.ql-indent[value="-1"]', "Decrease indent"],
+  ['button.ql-indent[value="+1"]', "Increase indent"],
+  ["button.ql-link", "Insert link"],
+  ["button.ql-image", "Insert image"],
+  ["button.ql-video", "Insert video"],
+  ["button.ql-clean", "Clear formatting"],
+] as const;
+
+export function labelRichEditorToolbar(container: HTMLElement): void {
+  RICH_EDITOR_TOOLBAR_LABELS.forEach(([selector, label]) => {
+    container.querySelectorAll<HTMLElement>(selector).forEach((control) => {
+      control.setAttribute("aria-label", label);
+      control.setAttribute("title", label);
+    });
+  });
+}
+
+export {RICH_EDITOR_TOOLBAR_LABELS};

--- a/src/components/admin/shared/AdminCodeEditor/index.tsx
+++ b/src/components/admin/shared/AdminCodeEditor/index.tsx
@@ -1,9 +1,20 @@
 import CodeEditor from "@uiw/react-textarea-code-editor";
-import type {ChangeEventHandler} from "react";
+import {useRef} from "react";
+import type {ChangeEventHandler, KeyboardEvent} from "react";
+
+export function isCaretOnLastLine(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+) {
+  return selectionStart === selectionEnd
+    && !value.slice(selectionEnd).includes("\n");
+}
 
 interface Props {
   ariaLabel?: string;
   code: string;
+  fontSize?: number | string;
   language: string;
   maxHeight?: string;
   minHeight?: string;
@@ -14,26 +25,54 @@ interface Props {
 export default function AdminCodeEditor({
   ariaLabel = "Code editor",
   code,
+  fontSize = 12,
   language,
   maxHeight,
   minHeight = "50vh",
   onChange,
   placeholder = "Please enter code here",
 }: Props) {
-  return (<label className="block overflow-hidden rounded-[10px] border bg-muted/30 focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/30">
+  const scrollContainerRef = useRef<HTMLLabelElement>(null);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      event.key !== "Enter"
+      || event.defaultPrevented
+      || event.nativeEvent.isComposing
+      || !isCaretOnLastLine(
+        event.currentTarget.value,
+        event.currentTarget.selectionStart,
+        event.currentTarget.selectionEnd,
+      )
+    ) {
+      return;
+    }
+
+    event.currentTarget.ownerDocument.defaultView?.requestAnimationFrame(() => {
+      const scrollContainer = scrollContainerRef.current;
+      if (scrollContainer) {
+        scrollContainer.scrollTop = scrollContainer.scrollHeight;
+      }
+    });
+  };
+
+  return (<label
+    className="block overflow-auto rounded-[10px] border bg-muted/30 focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/30"
+    ref={scrollContainerRef}
+    style={{maxHeight}}
+  >
     <CodeEditor
       aria-label={ariaLabel}
       value={code}
       language={language}
       placeholder={placeholder}
       onChange={onChange}
+      onKeyDown={onKeyDown}
       spellCheck={false}
       className="admin-code-editor"
       style={{
-        maxHeight,
         minHeight,
-        overflow: 'auto',
-        fontSize: 12,
+        fontSize,
         backgroundColor: "transparent",
         fontFamily: 'ui-monospace,SFMono-Regular,SF Mono,Consolas,Liberation Mono,Menlo,monospace',
       }}

--- a/src/components/admin/shared/AdminHtmlEditor/index.tsx
+++ b/src/components/admin/shared/AdminHtmlEditor/index.tsx
@@ -16,6 +16,7 @@ export default function AdminHtmlEditor({onChange, value = ""}: Props) {
     <AdminCodeEditor
       ariaLabel="HTML source"
       code={value}
+      fontSize={14.4}
       language="html"
       maxHeight="32rem"
       minHeight="16rem"

--- a/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaDialog/index.tsx
+++ b/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaDialog/index.tsx
@@ -14,6 +14,7 @@ import {
 import Requests from "@/client/requests";
 import {showToast} from "@/client/ToastUtils";
 import {Button} from "@/components/ui/button";
+import {richEditorMediaEmbedFormat} from "@/client/RichEditorMedia";
 
 const UPLOAD_STATUS__START = 1;
 
@@ -118,7 +119,7 @@ export default class RichEditorMediaDialog extends React.Component<any, any> {
         progressText: 'Done!',
         uploadStatus: null,
       }, () => {
-        this.insertMedia();
+        this.insertMedia(true);
         setIsOpen(false);
       })
     }, () => {
@@ -138,7 +139,7 @@ export default class RichEditorMediaDialog extends React.Component<any, any> {
     });
   }
 
-  insertMedia() {
+  insertMedia(uploadedFile = false) {
     const {quill, quillSelection, mediaType} = this.props;
     if (!quill) {
       return;
@@ -146,7 +147,14 @@ export default class RichEditorMediaDialog extends React.Component<any, any> {
     const {url} = this.state;
     if (url) {
       const index = quillSelection ? quillSelection.index : 0;
-      quill.insertEmbed(index, mediaType, url, Quill.sources.USER);
+      quill.insertEmbed(
+        index,
+        richEditorMediaEmbedFormat(mediaType, uploadedFile),
+        url,
+        Quill.sources.USER,
+      );
+      quill.insertText(index + 1, "\n", Quill.sources.USER);
+      quill.setSelection(index + 2, 0, Quill.sources.SILENT);
       this.setState({url: null});
     }
   }

--- a/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaSettingsDialog/index.tsx
+++ b/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaSettingsDialog/index.tsx
@@ -1,0 +1,144 @@
+import AdminDialog from "@/components/admin/shared/AdminDialog";
+import {Button} from "@/components/ui/button";
+import {DialogClose, DialogFooter} from "@/components/ui/dialog";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import {Input} from "@/components/ui/input";
+import {Textarea} from "@/components/ui/textarea";
+import type {
+  RichEditorMediaSettings,
+  RichEditorMediaType,
+} from "@/client/RichEditorMedia";
+
+interface Props {
+  errors: Partial<Record<"height" | "width", string>>;
+  mediaType: RichEditorMediaType;
+  onChange: (settings: RichEditorMediaSettings) => void;
+  onOpenChange: (open: boolean) => void;
+  onSave: () => void;
+  open: boolean;
+  settings: RichEditorMediaSettings;
+}
+
+export default function RichEditorMediaSettingsDialog({
+  errors,
+  mediaType,
+  onChange,
+  onOpenChange,
+  onSave,
+  open,
+  settings,
+}: Props) {
+  const update = (
+    field: keyof RichEditorMediaSettings,
+    value: string,
+  ) => onChange({...settings, [field]: value});
+
+  return (
+    <AdminDialog
+      onOpenChange={onOpenChange}
+      open={open}
+      title={`Edit ${mediaType}`}
+    >
+      <div className="space-y-5">
+        <p className="text-sm text-muted-foreground">
+          Control how this {mediaType} is displayed. Leave a value blank to use
+          its natural size.
+        </p>
+        <FieldGroup className="gap-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field data-invalid={Boolean(errors.width)}>
+              <FieldLabel htmlFor="rich-editor-media-width">Width</FieldLabel>
+              <Input
+                aria-invalid={Boolean(errors.width)}
+                id="rich-editor-media-width"
+                onChange={(event) => update("width", event.target.value)}
+                placeholder="e.g., 100% or 640px"
+                value={settings.width}
+              />
+              <FieldDescription>
+                CSS sizes such as 100%, 640px, or auto.
+              </FieldDescription>
+              <FieldError>{errors.width}</FieldError>
+            </Field>
+            <Field data-invalid={Boolean(errors.height)}>
+              <FieldLabel htmlFor="rich-editor-media-height">Height</FieldLabel>
+              <Input
+                aria-invalid={Boolean(errors.height)}
+                id="rich-editor-media-height"
+                onChange={(event) => update("height", event.target.value)}
+                placeholder="e.g., auto or 360px"
+                value={settings.height}
+              />
+              <FieldDescription>
+                {mediaType === "video"
+                  ? "Auto preserves an uploaded video's natural aspect ratio. Legacy embeds use a responsive 16:9 frame."
+                  : "Use auto to preserve the image's aspect ratio."}
+              </FieldDescription>
+              <FieldError>{errors.height}</FieldError>
+            </Field>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {mediaType === "image" && (
+              <Field>
+                <FieldLabel htmlFor="rich-editor-media-alt">Alt text</FieldLabel>
+                <Input
+                  id="rich-editor-media-alt"
+                  onChange={(event) => update("alt", event.target.value)}
+                  placeholder="Describe the image"
+                  value={settings.alt}
+                />
+                <FieldDescription>
+                  Helps people who use screen readers.
+                </FieldDescription>
+              </Field>
+            )}
+            <Field>
+              <FieldLabel htmlFor="rich-editor-media-title">Title</FieldLabel>
+              <Input
+                id="rich-editor-media-title"
+                onChange={(event) => update("title", event.target.value)}
+                placeholder="Optional title"
+                value={settings.title}
+              />
+              {mediaType === "video" && (
+                <FieldDescription>
+                  Describes the embedded video for screen readers.
+                </FieldDescription>
+              )}
+            </Field>
+          </div>
+          <Field>
+            <FieldLabel htmlFor="rich-editor-media-style">
+              Additional inline style
+            </FieldLabel>
+            <Textarea
+              id="rich-editor-media-style"
+              onChange={(event) => update("style", event.target.value)}
+              placeholder={mediaType === "video"
+                ? "e.g., aspect-ratio: 9 / 16; border-radius: 12px;"
+                : "e.g., border-radius: 12px; object-fit: cover;"}
+              rows={3}
+              value={settings.style}
+            />
+            <FieldDescription>
+              Optional CSS declarations. Set width and height in the fields
+              above so the visual editor can keep its resize controls in sync.
+            </FieldDescription>
+          </Field>
+        </FieldGroup>
+        <DialogFooter>
+          <DialogClose render={<Button type="button" variant="outline" />}>
+            Cancel
+          </DialogClose>
+          <Button onClick={onSave} type="button">Apply</Button>
+        </DialogFooter>
+      </div>
+    </AdminDialog>
+  );
+}

--- a/src/components/admin/shared/AdminRichEditor/component/RichEditorQuill/index.tsx
+++ b/src/components/admin/shared/AdminRichEditor/component/RichEditorQuill/index.tsx
@@ -1,13 +1,135 @@
 import React from "react";
-import BlotFormatter from "@enzedonline/quill-blot-formatter2";
-import Quill, {type Delta, type EmitterSource} from "quill";
+import Quill, {Delta, type EmitterSource} from "quill";
+import {
+  serializeRichEditorHtml,
+  shouldReplaceRichEditorHtml,
+} from "@/client/RichEditorHtml";
+import {labelRichEditorToolbar} from "@/client/RichEditorToolbar";
+import {
+  applyRichEditorMediaSettings,
+  findRichEditorMediaElement,
+  isValidMediaDimension,
+  readRichEditorMediaSettings,
+  RICH_EDITOR_LEGACY_VIDEO_FORMAT,
+  RICH_EDITOR_MEDIA_STYLE_FORMAT,
+  RICH_EDITOR_MEDIA_TITLE_FORMAT,
+  richEditorMediaType,
+  type RichEditorMediaSettings,
+  type RichEditorMediaType,
+} from "@/client/RichEditorMedia";
 import RichEditorMediaDialog from "../RichEditorMediaDialog";
+import RichEditorMediaSettingsDialog from "../RichEditorMediaSettingsDialog";
 
-Quill.register('modules/blotFormatter2', BlotFormatter);
+const BaseImage = Quill.import("formats/image") as any;
+const BaseVideo = Quill.import("formats/video") as any;
+
+function mediaStyleBlot(BaseBlot: any) {
+  return class extends BaseBlot {
+    static formats(domNode: HTMLElement) {
+      const formats = super.formats(domNode);
+      const style = domNode.getAttribute("style");
+      const title = domNode.getAttribute("title");
+      return {
+        ...formats,
+        ...(style && {[RICH_EDITOR_MEDIA_STYLE_FORMAT]: style}),
+        ...(title && {[RICH_EDITOR_MEDIA_TITLE_FORMAT]: title}),
+      };
+    }
+
+    format(name: string, value: unknown) {
+      if (name === RICH_EDITOR_MEDIA_STYLE_FORMAT) {
+        if (value) {
+          this.domNode.setAttribute("style", String(value));
+        } else {
+          this.domNode.removeAttribute("style");
+        }
+        return;
+      }
+      if (name === RICH_EDITOR_MEDIA_TITLE_FORMAT) {
+        if (value) {
+          this.domNode.setAttribute("title", String(value));
+        } else {
+          this.domNode.removeAttribute("title");
+        }
+        return;
+      }
+      super.format(name, value);
+    }
+  };
+}
+
+class NativeVideo extends BaseVideo {
+  static blotName = "video";
+  static className = "";
+  static tagName = "VIDEO";
+
+  static create(value: string) {
+    const node = super.create(value) as HTMLVideoElement;
+    node.removeAttribute("allowfullscreen");
+    node.removeAttribute("frameborder");
+    node.setAttribute("controls", "");
+    node.setAttribute("playsinline", "");
+    node.setAttribute("preload", "metadata");
+    node.setAttribute("width", "100%");
+    node.style.height = "auto";
+    return node;
+  }
+
+  html() {
+    return this.domNode.outerHTML;
+  }
+}
+
+const StyledLegacyVideo = mediaStyleBlot(BaseVideo);
+StyledLegacyVideo.blotName = RICH_EDITOR_LEGACY_VIDEO_FORMAT;
+
+Quill.register({
+  "formats/image": mediaStyleBlot(BaseImage),
+  [`formats/${RICH_EDITOR_LEGACY_VIDEO_FORMAT}`]: StyledLegacyVideo,
+  "formats/video": mediaStyleBlot(NativeVideo),
+}, true);
+
+const toolbarIcons = Quill.import("ui/icons") as Record<string, string>;
+toolbarIcons["code-block"] = [
+  '<svg viewbox="0 0 18 18">',
+  '<rect class="ql-stroke" height="12" width="14" x="2" y="3"/>',
+  '<polyline class="ql-even ql-stroke" points="6 7 4 9 6 11"/>',
+  '<polyline class="ql-even ql-stroke" points="12 7 14 9 12 11"/>',
+  '<line class="ql-stroke" x1="10" x2="8" y1="5" y2="13"/>',
+  '</svg>',
+].join("");
+
+interface ScrollPosition {
+  element: Element;
+  scrollLeft: number;
+  scrollTop: number;
+}
+
+function preserveScrollPositions(editorRoot: HTMLElement): () => void {
+  const elements = new Set<Element>();
+  let current: HTMLElement | null = editorRoot;
+  while (current) {
+    elements.add(current);
+    current = current.parentElement;
+  }
+  if (editorRoot.ownerDocument.scrollingElement) {
+    elements.add(editorRoot.ownerDocument.scrollingElement);
+  }
+
+  const positions: ScrollPosition[] = Array.from(elements).map((element) => ({
+    element,
+    scrollLeft: element.scrollLeft,
+    scrollTop: element.scrollTop,
+  }));
+  return () => positions.forEach(({element, scrollLeft, scrollTop}) => {
+    element.scrollLeft = scrollLeft;
+    element.scrollTop = scrollTop;
+  });
+}
 
 const toolbarOptions = [
   [{'header': [2, 3, false]}],
-  ['bold', 'italic', 'underline', 'blockquote', 'code-block'],
+  ['bold', 'italic', 'underline', 'blockquote', 'code', 'code-block'],
   [{'list': 'ordered'}, {'list': 'bullet'}, {'indent': '-1'}, {'indent': '+1'}],
   ['link', 'image', 'video'],
   ['clean']
@@ -21,18 +143,110 @@ const modules = {
     //   video: videoHandler,
     // },
   },
-  blotFormatter2: {
-    // see config options below
+  keyboard: {
+    bindings: {
+      preserveScrollOnEnter: {
+        key: "Enter",
+        handler(this: {quill: Quill}) {
+          const quill = this.quill;
+          const editorRoot = quill.root;
+          const selection = quill.getSelection();
+          const [currentLine] = selection
+            ? quill.getLine(selection.index)
+            : [null, -1];
+          const lines = quill.getLines();
+          const shouldRevealNewLine = Boolean(
+            currentLine && currentLine === lines[lines.length - 1],
+          );
+          const restoreScrollPositions = preserveScrollPositions(editorRoot);
+          editorRoot.ownerDocument.defaultView?.requestAnimationFrame(() => {
+            if (editorRoot.isConnected) {
+              restoreScrollPositions();
+              if (shouldRevealNewLine) {
+                quill.scrollSelectionIntoView();
+              }
+            }
+          });
+          return true;
+        },
+      },
+      exitTerminalCodeBlock: {
+        key: "Enter",
+        collapsed: true,
+        format: ["code-block"],
+        prefix: /^$/,
+        suffix: /^\s*$/,
+        handler(this: {quill: Quill}, range: {index: number}) {
+          const [line] = this.quill.getLine(range.index) as [
+            {next?: {formats?: () => Record<string, unknown>}} | null,
+            number,
+          ];
+          if (line?.next?.formats?.()["code-block"]) {
+            return true;
+          }
+
+          this.quill.formatLine(
+            range.index,
+            1,
+            "code-block",
+            false,
+            Quill.sources.USER,
+          );
+          this.quill.setSelection(range.index, 0, Quill.sources.SILENT);
+          return false;
+        },
+      },
+    },
   },
 };
 
 const formats = [
   'header',
-  'bold', 'italic', 'underline', 'blockquote', 'code-block',
+  'bold', 'italic', 'underline', 'blockquote', 'code', 'code-block',
   'list', 'indent',
   'link',
-  'image', 'video',
+  'image', 'video', RICH_EDITOR_LEGACY_VIDEO_FORMAT,
+  RICH_EDITOR_MEDIA_STYLE_FORMAT,
+  RICH_EDITOR_MEDIA_TITLE_FORMAT,
 ];
+
+const EMPTY_MEDIA_SETTINGS: RichEditorMediaSettings = {
+  alt: "",
+  height: "",
+  style: "",
+  title: "",
+  width: "",
+};
+
+type MediaDropPosition = "after" | "before";
+
+function editorBlockForTarget(
+  target: EventTarget | null,
+  editorRoot: HTMLElement,
+): HTMLElement | null {
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+  if (target === editorRoot) {
+    return editorRoot.lastElementChild as HTMLElement | null;
+  }
+
+  let block: HTMLElement | null = target;
+  while (block?.parentElement && block.parentElement !== editorRoot) {
+    block = block.parentElement;
+  }
+  return block?.parentElement === editorRoot ? block : null;
+}
+
+function blockEndsWithMedia(block: HTMLElement): boolean {
+  if (block.matches("img, video, iframe.ql-video")) {
+    return true;
+  }
+  return Boolean(
+    block.querySelector("img, video, iframe.ql-video") &&
+    !block.textContent?.trim(),
+  );
+}
 
 export default class RichEditorQuill extends React.Component<any, any> {
   editorElement: HTMLDivElement | null = null;
@@ -40,14 +254,223 @@ export default class RichEditorQuill extends React.Component<any, any> {
   textChangeHandler:
     | ((delta: Delta, oldDelta: Delta, source: EmitterSource) => void)
     | null = null;
+  mediaClickHandler: ((event: MouseEvent) => void) | null = null;
+  mediaDragEndHandler: ((event: DragEvent) => void) | null = null;
+  mediaDragOverHandler: ((event: DragEvent) => void) | null = null;
+  mediaDragStartHandler: ((event: DragEvent) => void) | null = null;
+  mediaDropHandler: ((event: DragEvent) => void) | null = null;
+  draggedMediaElement: HTMLElement | null = null;
+  mediaDropBlock: HTMLElement | null = null;
+  mediaDropPosition: MediaDropPosition | null = null;
+  selectedMediaElement: HTMLElement | null = null;
+  lastMediaClickAt = 0;
+  lastMediaClickElement: HTMLElement | null = null;
+  lastEmittedHtml: string | null = null;
 
   constructor(props: any) {
     super(props);
     this.state = {
-      isOpen: false,
+      isInsertOpen: false,
       mediaType: 'image',
       quillSelection: null,
+      isSettingsOpen: false,
+      mediaSettings: EMPTY_MEDIA_SETTINGS,
+      mediaSettingsErrors: {},
+      settingsMediaElement: null,
+      settingsMediaType: 'image',
     };
+    this.saveMediaSettings = this.saveMediaSettings.bind(this);
+  }
+
+  serializedHtml() {
+    return this.quillRef ? serializeRichEditorHtml(this.quillRef.root) : "";
+  }
+
+  emitHtmlChange() {
+    const html = this.serializedHtml();
+    this.lastEmittedHtml = html;
+    this.props.onChange(html);
+  }
+
+  enableMediaDragging() {
+    this.quillRef?.root.querySelectorAll<HTMLElement>(
+      "img, video, iframe.ql-video",
+    ).forEach((element) => {
+      element.draggable = true;
+    });
+  }
+
+  ensureTrailingEditableLine() {
+    const editor = this.quillRef;
+    const lastBlock = editor?.root.lastElementChild as HTMLElement | null;
+    if (!editor || !lastBlock || !blockEndsWithMedia(lastBlock)) {
+      return;
+    }
+
+    const lastBlot = Quill.find(lastBlock) as any;
+    const parentBlot = lastBlot?.parent;
+    if (!lastBlot || !parentBlot) {
+      return;
+    }
+    const editableBlock = editor.scroll.create("block");
+    parentBlot.insertBefore(editableBlock, lastBlot.next);
+    editor.update(Quill.sources.USER);
+  }
+
+  clearMediaDragState() {
+    this.draggedMediaElement?.classList.remove("rich-editor-media-dragging");
+    this.mediaDropBlock?.classList.remove(
+      "rich-editor-media-drop-after",
+      "rich-editor-media-drop-before",
+    );
+    this.draggedMediaElement = null;
+    this.mediaDropBlock = null;
+    this.mediaDropPosition = null;
+  }
+
+  selectMediaForClipboard(element: HTMLElement) {
+    const editor = this.quillRef;
+    const mediaBlot = Quill.find(element) as any;
+    if (!editor || !mediaBlot) {
+      return;
+    }
+    this.selectedMediaElement?.classList.remove("rich-editor-media-selected");
+    this.selectedMediaElement = element;
+    element.classList.add("rich-editor-media-selected");
+    editor.setSelection(
+      editor.getIndex(mediaBlot),
+      mediaBlot.length(),
+      Quill.sources.USER,
+    );
+  }
+
+  clearSelectedMedia() {
+    this.selectedMediaElement?.classList.remove("rich-editor-media-selected");
+    this.selectedMediaElement = null;
+  }
+
+  showMediaDropPosition(
+    block: HTMLElement,
+    position: MediaDropPosition,
+  ) {
+    if (this.mediaDropBlock === block && this.mediaDropPosition === position) {
+      return;
+    }
+    this.mediaDropBlock?.classList.remove(
+      "rich-editor-media-drop-after",
+      "rich-editor-media-drop-before",
+    );
+    this.mediaDropBlock = block;
+    this.mediaDropPosition = position;
+    block.classList.add(`rich-editor-media-drop-${position}`);
+  }
+
+  moveDraggedMedia() {
+    const editor = this.quillRef;
+    const sourceElement = this.draggedMediaElement;
+    const targetBlock = this.mediaDropBlock;
+    const position = this.mediaDropPosition;
+    if (!editor || !sourceElement || !targetBlock || !position) {
+      return;
+    }
+
+    const sourceBlot = Quill.find(sourceElement) as any;
+    const targetBlot = Quill.find(targetBlock) as any;
+    if (!sourceBlot || !targetBlot) {
+      return;
+    }
+    const sourceIndex = editor.getIndex(sourceBlot);
+    const sourceLength = sourceBlot.length();
+    const targetStart = editor.getIndex(targetBlot);
+    const targetIndex = position === "after"
+      ? targetStart + targetBlot.length()
+      : targetStart;
+    if (
+      targetIndex >= sourceIndex &&
+      targetIndex <= sourceIndex + sourceLength
+    ) {
+      return;
+    }
+
+    const mediaOperation = editor.getContents(
+      sourceIndex,
+      sourceLength,
+    ).ops.find((operation) => typeof operation.insert === "object");
+    if (!mediaOperation || typeof mediaOperation.insert !== "object") {
+      return;
+    }
+
+    let change = new Delta();
+    let nextIndex: number;
+    if (sourceIndex < targetIndex) {
+      nextIndex = targetIndex - sourceLength;
+      change = change
+        .retain(sourceIndex)
+        .delete(sourceLength)
+        .retain(nextIndex - sourceIndex)
+        .insert(mediaOperation.insert, mediaOperation.attributes);
+    } else {
+      nextIndex = targetIndex;
+      change = change
+        .retain(targetIndex)
+        .insert(mediaOperation.insert, mediaOperation.attributes)
+        .retain(sourceIndex - targetIndex)
+        .delete(sourceLength);
+    }
+    editor.updateContents(change, Quill.sources.USER);
+    this.ensureTrailingEditableLine();
+    editor.setSelection(nextIndex + sourceLength, 0, Quill.sources.SILENT);
+  }
+
+  openMediaSettings(element: HTMLElement) {
+    this.setState({
+      isSettingsOpen: true,
+      mediaSettings: readRichEditorMediaSettings(element),
+      mediaSettingsErrors: {},
+      settingsMediaElement: element,
+      settingsMediaType: richEditorMediaType(element),
+    });
+  }
+
+  saveMediaSettings() {
+    const {
+      mediaSettings,
+      settingsMediaElement,
+      settingsMediaType,
+    } = this.state as {
+      mediaSettings: RichEditorMediaSettings;
+      settingsMediaElement: HTMLElement | null;
+      settingsMediaType: RichEditorMediaType;
+    };
+    const errors = {
+      ...(!isValidMediaDimension(mediaSettings.width, "width") && {
+        width: "Enter a valid CSS width, such as 100%, 640px, or auto.",
+      }),
+      ...(!isValidMediaDimension(mediaSettings.height, "height") && {
+        height: "Enter a valid CSS height, such as auto or 360px.",
+      }),
+    };
+    if (Object.keys(errors).length > 0) {
+      this.setState({mediaSettingsErrors: errors});
+      return;
+    }
+    if (!settingsMediaElement || !this.quillRef) {
+      this.setState({isSettingsOpen: false});
+      return;
+    }
+
+    applyRichEditorMediaSettings(
+      settingsMediaElement,
+      settingsMediaType,
+      mediaSettings,
+    );
+    this.quillRef.update(Quill.sources.USER);
+    this.emitHtmlChange();
+    this.setState({
+      isSettingsOpen: false,
+      mediaSettingsErrors: {},
+      settingsMediaElement: null,
+    });
   }
 
   componentDidMount() {
@@ -65,29 +488,115 @@ export default class RichEditorQuill extends React.Component<any, any> {
       editor.clipboard.dangerouslyPasteHTML(initialValue, 'silent');
     }
     this.textChangeHandler = (_delta, _oldDelta, source) => {
+      this.enableMediaDragging();
       if (source !== 'silent') {
-        this.props.onChange(editor.root.innerHTML);
+        this.emitHtmlChange();
       }
     };
     editor.on('text-change', this.textChangeHandler);
 
     const toolbar = editor.getModule('toolbar') as {
       addHandler: (format: string, handler: () => void) => void;
+      container: HTMLElement;
     };
+    labelRichEditorToolbar(toolbar.container);
     toolbar.addHandler('image', () => {
       this.setState({
-        isOpen: true,
+        isInsertOpen: true,
         mediaType: 'image',
         quillSelection: editor.getSelection(),
       });
     });
     toolbar.addHandler('video', () => {
       this.setState({
-        isOpen: true,
+        isInsertOpen: true,
         mediaType: 'video',
         quillSelection: editor.getSelection(),
       });
     });
+    this.mediaClickHandler = (event) => {
+      const mediaElement = findRichEditorMediaElement(
+        event.target,
+        editor.root,
+      );
+      const target = event.target instanceof Element ? event.target : null;
+      if (!mediaElement) {
+        if (target && editor.root.contains(target)) {
+          this.clearSelectedMedia();
+        }
+        this.lastMediaClickAt = 0;
+        this.lastMediaClickElement = null;
+        return;
+      }
+
+      this.selectMediaForClipboard(mediaElement);
+
+      const clickedAt = Date.now();
+      const isDoubleClick =
+        mediaElement === this.lastMediaClickElement &&
+        clickedAt - this.lastMediaClickAt <= 650;
+      this.lastMediaClickAt = clickedAt;
+      this.lastMediaClickElement = mediaElement;
+      if (!isDoubleClick) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      this.lastMediaClickAt = 0;
+      this.lastMediaClickElement = null;
+      this.openMediaSettings(mediaElement);
+    };
+    document.addEventListener(
+      "click",
+      this.mediaClickHandler,
+      true,
+    );
+    this.mediaDragStartHandler = (event) => {
+      const mediaElement = findRichEditorMediaElement(event.target, editor.root);
+      if (!mediaElement) {
+        return;
+      }
+      this.draggedMediaElement = mediaElement;
+      mediaElement.classList.add("rich-editor-media-dragging");
+      if (event.dataTransfer) {
+        event.dataTransfer.effectAllowed = "move";
+        event.dataTransfer.setData("text/plain", "microfeed-rich-editor-media");
+      }
+    };
+    this.mediaDragOverHandler = (event) => {
+      if (!this.draggedMediaElement) {
+        return;
+      }
+      const block = editorBlockForTarget(event.target, editor.root);
+      if (!block || block.contains(this.draggedMediaElement)) {
+        return;
+      }
+      event.preventDefault();
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "move";
+      }
+      const bounds = block.getBoundingClientRect();
+      this.showMediaDropPosition(
+        block,
+        event.clientY < bounds.top + bounds.height / 2 ? "before" : "after",
+      );
+    };
+    this.mediaDropHandler = (event) => {
+      if (!this.draggedMediaElement || !this.mediaDropBlock) {
+        return;
+      }
+      event.preventDefault();
+      this.moveDraggedMedia();
+      this.clearMediaDragState();
+    };
+    this.mediaDragEndHandler = () => this.clearMediaDragState();
+    editor.root.addEventListener("dragstart", this.mediaDragStartHandler);
+    editor.root.addEventListener("dragover", this.mediaDragOverHandler);
+    editor.root.addEventListener("drop", this.mediaDropHandler);
+    editor.root.addEventListener("dragend", this.mediaDragEndHandler);
+    this.enableMediaDragging();
+    this.ensureTrailingEditableLine();
   }
 
   componentDidUpdate(previousProps: any) {
@@ -96,12 +605,18 @@ export default class RichEditorQuill extends React.Component<any, any> {
       previousProps.value !== this.props.value
     ) {
       const nextValue = this.props.value || '';
-      const currentValue = this.quillRef.root.innerHTML;
-      const emptyValuesMatch =
-        !nextValue && currentValue === '<p><br></p>';
-      if (!emptyValuesMatch && nextValue !== currentValue) {
+      const currentValue = this.serializedHtml();
+      const shouldReplace = shouldReplaceRichEditorHtml(
+        nextValue,
+        currentValue,
+        this.lastEmittedHtml,
+      );
+      this.lastEmittedHtml = null;
+      if (shouldReplace) {
         const selection = this.quillRef.getSelection();
         this.quillRef.clipboard.dangerouslyPasteHTML(nextValue, 'silent');
+        this.enableMediaDragging();
+        this.ensureTrailingEditableLine();
         if (selection) {
           const maxIndex = Math.max(0, this.quillRef.getLength() - 1);
           this.quillRef.setSelection(
@@ -115,27 +630,86 @@ export default class RichEditorQuill extends React.Component<any, any> {
   }
 
   componentWillUnmount() {
+    if (this.quillRef) {
+      const root = this.quillRef.root;
+      if (this.mediaDragStartHandler) {
+        root.removeEventListener("dragstart", this.mediaDragStartHandler);
+      }
+      if (this.mediaDragOverHandler) {
+        root.removeEventListener("dragover", this.mediaDragOverHandler);
+      }
+      if (this.mediaDropHandler) {
+        root.removeEventListener("drop", this.mediaDropHandler);
+      }
+      if (this.mediaDragEndHandler) {
+        root.removeEventListener("dragend", this.mediaDragEndHandler);
+      }
+    }
+    if (this.quillRef && this.mediaClickHandler) {
+      document.removeEventListener(
+        "click",
+        this.mediaClickHandler,
+        true,
+      );
+    }
     if (this.quillRef && this.textChangeHandler) {
       this.quillRef.off('text-change', this.textChangeHandler);
     }
+    this.clearMediaDragState();
+    this.clearSelectedMedia();
+    this.mediaDragEndHandler = null;
+    this.mediaDragOverHandler = null;
+    this.mediaDragStartHandler = null;
+    this.mediaDropHandler = null;
+    this.mediaClickHandler = null;
+    this.lastMediaClickAt = 0;
+    this.lastMediaClickElement = null;
+    this.lastEmittedHtml = null;
     this.textChangeHandler = null;
     this.quillRef = null;
   }
 
   render() {
     const {extra} = this.props;
-    const {isOpen, mediaType, quillSelection} = this.state;
+    const {
+      isInsertOpen,
+      isSettingsOpen,
+      mediaSettings,
+      mediaSettingsErrors,
+      mediaType,
+      quillSelection,
+      settingsMediaType,
+    } = this.state;
     return <div>
     <div ref={(element) => {
       this.editorElement = element;
     }} />
     <RichEditorMediaDialog
-      isOpen={isOpen}
-      setIsOpen={(isOpen: any) => this.setState({isOpen})}
+      isOpen={isInsertOpen}
+      setIsOpen={(isInsertOpen: any) => this.setState({isInsertOpen})}
       mediaType={mediaType}
       quill={this.quillRef}
       quillSelection={quillSelection}
       extra={extra}
+    />
+    <p className="mt-2 text-xs text-muted-foreground">
+      Tip: Drag an image or video to move it. Double-click to edit its size and
+      style.
+    </p>
+    <RichEditorMediaSettingsDialog
+      errors={mediaSettingsErrors}
+      mediaType={settingsMediaType}
+      onChange={(mediaSettings) => this.setState({
+        mediaSettings,
+        mediaSettingsErrors: {},
+      })}
+      onOpenChange={(isSettingsOpen) => this.setState({
+        isSettingsOpen,
+        ...(!isSettingsOpen && {settingsMediaElement: null}),
+      })}
+      onSave={this.saveMediaSettings}
+      open={isSettingsOpen}
+      settings={mediaSettings}
     />
   </div>
   }

--- a/src/components/admin/shared/AdminRichEditor/index.tsx
+++ b/src/components/admin/shared/AdminRichEditor/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import '@enzedonline/quill-blot-formatter2/dist/css/quill-blot-formatter2.css';
 import 'quill/dist/quill.snow.css';
 import {formatHtmlForEditing} from "@/client/HtmlUtils";
+import {stripTransientRichEditorAttributes} from "@/client/RichEditorMedia";
 import AdminRadioGroup from "../AdminRadioGroup";
 import AdminHtmlEditor from "../AdminHtmlEditor";
 import RichEditorQuill from "./component/RichEditorQuill";
@@ -11,7 +11,9 @@ export default class AdminRichEditor extends React.Component<any, any> {
     super(props);
     this.state = {
       mode: 'rich',
-      htmlSource: formatHtmlForEditing(props.value || ""),
+      htmlSource: formatHtmlForEditing(
+        stripTransientRichEditorAttributes(props.value || ""),
+      ),
 
       isOpenImage: false,
     };
@@ -32,8 +34,9 @@ export default class AdminRichEditor extends React.Component<any, any> {
   render() {
     const {htmlSource, mode} = this.state;
     const {label, value, extra, labelComponent} = this.props;
+    const editorValue = stripTransientRichEditorAttributes(value || "");
     return (
-      <div>
+      <div className="admin-rich-editor">
         {label && <div className="mb-2 font-semibold text-foreground">
           {label}
         </div>}
@@ -52,7 +55,7 @@ export default class AdminRichEditor extends React.Component<any, any> {
           />
         </div>
         {mode === 'rich' ? <RichEditorQuill
-          value={value}
+          value={editorValue}
           onChange={this.onRichChange}
           extra={extra}
         /> : <AdminHtmlEditor value={htmlSource} onChange={this.onHtmlChange} />}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,7 +17,10 @@ import {
 } from "@/shared/StringUtils";
 import {isExistingItemEditorPath} from "./server/admin-routes";
 import {adminProtectionStatus} from "@/server/auth/admin-protection";
-import {createMicrofeedAuth} from "@/server/auth/better-auth";
+import {
+  createMicrofeedAuth,
+  withAuthSessionCookies,
+} from "@/server/auth/better-auth";
 import {
   adminDashboardLockedResponse,
   hasAdminOwner,
@@ -72,6 +75,7 @@ function wantsJson(request: Request, pathname: string): boolean {
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const {pathname} = context.url;
+  let authSessionHeaders: Headers | undefined;
   const adminPath = normalizeAdminPath(env.MICROFEED_ADMIN_PATH);
   const builtInAuthEnabled = builtInAdminAuthEnabled(
     env.MICROFEED_ADMIN_AUTH_MODE,
@@ -161,39 +165,51 @@ export const onRequest = defineMiddleware(async (context, next) => {
         return next();
       }
       const auth = createMicrofeedAuth(env, context.request);
-      const authSession = await auth.api.getSession({
+      const sessionResult = await auth.api.getSession({
         headers: context.request.headers,
+        returnHeaders: true,
       });
+      const authSession = sessionResult.response;
+      authSessionHeaders = sessionResult.headers;
       if (!authSession && !await hasAdminOwner(env.FEED_DB)) {
-        return adminDashboardLockedResponse(
-          !wantsJson(context.request, pathname),
-          {
-            instanceName: env.MICROFEED_INSTANCE_NAME,
-            local: !env.MICROFEED_CLOUDFLARE_ACCOUNT_ID?.trim(),
-          },
+        return withAuthSessionCookies(
+          adminDashboardLockedResponse(
+            !wantsJson(context.request, pathname),
+            {
+              instanceName: env.MICROFEED_INSTANCE_NAME,
+              local: !env.MICROFEED_CLOUDFLARE_ACCOUNT_ID?.trim(),
+            },
+          ),
+          authSessionHeaders,
         );
       }
       if (pathname === loginPath) {
         if (authSession) {
-          return Response.redirect(
-            new URL(adminBasePath(adminPath), context.url),
-            302,
+          return withAuthSessionCookies(
+            Response.redirect(
+              new URL(adminBasePath(adminPath), context.url),
+              302,
+            ),
+            authSessionHeaders,
           );
         }
-        return next();
+        return withAuthSessionCookies(await next(), authSessionHeaders);
       }
       if (!authSession) {
         if (wantsJson(context.request, pathname)) {
-          return new Response("Unauthorized", {status: 401});
+          return withAuthSessionCookies(
+            new Response("Unauthorized", {status: 401}),
+            authSessionHeaders,
+          );
         }
         const loginUrl = new URL(loginPath, context.url);
         loginUrl.searchParams.set(
           "redirect",
           `${context.url.pathname}${context.url.search}`,
         );
-        return Response.redirect(
-          loginUrl,
-          302,
+        return withAuthSessionCookies(
+          Response.redirect(loginUrl, 302),
+          authSessionHeaders,
         );
       }
       context.locals.authSession = authSession.session;
@@ -215,7 +231,10 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
 
     if (isAdminAjax(pathname, adminPath)) {
-      return next();
+      const response = await next();
+      return authSessionHeaders
+        ? withAuthSessionCookies(response, authSessionHeaders)
+        : response;
     }
 
     // The item-edit page loads one item itself so deleted items can return a
@@ -265,5 +284,8 @@ export const onRequest = defineMiddleware(async (context, next) => {
     }
   }
 
-  return next();
+  const response = await next();
+  return authSessionHeaders
+    ? withAuthSessionCookies(response, authSessionHeaders)
+    : response;
 });

--- a/src/server/auth/better-auth.ts
+++ b/src/server/auth/better-auth.ts
@@ -56,4 +56,22 @@ export function createMicrofeedAuth(
   });
 }
 
+export function withAuthSessionCookies(
+  response: Response,
+  authHeaders: Headers,
+): Response {
+  const cookies = authHeaders.getSetCookie();
+  if (cookies.length === 0) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  cookies.forEach((cookie) => headers.append("set-cookie", cookie));
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
 export type MicrofeedAuth = ReturnType<typeof createMicrofeedAuth>;

--- a/src/server/themes/defaults/web_header.html
+++ b/src/server/themes/defaults/web_header.html
@@ -45,6 +45,46 @@
     max-width: 100%;
   }
 
+  /* Inline code */
+  :not(pre) > code {
+    padding: 0.1em 0.35em;
+    border: 1px solid #DCDCDC;
+    border-radius: 0.35em;
+    background: #f6f8fa;
+    color: #24292f;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.9em;
+    overflow-wrap: anywhere;
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+  }
+
+  /* Multiline code block */
+  pre {
+    max-width: 100%;
+    box-sizing: border-box;
+    padding: 1em;
+    margin: 1em 0;
+    overflow-x: auto;
+    border: 1px solid #DCDCDC;
+    border-radius: 0.5em;
+    background: #f6f8fa;
+    line-height: 1.5;
+    tab-size: 2;
+    white-space: pre;
+  }
+
+  pre code {
+    display: block;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: #24292f;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.9em;
+    overflow-wrap: normal;
+  }
+
   /* Some css classes */
   .flex {
     display: flex;
@@ -236,4 +276,3 @@
   }, false);
 
 </script>
-

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -212,11 +212,42 @@ a {
 }
 
 .ql-container .ql-editor {
+  contain: paint;
   height: auto;
   min-height:200px;
   max-height: 500px;
   overflow: auto;
   /* @apply min-h-screen; */
+}
+
+.admin-rich-editor .ql-container .ql-editor {
+  font-size: 120%;
+}
+
+.ql-editor img,
+.ql-editor video,
+.ql-editor iframe.ql-video {
+  cursor: grab;
+  user-select: none;
+  -webkit-user-drag: element;
+}
+
+.ql-editor .rich-editor-media-dragging {
+  cursor: grabbing;
+  opacity: 0.45;
+}
+
+.ql-editor .rich-editor-media-selected {
+  outline: 3px solid var(--color-brand-light);
+  outline-offset: 2px;
+}
+
+.ql-editor .rich-editor-media-drop-before {
+  box-shadow: 0 -3px 0 var(--color-brand-light);
+}
+
+.ql-editor .rich-editor-media-drop-after {
+  box-shadow: 0 3px 0 var(--color-brand-light);
 }
 
 .ql-toolbar {

--- a/tests/unit/client/RichEditorHtml.test.ts
+++ b/tests/unit/client/RichEditorHtml.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, test} from "vitest";
+import {
+  semanticCodeBlockHtml,
+  shouldReplaceRichEditorHtml,
+} from "@/client/RichEditorHtml";
+
+describe("semanticCodeBlockHtml", () => {
+  test("wraps multiple lines in semantic pre and code elements", () => {
+    expect(semanticCodeBlockHtml([
+      "const answer = 42;",
+      "console.log(answer);",
+    ])).toBe(
+      "<pre><code>const answer = 42;\nconsole.log(answer);</code></pre>",
+    );
+  });
+
+  test("escapes code without collapsing blank lines", () => {
+    expect(semanticCodeBlockHtml([
+      "if (value < 10 && value > 0) {",
+      "",
+      "}",
+    ])).toBe(
+      "<pre><code>if (value &lt; 10 &amp;&amp; value &gt; 0) {\n\n}</code></pre>",
+    );
+  });
+});
+
+describe("shouldReplaceRichEditorHtml", () => {
+  test("does not paste locally emitted HTML back into the editor", () => {
+    expect(shouldReplaceRichEditorHtml(
+      "<p>new line</p>",
+      "<p>new line</p>",
+      "<p>new line</p>",
+    )).toBe(false);
+  });
+
+  test("replaces editor content after a genuine external change", () => {
+    expect(shouldReplaceRichEditorHtml(
+      "<p>external edit</p>",
+      "<p>current value</p>",
+      null,
+    )).toBe(true);
+  });
+
+  test("treats Quill's empty paragraph as an empty value", () => {
+    expect(shouldReplaceRichEditorHtml("", "<p><br></p>", null)).toBe(false);
+  });
+});

--- a/tests/unit/client/RichEditorMedia.test.ts
+++ b/tests/unit/client/RichEditorMedia.test.ts
@@ -1,0 +1,175 @@
+import {describe, expect, it} from "vitest";
+
+import {
+  applyRichEditorMediaSettings,
+  isValidMediaDimension,
+  richEditorMediaEmbedFormat,
+  stripTransientRichEditorAttributes,
+} from "@/client/RichEditorMedia";
+
+function fakeMediaElement(tagName = "IFRAME") {
+  const attributes = new Map<string, string>();
+  const declarations = new Map<string, string>();
+  const style = {
+    get aspectRatio() {
+      return declarations.get("aspect-ratio") ?? "";
+    },
+    set aspectRatio(value: string) {
+      declarations.set("aspect-ratio", value);
+    },
+    get cssText() {
+      return Array.from(declarations)
+        .map(([property, value]) => `${property}: ${value};`)
+        .join(" ");
+    },
+    set cssText(value: string) {
+      declarations.clear();
+      for (const declaration of value.split(";")) {
+        const separator = declaration.indexOf(":");
+        if (separator > 0) {
+          declarations.set(
+            declaration.slice(0, separator).trim(),
+            declaration.slice(separator + 1).trim(),
+          );
+        }
+      }
+    },
+    get height() {
+      return declarations.get("height") ?? "";
+    },
+    set height(value: string) {
+      declarations.set("height", value);
+    },
+    get width() {
+      return declarations.get("width") ?? "";
+    },
+    set width(value: string) {
+      declarations.set("width", value);
+    },
+    getPropertyValue(property: string) {
+      return declarations.get(property) ?? "";
+    },
+    removeProperty(property: string) {
+      const previous = declarations.get(property) ?? "";
+      declarations.delete(property);
+      return previous;
+    },
+    setProperty(property: string, value: string) {
+      declarations.set(property, value);
+    },
+  };
+  return {
+    attributes,
+    declarations,
+    element: {
+      dataset: {} as DOMStringMap,
+      tagName,
+      getAttribute: (name: string) => attributes.get(name) ?? null,
+      removeAttribute: (name: string) => attributes.delete(name),
+      setAttribute: (name: string, value: string) => {
+        attributes.set(name, value);
+      },
+      style,
+    } as unknown as HTMLElement,
+  };
+}
+
+describe("rich editor media helpers", () => {
+  it("removes formatter-only attributes from iframe and image HTML", () => {
+    const html = [
+      '<iframe class="ql-video rich-editor-media-selected" draggable="true"',
+      ' data-blot-formatter-id="video-1"',
+      ' src="https://media.example.com/video.mp4"></iframe>',
+      "<p>Keep editing this source.</p>",
+      "<img class='rich-editor-media-dragging' draggable='true'",
+      " data-blot-formatter-id='image-1'",
+      ' src="/image.png">',
+      '<video class="ql-native-video ql-video custom-video"',
+      ' src="/video.mp4"></video>',
+    ].join("");
+
+    expect(stripTransientRichEditorAttributes(html)).toBe([
+      '<iframe class="ql-video"',
+      ' src="https://media.example.com/video.mp4"></iframe>',
+      "<p>Keep editing this source.</p>",
+      '<img src="/image.png">',
+      '<video class="custom-video" src="/video.mp4"></video>',
+    ].join(""));
+  });
+
+  it("does not change ordinary data attributes or media styles", () => {
+    const html = [
+      '<iframe class="ql-video" data-relative-size="true"',
+      ' style="--resize-width: 100%; border-radius: 12px"',
+      ' width="100%"></iframe>',
+    ].join("");
+
+    expect(stripTransientRichEditorAttributes(html)).toBe(html);
+  });
+
+  it("uses native video for uploads and keeps URL embeds compatible", () => {
+    expect(richEditorMediaEmbedFormat("image", true)).toBe("image");
+    expect(richEditorMediaEmbedFormat("video", true)).toBe("video");
+    expect(richEditorMediaEmbedFormat("video", false)).toBe("legacyVideo");
+  });
+
+  it("accepts practical CSS media dimensions and rejects invalid values", () => {
+    for (const value of ["", "auto", "0", "100%", "640px", "42.5rem"]) {
+      expect(isValidMediaDimension(value, "width"), value).toBe(true);
+    }
+    for (const value of ["wide", "100", "-12px", "100 pixels"]) {
+      expect(isValidMediaDimension(value, "height"), value).toBe(false);
+    }
+  });
+
+  it("uses a responsive aspect ratio for automatic video height", () => {
+    const {attributes, declarations, element} = fakeMediaElement();
+
+    applyRichEditorMediaSettings(element, "video", {
+      alt: "",
+      height: "auto",
+      style: "border-radius: 12px;",
+      title: "Walkthrough",
+      width: "100%",
+    });
+
+    expect(attributes.get("width")).toBe("100%");
+    expect(attributes.has("height")).toBe(false);
+    expect(attributes.get("title")).toBe("Walkthrough");
+    expect(declarations.get("width")).toBe("100%");
+    expect(declarations.get("height")).toBe("auto");
+    expect(declarations.get("aspect-ratio")).toBe("16 / 9");
+    expect(declarations.get("--resize-width")).toBe("100%");
+    expect(element.dataset.relativeSize).toBe("true");
+  });
+
+  it("preserves an explicit video aspect ratio", () => {
+    const {declarations, element} = fakeMediaElement();
+
+    applyRichEditorMediaSettings(element, "video", {
+      alt: "",
+      height: "auto",
+      style: "aspect-ratio: 9 / 16;",
+      title: "",
+      width: "100%",
+    });
+
+    expect(declarations.get("aspect-ratio")).toBe("9 / 16");
+  });
+
+  it("lets native video preserve its intrinsic aspect ratio", () => {
+    const {declarations, element} = fakeMediaElement("VIDEO");
+
+    applyRichEditorMediaSettings(element, "video", {
+      alt: "",
+      height: "auto",
+      style: "",
+      title: "",
+      width: "100%",
+    });
+
+    expect(declarations.get("width")).toBe("100%");
+    expect(declarations.get("height")).toBe("auto");
+    expect(declarations.has("aspect-ratio")).toBe(false);
+  });
+});

--- a/tests/unit/client/RichEditorToolbar.test.ts
+++ b/tests/unit/client/RichEditorToolbar.test.ts
@@ -1,0 +1,45 @@
+import {describe, expect, it} from "vitest";
+
+import {
+  labelRichEditorToolbar,
+  RICH_EDITOR_TOOLBAR_LABELS,
+} from "@/client/RichEditorToolbar";
+
+describe("labelRichEditorToolbar", () => {
+  it("adds accessible hover labels to every configured toolbar control", () => {
+    const controls = new Map<string, {
+      attributes: Map<string, string>;
+      setAttribute(name: string, value: string): void;
+    }>(
+      RICH_EDITOR_TOOLBAR_LABELS.map(([selector]) => [
+        selector,
+        {
+          attributes: new Map<string, string>(),
+          setAttribute(name: string, value: string) {
+            this.attributes.set(name, value);
+          },
+        },
+      ]),
+    );
+    const container = {
+      querySelectorAll(selector: string) {
+        const control = controls.get(selector);
+        return control ? [control] : [];
+      },
+    } as unknown as HTMLElement;
+
+    labelRichEditorToolbar(container);
+
+    RICH_EDITOR_TOOLBAR_LABELS.forEach(([selector, label]) => {
+      expect(controls.get(selector)?.attributes.get("aria-label")).toBe(label);
+      expect(controls.get(selector)?.attributes.get("title")).toBe(label);
+    });
+  });
+
+  it("keeps the clear-formatting control explicitly labeled", () => {
+    expect(RICH_EDITOR_TOOLBAR_LABELS).toContainEqual([
+      "button.ql-clean",
+      "Clear formatting",
+    ]);
+  });
+});

--- a/tests/unit/components/admin-ui-controls.test.ts
+++ b/tests/unit/components/admin-ui-controls.test.ts
@@ -3,8 +3,12 @@ import {renderToStaticMarkup} from "react-dom/server";
 import {describe, expect, it, vi} from "vitest";
 
 import AdminCopyableUrl from "@/components/admin/shared/AdminCopyableUrl";
+import AdminCodeEditor, {
+  isCaretOnLastLine,
+} from "@/components/admin/shared/AdminCodeEditor";
 import AdminDialog from "@/components/admin/shared/AdminDialog";
 import AdminImagePreviewDialog from "@/components/admin/shared/AdminImagePreviewDialog";
+import AdminHtmlEditor from "@/components/admin/shared/AdminHtmlEditor";
 import AdminPublicAccess, {
   publicAccessItems,
 } from "@/components/admin/shared/AdminPublicAccess";
@@ -15,6 +19,44 @@ import SettingsBase from "@/components/admin/settings/SettingsBase";
 import {Input} from "@/components/ui/input";
 
 describe("admin UI controls", () => {
+  it("only auto-scrolls a code editor when its caret is on the final line", () => {
+    const value = "first line\nsecond line\nlast line";
+
+    expect(isCaretOnLastLine(value, value.length, value.length)).toBe(true);
+    expect(isCaretOnLastLine(value, 24, 24)).toBe(true);
+    expect(isCaretOnLastLine(value, 5, 5)).toBe(false);
+    expect(isCaretOnLastLine(value, 5, value.length)).toBe(false);
+  });
+
+  it("scrolls code editors outside their synchronized textarea and preview layers", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(AdminCodeEditor, {
+        code: "<p>Hello</p>",
+        language: "html",
+        maxHeight: "32rem",
+        minHeight: "16rem",
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(output).toMatch(
+      /^<label[^>]+overflow-auto[^>]+style="max-height:32rem"/u,
+    );
+    expect(output).toContain("min-height:16rem");
+    expect(output).not.toContain("max-height:32rem;min-height:16rem");
+  });
+
+  it("renders the rich HTML source editor at 120% of its base font size", () => {
+    const output = renderToStaticMarkup(
+      React.createElement(AdminHtmlEditor, {
+        onChange: vi.fn(),
+        value: "<p>Hello</p>",
+      }),
+    );
+
+    expect(output).toContain("font-size:14.4px");
+  });
+
   it("orders and labels the public access feeds", () => {
     const links = {
       json: "https://feed.example.com/json/",

--- a/tests/unit/server/better-auth.test.ts
+++ b/tests/unit/server/better-auth.test.ts
@@ -1,0 +1,39 @@
+import {describe, expect, it} from "vitest";
+
+import {withAuthSessionCookies} from "@/server/auth/better-auth";
+
+describe("withAuthSessionCookies", () => {
+  it("forwards refreshed session cookies without changing the response", async () => {
+    const authHeaders = new Headers();
+    authHeaders.append(
+      "set-cookie",
+      "microfeed.session_token=refreshed; Path=/; HttpOnly",
+    );
+    authHeaders.append(
+      "set-cookie",
+      "microfeed.session_data=cached; Path=/; HttpOnly",
+    );
+    const response = withAuthSessionCookies(
+      new Response("updated", {
+        headers: {"x-response-header": "preserved"},
+        status: 202,
+        statusText: "Accepted",
+      }),
+      authHeaders,
+    );
+
+    expect(response.status).toBe(202);
+    expect(response.statusText).toBe("Accepted");
+    expect(response.headers.get("x-response-header")).toBe("preserved");
+    expect(response.headers.getSetCookie()).toEqual([
+      "microfeed.session_token=refreshed; Path=/; HttpOnly",
+      "microfeed.session_data=cached; Path=/; HttpOnly",
+    ]);
+    expect(await response.text()).toBe("updated");
+  });
+
+  it("returns the original response when no session cookie changed", () => {
+    const response = new Response("unchanged");
+    expect(withAuthSessionCookies(response, new Headers())).toBe(response);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,15 +1532,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@enzedonline/quill-blot-formatter2@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "@enzedonline/quill-blot-formatter2@npm:3.2.0"
-  dependencies:
-    deepmerge: "npm:^4.3.1"
-  checksum: 10/a7f00f4aebfb5f8932d6317c1e3fe3a3e287e21c9a1920f769aeda8bcbcbdcf54aec5cde57328b6609d5479e4bcd317e558cff63b577b7a4a3018fd61f052643
-  languageName: node
-  linkType: hard
-
 "@esbuild/aix-ppc64@npm:0.28.1":
   version: 0.28.1
   resolution: "@esbuild/aix-ppc64@npm:0.28.1"
@@ -8778,7 +8769,6 @@ __metadata:
     "@base-ui/react": "npm:^1.6.0"
     "@clack/prompts": "npm:^1.7.0"
     "@cloudflare/vitest-pool-workers": "npm:^0.19.0"
-    "@enzedonline/quill-blot-formatter2": "npm:^3.2.0"
     "@fontsource-variable/geist": "npm:^5.3.0"
     "@redocly/cli": "npm:^2.44.1"
     "@scalar/api-reference-react": "npm:^0.9.60"


### PR DESCRIPTION
## Summary

- replace uploaded-video iframe embeds with native video elements while retaining legacy and external URL compatibility
- add media drag-and-drop reordering, clipboard selection, trailing editable lines, and a reusable dialog for image/video size, style, title, and alt text
- produce semantic inline and multiline code markup, label every visual-editor toolbar control, and add default public-site code styling
- improve visual and HTML source editor sizing, scrolling, cursor behavior, and synchronization without unexpected page jumps
- refresh built-in authentication session cookies so long editing sessions can still save successfully
- remove the obsolete Quill blot formatter dependency and transient formatter markup

## Related issue

None.

## Testing

- [x] `yarn check`
- [x] Focused rich-editor, toolbar, HTML serialization, media, admin-control, and authentication tests
- [x] `git diff --check`

## Screenshots

N/A. The visible editor interactions were exercised manually throughout implementation.

## Risks

- Existing iframe video embeds remain supported, while newly uploaded videos serialize as native video elements.
- Rich-editor HTML serialization now normalizes code blocks and removes editor-only media attributes before saving.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
