### PR TITLE
Add deployment walkthrough to quick start

### DIFF
--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -48,6 +48,11 @@ You need:
 The result is a microfeed site in your Cloudflare account with a public
 website, RSS feed, JSON Feed, and a private admin dashboard.
 
+<video class="docs-walkthrough" controls autoplay muted playsinline preload="metadata" poster="/images/screenshots/1-deploy-1.png" aria-label="A silent Codex deployment walkthrough progressing from the initial request through verification to the ready microfeed dashboard">
+  <source src="/images/screenshots/1-deploy-walkthrough.mp4" type="video/mp4">
+  <a href="/images/screenshots/1-deploy-walkthrough.mp4">Watch the microfeed deployment walkthrough.</a>
+</video>
+
 ## Confirm the installation
 
 Ask the agent to run `yarn manage status`. The report should confirm the Worker,

--- a/tests/unit/docs-site.test.ts
+++ b/tests/unit/docs-site.test.ts
@@ -375,6 +375,19 @@ describe("documentation site", () => {
     expect(quickStart).toContain("cd microfeed");
     expect(quickStart).toContain('```text frame="terminal" wrap');
     expect(quickStart).toContain("Deploy microfeed to Cloudflare.");
+    expect(quickStart).toContain(
+      '<video class="docs-walkthrough" controls autoplay muted playsinline preload="metadata"',
+    );
+    expect(quickStart).toContain(
+      '<source src="/images/screenshots/1-deploy-walkthrough.mp4" type="video/mp4">',
+    );
+    const walkthroughIndex = quickStart.indexOf("1-deploy-walkthrough.mp4");
+    expect(walkthroughIndex).toBeGreaterThan(
+      quickStart.indexOf("The result is a microfeed site"),
+    );
+    expect(walkthroughIndex).toBeLessThan(
+      quickStart.indexOf("## Confirm the installation"),
+    );
     expect(quickStart).toContain("## Confirm the installation");
     expect(quickStart).toContain("`yarn manage status`");
     expect(quickStart).toContain("[Deploy with an AI coding agent](./ai-agent/)");


### PR DESCRIPTION
## Summary

- Add the existing deployment walkthrough video to the end of the Quick start Deploy with an agent section.
- Reuse the accessible video controls, poster, fallback link, and responsive theme-safe styling from the detailed agent guide.
- Add focused coverage that verifies the embed source and its placement before Confirm the installation.

## Related issue

N/A.

## Testing

- [x] yarn vitest run tests/unit/docs-site.test.ts
- [x] yarn docs:check
- [x] yarn check
- [x] Verified desktop and 390px mobile layouts in light and dark themes with no horizontal overflow.

## Screenshots

N/A. The visible addition is the existing 22-second walkthrough video, verified in the local rendered preview on desktop and mobile.

## Risks

None. This reuses an existing published asset and shared documentation styling.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.