### PR TITLE
Cache public pages with Workers Caching

### DIFF
--- a/manage-cli/lib/config.ts
+++ b/manage-cli/lib/config.ts
@@ -531,6 +531,11 @@ export function workersDevEnabled(config: MicrofeedConfig): boolean {
   return config.customDomain === null;
 }
 
+export function workersCacheEnabled(config: MicrofeedConfig): boolean {
+  return config.hosting === "cloudflare" &&
+    deploymentEnvironment(config) === "production";
+}
+
 export function localConfig(instanceName = "local"): MicrofeedConfig {
   const resourcePrefix = instanceName === "local"
     ? "microfeed-local"
@@ -659,6 +664,10 @@ export async function generateWranglerConfig(
     .replaceAll("__PROJECT_ROOT__", relativeRoot)
     .replaceAll("__WORKER_NAME__", workerName(config))
     .replaceAll("__WORKERS_DEV__", String(workersDevEnabled(config)))
+    .replaceAll(
+      "__WORKERS_CACHE_ENABLED__",
+      String(workersCacheEnabled(config)),
+    )
     .replaceAll("__CLOUDFLARE_ACCOUNT_ID__", config.accountId ?? "")
     .replaceAll("__PROJECT_NAME__", config.projectName)
     .replaceAll("__ADMIN_AUTH_MODE__", effectiveAdminAuthMode)

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import {env} from "cloudflare:workers";
+import {cache, env} from "cloudflare:workers";
 import {defineMiddleware} from "astro:middleware";
 
 import {builtInAdminAuthEnabled} from "@/shared/AdminAuth";
@@ -31,6 +31,7 @@ import {
   decideApiRequest,
 } from "@/server/api/access";
 import {createFeedCrud, loadFeed} from "@/server/feed/feed";
+import {applyWorkerCachePolicy} from "@/server/cache/public-cache";
 
 const AUTH_BASE_PATH = "/api/auth";
 function apiNotFoundResponse(): Response {
@@ -73,7 +74,7 @@ function wantsJson(request: Request, pathname: string): boolean {
     request.headers.get("accept")?.includes("application/json") === true;
 }
 
-export const onRequest = defineMiddleware(async (context, next) => {
+const handleRequest = defineMiddleware(async (context, next) => {
   const {pathname} = context.url;
   let authSessionHeaders: Headers | undefined;
   const adminPath = normalizeAdminPath(env.MICROFEED_ADMIN_PATH);
@@ -132,7 +133,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
       );
     }
 
-    const loaded = await loadFeed(env, context.request);
+    const loaded = await loadFeed(env, context.request, undefined, cache);
     const webGlobalSettings = loaded.content.settings?.webGlobalSettings ?? {};
     context.locals.feedDb = loaded.database;
     context.locals.feedContent = loaded.content;
@@ -277,6 +278,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
               }
             : {}),
         },
+        cache,
       );
       context.locals.feedDb = loaded.database;
       context.locals.feedContent = loaded.content;
@@ -288,4 +290,15 @@ export const onRequest = defineMiddleware(async (context, next) => {
   return authSessionHeaders
     ? withAuthSessionCookies(response, authSessionHeaders)
     : response;
+});
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const response = await handleRequest(context, next);
+  if (!(response instanceof Response)) {
+    throw new TypeError("microfeed middleware did not return a response");
+  }
+  return applyWorkerCachePolicy(context.request, response, {
+    adminPath: normalizeAdminPath(env.MICROFEED_ADMIN_PATH),
+    deploymentEnvironment: env.DEPLOYMENT_ENVIRONMENT,
+  });
 });

--- a/src/pages/[adminPath]/ajax/feed.ts
+++ b/src/pages/[adminPath]/ajax/feed.ts
@@ -1,4 +1,4 @@
-import {env, waitUntil} from "cloudflare:workers";
+import {cache, env, waitUntil} from "cloudflare:workers";
 import type {APIRoute} from "astro";
 
 import FeedDb from "@/server/feed/FeedDb";
@@ -6,17 +6,19 @@ import {scheduleBestEffortMediaDeletion} from "@/server/media/deletions";
 import {mediaBucket} from "@/server/media/storage";
 import {jsonResponse} from "../../../server/http";
 import type {FeedContent} from "../../../types";
+import type {PublicCachePurger} from "@/server/cache/public-cache";
 
 export async function updateAdminFeed(
   request: Request,
   runtimeEnv: Env,
   schedule: (promise: Promise<unknown>) => void,
+  publicCachePurger?: PublicCachePurger,
 ): Promise<Response> {
   const updatedFeed = await request.json() as FeedContent;
   const deleteImageUrls = Array.isArray(updatedFeed.deleteImageUrls)
     ? updatedFeed.deleteImageUrls
     : [];
-  const database = new FeedDb(runtimeEnv, request);
+  const database = new FeedDb(runtimeEnv, request, publicCachePurger);
   await database.putContent(updatedFeed);
   scheduleBestEffortMediaDeletion(
     mediaBucket(runtimeEnv),
@@ -27,4 +29,4 @@ export async function updateAdminFeed(
 }
 
 export const POST: APIRoute = async ({request}) =>
-  updateAdminFeed(request, env, waitUntil);
+  updateAdminFeed(request, env, waitUntil, cache);

--- a/src/pages/[adminPath]/ajax/r2-ops.ts
+++ b/src/pages/[adminPath]/ajax/r2-ops.ts
@@ -1,4 +1,4 @@
-import {env, waitUntil} from "cloudflare:workers";
+import {cache, env, waitUntil} from "cloudflare:workers";
 import type {APIRoute} from "astro";
 
 import {jsonResponse} from "../../../server/http";
@@ -13,6 +13,7 @@ import {
   mediaStorageUnavailableResponse,
 } from "@/server/media/storage";
 import type {UploadRequest} from "../../../types";
+import type {PublicCachePurger} from "@/server/cache/public-cache";
 
 export const POST: APIRoute = async ({request}) => {
   if (!mediaBucket(env)) {
@@ -33,6 +34,7 @@ export async function deleteAdminImage(
   request: Request,
   runtimeEnv: Env,
   schedule: (promise: Promise<unknown>) => void,
+  publicCachePurger?: PublicCachePurger,
 ): Promise<Response> {
   let rawInput: unknown;
   try {
@@ -47,7 +49,8 @@ export async function deleteAdminImage(
 
   try {
     const storedImageUrl = input.target
-      ? await new FeedDb(runtimeEnv, request).removeImageMetadata(input.target)
+      ? await new FeedDb(runtimeEnv, request, publicCachePurger)
+        .removeImageMetadata(input.target)
       : null;
     const keys = scheduleBestEffortMediaDeletion(
       mediaBucket(runtimeEnv),
@@ -65,4 +68,4 @@ export async function deleteAdminImage(
 }
 
 export const DELETE: APIRoute = async ({request}) =>
-  deleteAdminImage(request, env, waitUntil);
+  deleteAdminImage(request, env, waitUntil, cache);

--- a/src/server/cache/public-cache.ts
+++ b/src/server/cache/public-cache.ts
@@ -1,0 +1,287 @@
+import {isAdminPathname} from "@/shared/AdminPath";
+import {
+  ITEMS_SORT_ORDERS,
+  SETTINGS_CATEGORIES,
+} from "@/shared/Constants";
+import {
+  decodeItemCursor,
+  ITEM_ORDERS,
+  ITEM_SORTS,
+} from "@/shared/ItemPagination";
+import {getIdFromSlug} from "@/shared/StringUtils";
+import type {FeedContent, ImageMetadataTarget} from "@/types";
+
+export const PUBLIC_CACHE_BROWSER_CONTROL = "no-cache";
+export const PUBLIC_CACHE_EDGE_CONTROL =
+  "public, max-age=300, stale-if-error=86400";
+export const PRIVATE_CACHE_CONTROL = "private, no-store";
+
+export const PUBLIC_CACHE_TAGS = {
+  CHANNEL_PRIMARY: "mf:channel:primary",
+  ITEMS: "mf:items",
+  PUBLIC: "mf:public",
+  THEME_CURRENT: "mf:theme:current",
+  item: (itemId: string) => `mf:item:${itemId}`,
+} as const;
+
+export type PublicCachePurger = Pick<CacheContext, "purge">;
+
+interface WorkerCachePolicyOptions {
+  adminPath: string;
+  deploymentEnvironment?: "preview" | "production";
+}
+
+const PAGINATED_PUBLIC_PATHS = new Set(["/", "/json/", "/rss/"]);
+const PUBLIC_PAGE_PATHS = new Set([
+  "/",
+  "/.well-known/microfeed.json",
+  "/json/",
+  "/rss/",
+  "/rss/stylesheet/",
+  "/sitemap.xml",
+]);
+const PAGINATION_PARAMETERS = new Set([
+  "next_cursor",
+  "order",
+  "prev_cursor",
+  "sort",
+]);
+const FEED_CONTENT_PATHS = new Set([
+  "/",
+  "/json/",
+  "/rss/",
+  "/rss/stylesheet/",
+  "/sitemap.xml",
+]);
+
+function normalizedTags(tags: Iterable<string>): string[] {
+  return [...new Set(tags)].filter(
+    (tag) => /^[\x21-\x7e]{1,1024}$/u.test(tag) && !tag.includes(","),
+  );
+}
+
+function isItemPath(pathname: string): boolean {
+  return /^\/i\/[^/]+\/(?:json\/|rss\/)?$/u.test(pathname);
+}
+
+function isPublicPagePath(pathname: string): boolean {
+  return PUBLIC_PAGE_PATHS.has(pathname) || isItemPath(pathname);
+}
+
+function isPublicAssetPath(pathname: string): boolean {
+  return pathname.startsWith("/_astro/") ||
+    pathname.startsWith("/assets/") ||
+    pathname.startsWith("/media/");
+}
+
+function itemIdForPath(pathname: string): string | undefined {
+  const slug = /^\/i\/([^/]+)\/(?:json\/|rss\/)?$/u.exec(pathname)?.[1];
+  return slug ? getIdFromSlug(slug) : undefined;
+}
+
+function isFeedContentPath(pathname: string): boolean {
+  return FEED_CONTENT_PATHS.has(pathname) || isItemPath(pathname);
+}
+
+function isThemePath(pathname: string): boolean {
+  return pathname === "/" || pathname === "/rss/stylesheet/" ||
+    /^\/i\/[^/]+\/$/u.test(pathname);
+}
+
+function validPaginationQuery(url: URL): boolean {
+  if (!url.search) return true;
+  if (!PAGINATED_PUBLIC_PATHS.has(url.pathname)) return false;
+
+  const entries = [...url.searchParams.entries()];
+  if (
+    entries.some(([key]) => !PAGINATION_PARAMETERS.has(key)) ||
+    new Set(entries.map(([key]) => key)).size !== entries.length ||
+    (
+      url.searchParams.has("next_cursor") &&
+      url.searchParams.has("prev_cursor")
+    )
+  ) {
+    return false;
+  }
+
+  const sort = url.searchParams.get("sort");
+  const canonicalSort = sort === null ||
+    Object.values(ITEM_SORTS).some((value) => value === sort);
+  const legacySort = Object.values(ITEMS_SORT_ORDERS).some(
+    (value) => value === sort,
+  );
+  if (!canonicalSort && !legacySort) return false;
+
+  const order = url.searchParams.get("order");
+  if (
+    order !== null &&
+    !Object.values(ITEM_ORDERS).some((value) => value === order)
+  ) {
+    return false;
+  }
+  if (legacySort && order !== null) return false;
+
+  for (const key of ["next_cursor", "prev_cursor"]) {
+    const value = url.searchParams.get(key);
+    if (value === null) continue;
+    if (legacySort) {
+      if (!/^\d{1,16}$/u.test(value)) return false;
+    } else if (value.length > 512 || !decodeItemCursor(value)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isSensitivePath(pathname: string, adminPath: string): boolean {
+  return isAdminPathname(pathname, adminPath) ||
+    pathname === "/api" ||
+    pathname.startsWith("/api/") ||
+    pathname === "/media" ||
+    pathname.startsWith("/media/") ||
+    pathname === "/media-upload" ||
+    pathname.startsWith("/media-upload/") ||
+    pathname === "/.well-known/microfeed/bootstrap-admin" ||
+    pathname.startsWith("/.well-known/microfeed/bootstrap-admin/");
+}
+
+export function publicCacheTagsForPath(pathname: string): string[] {
+  const tags = new Set<string>([PUBLIC_CACHE_TAGS.PUBLIC]);
+  if (isFeedContentPath(pathname)) {
+    tags.add(PUBLIC_CACHE_TAGS.CHANNEL_PRIMARY);
+  }
+  if (
+    pathname === "/" || pathname === "/json/" || pathname === "/rss/" ||
+    pathname === "/sitemap.xml"
+  ) {
+    tags.add(PUBLIC_CACHE_TAGS.ITEMS);
+  }
+  if (isThemePath(pathname)) {
+    tags.add(PUBLIC_CACHE_TAGS.THEME_CURRENT);
+  }
+  const itemId = itemIdForPath(pathname);
+  if (itemId) tags.add(PUBLIC_CACHE_TAGS.item(itemId));
+  return normalizedTags(tags);
+}
+
+function isPublicCacheableResponse(
+  request: Request,
+  response: Response,
+  options: WorkerCachePolicyOptions,
+): boolean {
+  const method = request.method.toUpperCase();
+  const url = new URL(request.url);
+  return options.deploymentEnvironment !== "preview" &&
+    (method === "GET" || method === "HEAD") &&
+    response.status === 200 &&
+    !request.headers.has("authorization") &&
+    !response.headers.has("set-cookie") &&
+    isPublicPagePath(url.pathname) &&
+    !isSensitivePath(url.pathname, options.adminPath) &&
+    validPaginationQuery(url);
+}
+
+function responseWithCacheHeaders(
+  response: Response,
+  headers: Headers,
+): Response {
+  if (response.status === 101) return response;
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+export function applyWorkerCachePolicy(
+  request: Request,
+  response: Response,
+  options: WorkerCachePolicyOptions,
+): Response {
+  const headers = new Headers(response.headers);
+  if (!isPublicCacheableResponse(request, response, options)) {
+    headers.set("Cloudflare-CDN-Cache-Control", "no-store");
+    headers.delete("Cache-Tag");
+    const publicAsset = options.deploymentEnvironment !== "preview" &&
+      (request.method === "GET" || request.method === "HEAD") &&
+      response.status === 200 &&
+      !request.headers.has("authorization") &&
+      !response.headers.has("set-cookie") &&
+      isPublicAssetPath(new URL(request.url).pathname);
+    if (!publicAsset) {
+      headers.set("Cache-Control", PRIVATE_CACHE_CONTROL);
+    }
+    return responseWithCacheHeaders(response, headers);
+  }
+
+  headers.set("Cache-Control", PUBLIC_CACHE_BROWSER_CONTROL);
+  headers.set("Cloudflare-CDN-Cache-Control", PUBLIC_CACHE_EDGE_CONTROL);
+  headers.set(
+    "Cache-Tag",
+    publicCacheTagsForPath(new URL(request.url).pathname).join(","),
+  );
+  return responseWithCacheHeaders(response, headers);
+}
+
+export function publicCacheTagsForFeedUpdate(
+  feed: FeedContent,
+): string[] {
+  const tags = new Set<string>();
+  if (feed.item) {
+    tags.add(PUBLIC_CACHE_TAGS.ITEMS);
+    if (typeof feed.item.id === "string") {
+      tags.add(PUBLIC_CACHE_TAGS.item(feed.item.id));
+    }
+  }
+  if (feed.channel) {
+    tags.add(PUBLIC_CACHE_TAGS.CHANNEL_PRIMARY);
+  }
+  for (const category of Object.keys(feed.settings ?? {})) {
+    if (category === SETTINGS_CATEGORIES.API_SETTINGS) continue;
+    tags.add(
+      category === SETTINGS_CATEGORIES.CUSTOM_CODE
+        ? PUBLIC_CACHE_TAGS.THEME_CURRENT
+        : PUBLIC_CACHE_TAGS.PUBLIC,
+    );
+  }
+  return normalizedTags(tags);
+}
+
+export function publicCacheTagsForImageTarget(
+  target: ImageMetadataTarget,
+): string[] {
+  if (target.type === "item") {
+    return normalizedTags([
+      PUBLIC_CACHE_TAGS.item(target.id),
+      PUBLIC_CACHE_TAGS.ITEMS,
+    ]);
+  }
+  if (target.type === "channel") {
+    return [PUBLIC_CACHE_TAGS.CHANNEL_PRIMARY];
+  }
+  return [PUBLIC_CACHE_TAGS.PUBLIC];
+}
+
+export async function purgePublicCache(
+  tags: Iterable<string>,
+  purger: PublicCachePurger,
+): Promise<void> {
+  const uniqueTags = normalizedTags(tags);
+  if (uniqueTags.length === 0) return;
+  try {
+    const result = await purger.purge({tags: uniqueTags});
+    if (!result.success) {
+      console.error(JSON.stringify({
+        errors: result.errors,
+        message: "Failed to purge public Workers cache",
+        tags: uniqueTags,
+      }));
+    }
+  } catch (error) {
+    console.error(JSON.stringify({
+      error: error instanceof Error ? error.message : String(error),
+      message: "Failed to purge public Workers cache",
+      tags: uniqueTags,
+    }));
+  }
+}

--- a/src/server/feed/FeedCrudManager.ts
+++ b/src/server/feed/FeedCrudManager.ts
@@ -154,13 +154,13 @@ export default class FeedCrudManager {
       id: itemId,
       guid,
     };
-    await this.feedDb.putContent(this.feedContent);
+    await this.feedDb.putContent({item: this.feedContent.item});
     return itemId;
   }
 
   async saveInternalItem(item: any) {
     this.feedContent.item = item;
-    await this.feedDb.putContent(this.feedContent);
+    await this.feedDb.putContent({item: this.feedContent.item});
     return item.id;
   }
 
@@ -173,7 +173,7 @@ export default class FeedCrudManager {
       ...this.feedContent.channel,
       ...this._publicToInternalSchemaForChannel(channel),
     };
-    await this.feedDb.putContent(this.feedContent);
+    await this.feedDb.putContent({channel: this.feedContent.channel});
     return this.feedContent.id;
   }
 }

--- a/src/server/feed/FeedDb.ts
+++ b/src/server/feed/FeedDb.ts
@@ -15,7 +15,13 @@ import {
   type ResolvedItemPagination,
 } from "@/shared/ItemPagination";
 import FeedPublicJsonBuilder from "./FeedPublicJsonBuilder";
-import type {ImageMetadataTarget} from "@/types";
+import {
+  publicCacheTagsForFeedUpdate,
+  publicCacheTagsForImageTarget,
+  type PublicCachePurger,
+  purgePublicCache,
+} from "@/server/cache/public-cache";
+import type {FeedContent, ImageMetadataTarget} from "@/types";
 
 /**
  * support url query parameters:
@@ -72,8 +78,22 @@ function getItemJson(itemObj: any) {
 export default class FeedDb {
   [member: string]: any;
 
-  constructor(env: Pick<Env, "FEED_DB">, request: Request) {
-    this.FEED_DB = env.FEED_DB;
+  constructor(
+    runtimeEnv: Pick<
+      Env,
+      | "DEPLOYMENT_ENVIRONMENT"
+      | "FEED_DB"
+      | "MICROFEED_CLOUDFLARE_ACCOUNT_ID"
+    >,
+    request: Request,
+    publicCachePurger?: PublicCachePurger,
+  ) {
+    this.FEED_DB = runtimeEnv.FEED_DB;
+    this.publicCacheInvalidationEnabled =
+      runtimeEnv.DEPLOYMENT_ENVIRONMENT !== "preview" &&
+      Boolean(runtimeEnv.MICROFEED_CLOUDFLARE_ACCOUNT_ID?.trim()) &&
+      publicCachePurger !== undefined;
+    this.publicCachePurger = publicCachePurger;
 
     const urlObj = new URL(request.url);
     this.baseUrl = urlObj.origin;
@@ -511,19 +531,31 @@ export default class FeedDb {
     console.log('Done!', res);
   }
 
-  async putContent(feed: any) {
+  async _purgePublicCacheTags(tags: string[]) {
+    if (!this.publicCacheInvalidationEnabled) return;
+    await purgePublicCache(tags, this.publicCachePurger);
+  }
+
+  async putContent(feed: FeedContent) {
     const {channel, settings, item} = feed;
-    if (channel) {
-      await this._putChannelToContent(channel);
-    }
+    const cacheTags = publicCacheTagsForFeedUpdate(feed);
+    try {
+      if (channel) {
+        await this._putChannelToContent(channel);
+      }
 
-    if (settings) {
-      await this._putSettingsToContent(settings);
-    }
+      if (settings) {
+        await this._putSettingsToContent(settings);
+      }
 
-    if (item) {
-      await this._putItemToContent(item);
+      if (item) {
+        await this._putItemToContent(item);
+      }
+    } catch (error) {
+      await this._purgePublicCacheTags(cacheTags);
+      throw error;
     }
+    await this._purgePublicCacheTags(cacheTags);
   }
 
   async removeImageMetadata(
@@ -574,6 +606,9 @@ export default class FeedDb {
     }
 
     const [selected] = await this.FEED_DB.batch([select, update]);
+    await this._purgePublicCacheTags(
+      publicCacheTagsForImageTarget(target),
+    );
     const imageUrl = selected.results[0]?.image_url;
     return typeof imageUrl === "string" ? imageUrl : null;
   }

--- a/src/server/feed/feed.ts
+++ b/src/server/feed/feed.ts
@@ -10,6 +10,7 @@ import type {
   PublicFeed,
 } from "@/types";
 import type {ItemOrder, ItemSort} from "@/shared/ItemPagination";
+import type {PublicCachePurger} from "@/server/cache/public-cache";
 
 export interface FeedQuery {
   adminProtection?: AdminProtectionStatus;
@@ -29,8 +30,9 @@ export async function loadFeed(
   runtimeEnv: Env,
   request: Request,
   query?: FeedQuery,
+  publicCachePurger?: PublicCachePurger,
 ): Promise<LoadedFeed> {
-  const database = new FeedDb(runtimeEnv, request);
+  const database = new FeedDb(runtimeEnv, request, publicCachePurger);
   const fetchItems = query
     ? getFetchItemsParams(
         request,

--- a/tests/unit/manage-cli/WranglerTemplate.test.ts
+++ b/tests/unit/manage-cli/WranglerTemplate.test.ts
@@ -5,6 +5,7 @@ import {describe, expect, it} from "vitest";
 import {
   adminAuthMode,
   requiredSecrets,
+  workersCacheEnabled,
   workersDevEnabled,
 } from "../../../manage-cli/lib/config";
 import type {MicrofeedConfig} from "../../../manage-cli/types";
@@ -32,6 +33,7 @@ describe("Wrangler configuration template", () => {
     const config = JSON.parse(
       template
         .replace("__WORKERS_DEV__", "true")
+        .replace("__WORKERS_CACHE_ENABLED__", "true")
         .replace(
           "__REQUIRED_SECRETS__",
           '["UPLOAD_SIGNING_KEY","BETTER_AUTH_SECRET"]',
@@ -40,6 +42,9 @@ describe("Wrangler configuration template", () => {
         .replace("__R2_SETUP_MODE__", "automatic")
         .replace("__ROUTES__", "[]"),
     ) as {
+      cache?: {
+        enabled?: boolean;
+      };
       observability?: {
         enabled?: boolean;
       };
@@ -49,6 +54,7 @@ describe("Wrangler configuration template", () => {
       vars?: Record<string, string>;
     };
 
+    expect(config.cache?.enabled).toBe(true);
     expect(config.observability?.enabled).toBe(false);
     expect(config.version_metadata?.binding).toBe("CF_VERSION_METADATA");
     expect(config.vars?.MICROFEED_CLOUDFLARE_ACCOUNT_ID).toBe(
@@ -67,6 +73,19 @@ describe("Wrangler configuration template", () => {
     expect(workersDevEnabled({
       ...config,
       customDomain: "feed.example.com",
+    })).toBe(false);
+  });
+
+  it("enables Workers Caching only for Cloudflare production", () => {
+    expect(workersCacheEnabled(config)).toBe(true);
+    expect(workersCacheEnabled({
+      ...config,
+      deploymentEnvironment: "preview",
+    })).toBe(false);
+    expect(workersCacheEnabled({
+      ...config,
+      accountId: null,
+      hosting: "local",
     })).toBe(false);
   });
 

--- a/tests/worker/public-cache.test.ts
+++ b/tests/worker/public-cache.test.ts
@@ -1,0 +1,204 @@
+import {env} from "cloudflare:workers";
+import {describe, expect, it, vi} from "vitest";
+
+import {
+  applyWorkerCachePolicy,
+  PRIVATE_CACHE_CONTROL,
+  PUBLIC_CACHE_BROWSER_CONTROL,
+  PUBLIC_CACHE_EDGE_CONTROL,
+  PUBLIC_CACHE_TAGS,
+  publicCacheTagsForFeedUpdate,
+  purgePublicCache,
+} from "@/server/cache/public-cache";
+import FeedDb from "@/server/feed/FeedDb";
+import {SETTINGS_CATEGORIES, STATUSES} from "@/shared/Constants";
+import {encodeItemCursor} from "@/shared/ItemPagination";
+
+const ITEM_ID = "cacheitem01";
+
+function policy(
+  path: string,
+  response = new Response("ok"),
+  init?: RequestInit,
+) {
+  return applyWorkerCachePolicy(
+    new Request(`https://feed.example.com${path}`, init),
+    response,
+    {adminPath: "secret-admin", deploymentEnvironment: "production"},
+  );
+}
+
+describe("Workers Caching response policy", () => {
+  it("caches public pages at the edge while browsers revalidate", () => {
+    const response = policy("/");
+
+    expect(response.headers.get("cache-control")).toBe(
+      PUBLIC_CACHE_BROWSER_CONTROL,
+    );
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe(
+      PUBLIC_CACHE_EDGE_CONTROL,
+    );
+    expect(response.headers.get("cache-tag")?.split(",")).toEqual([
+      PUBLIC_CACHE_TAGS.PUBLIC,
+      PUBLIC_CACHE_TAGS.CHANNEL_PRIMARY,
+      PUBLIC_CACHE_TAGS.ITEMS,
+      PUBLIC_CACHE_TAGS.THEME_CURRENT,
+    ]);
+  });
+
+  it("tags item representations independently from aggregate pages", () => {
+    const tags = policy(`/i/a-title-${ITEM_ID}/json/`)
+      .headers.get("cache-tag")?.split(",");
+
+    expect(tags).toEqual([
+      PUBLIC_CACHE_TAGS.PUBLIC,
+      PUBLIC_CACHE_TAGS.CHANNEL_PRIMARY,
+      PUBLIC_CACHE_TAGS.item(ITEM_ID),
+    ]);
+  });
+
+  it.each([
+    ["admin", "/secret-admin/", undefined],
+    ["versioned API", "/api/v1/items/", undefined],
+    ["legacy API", "/api/items/", undefined],
+    ["authentication", "/api/auth/get-session", undefined],
+    ["mutation", "/", {method: "POST"}],
+    ["unknown query", "/?nonce=random", undefined],
+  ])("does not cache %s responses", (_name, path, init) => {
+    const response = policy(path, new Response("ok"), init);
+
+    expect(response.headers.get("cache-control")).toBe(PRIVATE_CACHE_CONTROL);
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe(
+      "no-store",
+    );
+    expect(response.headers.has("cache-tag")).toBe(false);
+  });
+
+  it("bypasses Workers Caching without weakening public asset headers", () => {
+    const response = policy("/media/audio.mp3", new Response("audio", {
+      headers: {"cache-control": "public, max-age=3600"},
+    }));
+
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=3600",
+    );
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe(
+      "no-store",
+    );
+    expect(response.headers.has("cache-tag")).toBe(false);
+  });
+
+  it("does not cache previews, errors, authenticated requests, or cookies", () => {
+    const preview = applyWorkerCachePolicy(
+      new Request("https://feed.example.com/"),
+      new Response("ok"),
+      {adminPath: "admin", deploymentEnvironment: "preview"},
+    );
+    const error = policy("/missing/", new Response("missing", {status: 404}));
+    const authorized = policy("/", new Response("ok"), {
+      headers: {authorization: "Bearer secret"},
+    });
+    const cookieResponse = policy("/", new Response("ok", {
+      headers: {"set-cookie": "session=secret"},
+    }));
+
+    for (const response of [preview, error, authorized, cookieResponse]) {
+      expect(response.headers.get("cache-control")).toBe(
+        PRIVATE_CACHE_CONTROL,
+      );
+    }
+  });
+
+  it("allows bounded, valid pagination query parameters", () => {
+    const cursor = encodeItemCursor(1_800_000_000_000, ITEM_ID);
+    const response = policy(
+      `/?sort=updated_at&order=desc&next_cursor=${cursor}`,
+    );
+
+    expect(response.headers.get("cloudflare-cdn-cache-control")).toBe(
+      PUBLIC_CACHE_EDGE_CONTROL,
+    );
+  });
+});
+
+describe("Workers cache invalidation", () => {
+  it("maps item, channel, theme, and general setting writes to tags", () => {
+    expect(publicCacheTagsForFeedUpdate({
+      channel: {},
+      item: {id: ITEM_ID},
+      settings: {
+        [SETTINGS_CATEGORIES.API_SETTINGS]: {enabled: true},
+        [SETTINGS_CATEGORIES.CUSTOM_CODE]: {},
+        [SETTINGS_CATEGORIES.WEB_GLOBAL_SETTINGS]: {},
+      },
+    })).toEqual([
+      PUBLIC_CACHE_TAGS.ITEMS,
+      PUBLIC_CACHE_TAGS.item(ITEM_ID),
+      PUBLIC_CACHE_TAGS.CHANNEL_PRIMARY,
+      PUBLIC_CACHE_TAGS.THEME_CURRENT,
+      PUBLIC_CACHE_TAGS.PUBLIC,
+    ]);
+  });
+
+  it("deduplicates tags before calling the platform purge API", async () => {
+    const purge = vi.fn(async () => ({errors: [], success: true}));
+
+    await purgePublicCache(
+      [PUBLIC_CACHE_TAGS.ITEMS, PUBLIC_CACHE_TAGS.ITEMS],
+      {purge},
+    );
+
+    expect(purge).toHaveBeenCalledWith({tags: [PUBLIC_CACHE_TAGS.ITEMS]});
+  });
+
+  it("purges item tags immediately after a successful D1 write", async () => {
+    const purge = vi.fn(async () => ({errors: [], success: true}));
+    const database = new FeedDb(
+      {
+        DEPLOYMENT_ENVIRONMENT: "production",
+        FEED_DB: env.FEED_DB,
+        MICROFEED_CLOUDFLARE_ACCOUNT_ID: "test-account-id",
+      },
+      new Request("https://feed.example.com/api/v1/items/"),
+      {purge},
+    );
+    await database.getContent();
+
+    await database.putContent({
+      item: {
+        id: ITEM_ID,
+        pubDateMs: Date.now(),
+        status: STATUSES.PUBLISHED,
+        title: "Cached item",
+      },
+    });
+
+    expect(purge).toHaveBeenLastCalledWith({
+      tags: [PUBLIC_CACHE_TAGS.ITEMS, PUBLIC_CACHE_TAGS.item(ITEM_ID)],
+    });
+  });
+
+  it("does not purge from a preview deployment", async () => {
+    const purge = vi.fn(async () => ({errors: [], success: true}));
+    const database = new FeedDb(
+      {
+        DEPLOYMENT_ENVIRONMENT: "preview",
+        FEED_DB: env.FEED_DB,
+        MICROFEED_CLOUDFLARE_ACCOUNT_ID: "test-account-id",
+      },
+      new Request("https://preview.example.com/admin/ajax/feed/"),
+      {purge},
+    );
+
+    await database.putContent({
+      item: {
+        id: ITEM_ID,
+        pubDateMs: Date.now(),
+        status: STATUSES.PUBLISHED,
+        title: "Preview item",
+      },
+    });
+
+    expect(purge).not.toHaveBeenCalled();
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,9 @@
   "main": "@astrojs/cloudflare/entrypoints/server",
   "compatibility_date": "2026-07-29",
   "compatibility_flags": ["nodejs_compat"],
+  "cache": {
+    "enabled": true
+  },
   "assets": {
     "binding": "ASSETS",
     "directory": "./dist"

--- a/wrangler.template.jsonc
+++ b/wrangler.template.jsonc
@@ -5,6 +5,9 @@
   "main": "@astrojs/cloudflare/entrypoints/server",
   "compatibility_date": "2026-07-29",
   "compatibility_flags": ["nodejs_compat"],
+  "cache": {
+    "enabled": __WORKERS_CACHE_ENABLED__
+  },
   "assets": {
     "binding": "ASSETS",
     "directory": "__PROJECT_ROOT__/dist"


### PR DESCRIPTION
## Summary

- Enable Cloudflare Workers Caching for production deployments through cache.enabled.
- Cache only public GET and HEAD pages at the edge while requiring browser revalidation.
- Add item, channel, theme, collection, and public cache tags, then purge affected tags after successful writes.
- Bypass Workers Caching for admin, API, authentication, preview, personalized, error, mutation, media, and unsupported-query responses.
- Keep generated preview and local configurations cache-disabled.

This reduces Worker rendering and database work on public cache hits while keeping updates immediately invalidatable.

## Related issue

None.

## Testing

- [x] yarn check
- Added 15 focused Worker tests covering cache eligibility, safety exclusions, tag mapping, purging, and preview behavior.

## Screenshots

N/A. There are no visible interface changes.

## Risks

- Workers Caching is enabled only for Cloudflare production deployments.
- A purge failure is logged without rolling back an already successful content write; cached public responses have a five-minute maximum edge lifetime.
- Public responses must remain visitor-independent. Requests with authorization or responses that set cookies are explicitly excluded.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed. N/A: no commands or user workflow changed.
- [x] No secrets, private configuration, production data, or generated files are included.