### PR TITLE
Use native video embeds and fix editor media dragging

### DIFF
--- a/src/client/RichEditorMedia.ts
+++ b/src/client/RichEditorMedia.ts
@@ -1,16 +1,24 @@
 export const RICH_EDITOR_MEDIA_STYLE_FORMAT = "mediaStyle";
 export const RICH_EDITOR_MEDIA_TITLE_FORMAT = "mediaTitle";
 export const RICH_EDITOR_LEGACY_VIDEO_FORMAT = "legacyVideo";
+const RICH_EDITOR_MEDIA_DRAG_THRESHOLD_PX = 6;
 
 export type RichEditorMediaType = "image" | "video";
 
 export function richEditorMediaEmbedFormat(
   mediaType: RichEditorMediaType,
-  uploadedFile: boolean,
-): RichEditorMediaType | typeof RICH_EDITOR_LEGACY_VIDEO_FORMAT {
-  return mediaType === "video" && !uploadedFile
-    ? RICH_EDITOR_LEGACY_VIDEO_FORMAT
-    : mediaType;
+): RichEditorMediaType {
+  return mediaType;
+}
+
+export function shouldStartRichEditorMediaDrag(
+  startX: number,
+  startY: number,
+  currentX: number,
+  currentY: number,
+): boolean {
+  return Math.hypot(currentX - startX, currentY - startY) >=
+    RICH_EDITOR_MEDIA_DRAG_THRESHOLD_PX;
 }
 
 export interface RichEditorMediaSettings {
@@ -59,7 +67,7 @@ export function stripTransientRichEditorAttributes(html: string): string {
       /\sdata-blot-formatter-id=(?:"[^"]*"|'[^']*')/giu,
       "",
     )
-    .replace(/\sdraggable=(?:"true"|'true')/giu, "")
+    .replace(/\sdraggable=(?:"(?:true|false)"|'(?:true|false)')/giu, "")
     .replace(
       /\sclass=("([^"]*)"|'([^']*)')/giu,
       (_match, quotedValue: string, doubleQuoted: string, singleQuoted: string) => {

--- a/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaDialog/index.tsx
+++ b/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaDialog/index.tsx
@@ -119,7 +119,7 @@ export default class RichEditorMediaDialog extends React.Component<any, any> {
         progressText: 'Done!',
         uploadStatus: null,
       }, () => {
-        this.insertMedia(true);
+        this.insertMedia();
         setIsOpen(false);
       })
     }, () => {
@@ -139,7 +139,7 @@ export default class RichEditorMediaDialog extends React.Component<any, any> {
     });
   }
 
-  insertMedia(uploadedFile = false) {
+  insertMedia() {
     const {quill, quillSelection, mediaType} = this.props;
     if (!quill) {
       return;
@@ -149,7 +149,7 @@ export default class RichEditorMediaDialog extends React.Component<any, any> {
       const index = quillSelection ? quillSelection.index : 0;
       quill.insertEmbed(
         index,
-        richEditorMediaEmbedFormat(mediaType, uploadedFile),
+        richEditorMediaEmbedFormat(mediaType),
         url,
         Quill.sources.USER,
       );

--- a/src/components/admin/shared/AdminRichEditor/component/RichEditorQuill/index.tsx
+++ b/src/components/admin/shared/AdminRichEditor/component/RichEditorQuill/index.tsx
@@ -14,6 +14,7 @@ import {
   RICH_EDITOR_MEDIA_STYLE_FORMAT,
   RICH_EDITOR_MEDIA_TITLE_FORMAT,
   richEditorMediaType,
+  shouldStartRichEditorMediaDrag,
   type RichEditorMediaSettings,
   type RichEditorMediaType,
 } from "@/client/RichEditorMedia";
@@ -220,6 +221,13 @@ const EMPTY_MEDIA_SETTINGS: RichEditorMediaSettings = {
 
 type MediaDropPosition = "after" | "before";
 
+interface MediaPointerDown {
+  element: HTMLElement;
+  pointerId: number;
+  startX: number;
+  startY: number;
+}
+
 function editorBlockForTarget(
   target: EventTarget | null,
   editorRoot: HTMLElement,
@@ -255,13 +263,14 @@ export default class RichEditorQuill extends React.Component<any, any> {
     | ((delta: Delta, oldDelta: Delta, source: EmitterSource) => void)
     | null = null;
   mediaClickHandler: ((event: MouseEvent) => void) | null = null;
-  mediaDragEndHandler: ((event: DragEvent) => void) | null = null;
-  mediaDragOverHandler: ((event: DragEvent) => void) | null = null;
-  mediaDragStartHandler: ((event: DragEvent) => void) | null = null;
-  mediaDropHandler: ((event: DragEvent) => void) | null = null;
+  mediaPointerCancelHandler: ((event: PointerEvent) => void) | null = null;
+  mediaPointerDownHandler: ((event: PointerEvent) => void) | null = null;
+  mediaPointerMoveHandler: ((event: PointerEvent) => void) | null = null;
+  mediaPointerUpHandler: ((event: PointerEvent) => void) | null = null;
   draggedMediaElement: HTMLElement | null = null;
   mediaDropBlock: HTMLElement | null = null;
   mediaDropPosition: MediaDropPosition | null = null;
+  mediaPointerDown: MediaPointerDown | null = null;
   selectedMediaElement: HTMLElement | null = null;
   lastMediaClickAt = 0;
   lastMediaClickElement: HTMLElement | null = null;
@@ -292,11 +301,11 @@ export default class RichEditorQuill extends React.Component<any, any> {
     this.props.onChange(html);
   }
 
-  enableMediaDragging() {
+  prepareMediaDragging() {
     this.quillRef?.root.querySelectorAll<HTMLElement>(
       "img, video, iframe.ql-video",
     ).forEach((element) => {
-      element.draggable = true;
+      element.draggable = false;
     });
   }
 
@@ -317,15 +326,20 @@ export default class RichEditorQuill extends React.Component<any, any> {
     editor.update(Quill.sources.USER);
   }
 
-  clearMediaDragState() {
-    this.draggedMediaElement?.classList.remove("rich-editor-media-dragging");
+  clearMediaDropPosition() {
     this.mediaDropBlock?.classList.remove(
       "rich-editor-media-drop-after",
       "rich-editor-media-drop-before",
     );
-    this.draggedMediaElement = null;
     this.mediaDropBlock = null;
     this.mediaDropPosition = null;
+  }
+
+  clearMediaDragState() {
+    this.draggedMediaElement?.classList.remove("rich-editor-media-dragging");
+    this.clearMediaDropPosition();
+    this.draggedMediaElement = null;
+    this.mediaPointerDown = null;
   }
 
   selectMediaForClipboard(element: HTMLElement) {
@@ -488,7 +502,7 @@ export default class RichEditorQuill extends React.Component<any, any> {
       editor.clipboard.dangerouslyPasteHTML(initialValue, 'silent');
     }
     this.textChangeHandler = (_delta, _oldDelta, source) => {
-      this.enableMediaDragging();
+      this.prepareMediaDragging();
       if (source !== 'silent') {
         this.emitHtmlChange();
       }
@@ -552,29 +566,54 @@ export default class RichEditorQuill extends React.Component<any, any> {
       this.mediaClickHandler,
       true,
     );
-    this.mediaDragStartHandler = (event) => {
+    this.mediaPointerDownHandler = (event) => {
+      if (event.button !== 0 || !event.isPrimary) {
+        return;
+      }
       const mediaElement = findRichEditorMediaElement(event.target, editor.root);
       if (!mediaElement) {
         return;
       }
-      this.draggedMediaElement = mediaElement;
-      mediaElement.classList.add("rich-editor-media-dragging");
-      if (event.dataTransfer) {
-        event.dataTransfer.effectAllowed = "move";
-        event.dataTransfer.setData("text/plain", "microfeed-rich-editor-media");
-      }
+      this.clearMediaDragState();
+      this.mediaPointerDown = {
+        element: mediaElement,
+        pointerId: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+      };
     };
-    this.mediaDragOverHandler = (event) => {
+    this.mediaPointerMoveHandler = (event) => {
+      const pointerDown = this.mediaPointerDown;
+      if (!pointerDown || event.pointerId !== pointerDown.pointerId) {
+        return;
+      }
       if (!this.draggedMediaElement) {
-        return;
+        if (!shouldStartRichEditorMediaDrag(
+          pointerDown.startX,
+          pointerDown.startY,
+          event.clientX,
+          event.clientY,
+        )) {
+          return;
+        }
+        if (!editor.root.contains(pointerDown.element)) {
+          this.clearMediaDragState();
+          return;
+        }
+        this.clearSelectedMedia();
+        this.draggedMediaElement = pointerDown.element;
+        this.draggedMediaElement.classList.add("rich-editor-media-dragging");
       }
-      const block = editorBlockForTarget(event.target, editor.root);
-      if (!block || block.contains(this.draggedMediaElement)) {
-        return;
-      }
+
       event.preventDefault();
-      if (event.dataTransfer) {
-        event.dataTransfer.dropEffect = "move";
+      const target = editor.root.ownerDocument.elementFromPoint(
+        event.clientX,
+        event.clientY,
+      );
+      const block = editorBlockForTarget(target, editor.root);
+      if (!block || block.contains(this.draggedMediaElement)) {
+        this.clearMediaDropPosition();
+        return;
       }
       const bounds = block.getBoundingClientRect();
       this.showMediaDropPosition(
@@ -582,20 +621,35 @@ export default class RichEditorQuill extends React.Component<any, any> {
         event.clientY < bounds.top + bounds.height / 2 ? "before" : "after",
       );
     };
-    this.mediaDropHandler = (event) => {
-      if (!this.draggedMediaElement || !this.mediaDropBlock) {
+    this.mediaPointerUpHandler = (event) => {
+      if (
+        !this.mediaPointerDown ||
+        event.pointerId !== this.mediaPointerDown.pointerId
+      ) {
         return;
       }
-      event.preventDefault();
-      this.moveDraggedMedia();
+      if (this.draggedMediaElement) {
+        event.preventDefault();
+        this.moveDraggedMedia();
+        this.lastMediaClickAt = 0;
+        this.lastMediaClickElement = null;
+      }
       this.clearMediaDragState();
     };
-    this.mediaDragEndHandler = () => this.clearMediaDragState();
-    editor.root.addEventListener("dragstart", this.mediaDragStartHandler);
-    editor.root.addEventListener("dragover", this.mediaDragOverHandler);
-    editor.root.addEventListener("drop", this.mediaDropHandler);
-    editor.root.addEventListener("dragend", this.mediaDragEndHandler);
-    this.enableMediaDragging();
+    this.mediaPointerCancelHandler = (event) => {
+      if (event.pointerId === this.mediaPointerDown?.pointerId) {
+        this.clearMediaDragState();
+      }
+    };
+    editor.root.addEventListener("pointerdown", this.mediaPointerDownHandler);
+    document.addEventListener("pointermove", this.mediaPointerMoveHandler, true);
+    document.addEventListener("pointerup", this.mediaPointerUpHandler, true);
+    document.addEventListener(
+      "pointercancel",
+      this.mediaPointerCancelHandler,
+      true,
+    );
+    this.prepareMediaDragging();
     this.ensureTrailingEditableLine();
   }
 
@@ -615,7 +669,7 @@ export default class RichEditorQuill extends React.Component<any, any> {
       if (shouldReplace) {
         const selection = this.quillRef.getSelection();
         this.quillRef.clipboard.dangerouslyPasteHTML(nextValue, 'silent');
-        this.enableMediaDragging();
+        this.prepareMediaDragging();
         this.ensureTrailingEditableLine();
         if (selection) {
           const maxIndex = Math.max(0, this.quillRef.getLength() - 1);
@@ -632,18 +686,30 @@ export default class RichEditorQuill extends React.Component<any, any> {
   componentWillUnmount() {
     if (this.quillRef) {
       const root = this.quillRef.root;
-      if (this.mediaDragStartHandler) {
-        root.removeEventListener("dragstart", this.mediaDragStartHandler);
+      if (this.mediaPointerDownHandler) {
+        root.removeEventListener("pointerdown", this.mediaPointerDownHandler);
       }
-      if (this.mediaDragOverHandler) {
-        root.removeEventListener("dragover", this.mediaDragOverHandler);
-      }
-      if (this.mediaDropHandler) {
-        root.removeEventListener("drop", this.mediaDropHandler);
-      }
-      if (this.mediaDragEndHandler) {
-        root.removeEventListener("dragend", this.mediaDragEndHandler);
-      }
+    }
+    if (this.mediaPointerMoveHandler) {
+      document.removeEventListener(
+        "pointermove",
+        this.mediaPointerMoveHandler,
+        true,
+      );
+    }
+    if (this.mediaPointerUpHandler) {
+      document.removeEventListener(
+        "pointerup",
+        this.mediaPointerUpHandler,
+        true,
+      );
+    }
+    if (this.mediaPointerCancelHandler) {
+      document.removeEventListener(
+        "pointercancel",
+        this.mediaPointerCancelHandler,
+        true,
+      );
     }
     if (this.quillRef && this.mediaClickHandler) {
       document.removeEventListener(
@@ -657,10 +723,10 @@ export default class RichEditorQuill extends React.Component<any, any> {
     }
     this.clearMediaDragState();
     this.clearSelectedMedia();
-    this.mediaDragEndHandler = null;
-    this.mediaDragOverHandler = null;
-    this.mediaDragStartHandler = null;
-    this.mediaDropHandler = null;
+    this.mediaPointerCancelHandler = null;
+    this.mediaPointerDownHandler = null;
+    this.mediaPointerMoveHandler = null;
+    this.mediaPointerUpHandler = null;
     this.mediaClickHandler = null;
     this.lastMediaClickAt = 0;
     this.lastMediaClickElement = null;
@@ -692,10 +758,6 @@ export default class RichEditorQuill extends React.Component<any, any> {
       quillSelection={quillSelection}
       extra={extra}
     />
-    <p className="mt-2 text-xs text-muted-foreground">
-      Tip: Drag an image or video to move it. Double-click to edit its size and
-      style.
-    </p>
     <RichEditorMediaSettingsDialog
       errors={mediaSettingsErrors}
       mediaType={settingsMediaType}

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -229,7 +229,7 @@ a {
 .ql-editor iframe.ql-video {
   cursor: grab;
   user-select: none;
-  -webkit-user-drag: element;
+  -webkit-user-drag: none;
 }
 
 .ql-editor .rich-editor-media-dragging {

--- a/tests/unit/client/RichEditorMedia.test.ts
+++ b/tests/unit/client/RichEditorMedia.test.ts
@@ -4,6 +4,7 @@ import {
   applyRichEditorMediaSettings,
   isValidMediaDimension,
   richEditorMediaEmbedFormat,
+  shouldStartRichEditorMediaDrag,
   stripTransientRichEditorAttributes,
 } from "@/client/RichEditorMedia";
 
@@ -81,7 +82,7 @@ describe("rich editor media helpers", () => {
       ' data-blot-formatter-id="video-1"',
       ' src="https://media.example.com/video.mp4"></iframe>',
       "<p>Keep editing this source.</p>",
-      "<img class='rich-editor-media-dragging' draggable='true'",
+      "<img class='rich-editor-media-dragging' draggable='false'",
       " data-blot-formatter-id='image-1'",
       ' src="/image.png">',
       '<video class="ql-native-video ql-video custom-video"',
@@ -107,10 +108,14 @@ describe("rich editor media helpers", () => {
     expect(stripTransientRichEditorAttributes(html)).toBe(html);
   });
 
-  it("uses native video for uploads and keeps URL embeds compatible", () => {
-    expect(richEditorMediaEmbedFormat("image", true)).toBe("image");
-    expect(richEditorMediaEmbedFormat("video", true)).toBe("video");
-    expect(richEditorMediaEmbedFormat("video", false)).toBe("legacyVideo");
+  it("uses native media formats for new URL and file inserts", () => {
+    expect(richEditorMediaEmbedFormat("image")).toBe("image");
+    expect(richEditorMediaEmbedFormat("video")).toBe("video");
+  });
+
+  it("starts pointer dragging only after intentional movement", () => {
+    expect(shouldStartRichEditorMediaDrag(10, 10, 13, 14)).toBe(false);
+    expect(shouldStartRichEditorMediaDrag(10, 10, 16, 10)).toBe(true);
   });
 
   it("accepts practical CSS media dimensions and rejects invalid values", () => {


### PR DESCRIPTION
## Summary

- Insert new video URLs as native video elements instead of iframe embeds.
- Replace unreliable native HTML drag-and-drop with pointer-based image and video reordering.
- Remove the outdated editor drag tip while preserving legacy iframe compatibility.

## Related issue

N/A.

## Testing

- [x] yarn check
- [x] Manually verified image reordering in the local visual editor.
- [x] Manually verified native video reordering and clean serialized HTML.

## Screenshots

N/A. This changes editor interaction behavior and removes one line of helper text.

## Risks

Low. Existing legacy iframe embeds remain supported; new video inserts use the already registered native video blot.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] No documentation update is required because commands and documented public contracts are unchanged.
- [x] No secrets, private configuration, production data, or generated files are included.