### PR TITLE
Advertise agentic content publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
     <a href="https://docs.microfeed.org"><b>Docs</b></a>   
     ·    
     <a href="https://www.microfeed.org/api/"><b>API</b></a>   
+    ·
+    <a href="https://www.npmjs.com/package/@microfeed/cli"><b>Content CLI</b></a>
     ·        
     <a href="https://github.com/microfeed/microfeed/issues/new?assignees=&labels=bug"><b>Report Bug</b></a>
     ·
@@ -27,6 +29,11 @@ Welcome to microfeed, a lightweight content management system (CMS) self-hosted 
 With microfeed, you can easily publish a variety of content such as audios, videos, photos, documents, blog posts,
 and external URLs to a feed in the form of web, RSS, and JSON. It's the perfect solution for tech-savvy individuals who
 want to self-host their own CMS without having to run their own servers.
+
+Publish content yourself in the built-in admin dashboard, or let a coding agent
+manage it through the official [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli).
+The CLI handles OAuth credentials internally while browser consent and destructive
+actions stay under your control.
 
 microfeed is built by [Listen Notes](https://www.listennotes.com/) and is hosted on Cloudflare's [Workers](https://workers.cloudflare.com/),
 [R2](https://www.cloudflare.com/products/r2/), and [D1](https://developers.cloudflare.com/d1/).
@@ -84,6 +91,12 @@ Check out some examples of microfeed in action:
 microfeed provides a simple yet powerful admin dashboard: the site-management
 area where you create and edit posts, upload media files, and customize how
 your site looks. If you've used WordPress before, you'll find it familiar.
+
+For agentic content management, the official
+[`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli) lets a local
+coding agent create, update, and delete items; upload cover art, inline media,
+and RSS enclosures; and call the authenticated REST API. Inside this repository
+the same command is available as `yarn microfeed`, with no global installation.
 
 <p align="center">
   <a href="docs/public/images/screenshots/2-dashboard-1-home.png">
@@ -166,9 +179,22 @@ reference](https://docs.microfeed.org/manage-cli/).
 ## ✍️ Start publishing
 
 Once initialization is complete, your microfeed instance is ready to use.
-From the microfeed admin dashboard, you can create, edit, or delete posts;
-upload audio, video, images, and other media files when R2 is enabled; use
-external URLs in content-only mode; and customize your site.
+Choose the publishing workflow that fits the task:
+
+* **For people:** use the microfeed admin dashboard to create, edit, or delete
+  posts; upload audio, video, images, and other media files when R2 is enabled;
+  use external URLs in content-only mode; and customize your site.
+* **For coding agents:** use the official
+  [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli) to manage the
+  same content through short-lived OAuth access after you enable the API. The
+  agent may start login, but you sign in and approve permissions in the
+  browser. See the [guided CLI workflow](https://docs.microfeed.org/api/cli/)
+  or the complete [`yarn microfeed`
+  reference](https://docs.microfeed.org/microfeed-cli/).
+
+Inside a microfeed clone, ask your agent to use `yarn microfeed`. For one-off
+use elsewhere, it can run `yarn dlx @microfeed/cli`. Never paste an API key or
+OAuth token into an agent conversation.
 
 You can also customize the appearance of the website at Settings / Custom code by editing the raw HTML and CSS:
 

--- a/README.md
+++ b/README.md
@@ -181,10 +181,12 @@ reference](https://docs.microfeed.org/manage-cli/).
 Once initialization is complete, your microfeed instance is ready to use.
 Choose the publishing workflow that fits the task:
 
-* **For people:** use the microfeed admin dashboard to create, edit, or delete
+* **For people:** use the microfeed [admin
+  dashboard](https://docs.microfeed.org/dashboard/) to create, edit, or delete
   posts; upload audio, video, images, and other media files when R2 is enabled;
-  use external URLs in content-only mode; and customize your site.
-* **For coding agents:** use the official
+  use external URLs in content-only mode; and [customize your
+  site](https://docs.microfeed.org/dashboard/customize/).
+* **For AI agents:** use the official
   [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli) to manage the
   same content through short-lived OAuth access after you enable the API. The
   agent may start login, but you sign in and approve permissions in the

--- a/docs/api/ai-agents.md
+++ b/docs/api/ai-agents.md
@@ -3,9 +3,11 @@ title: Use the API with AI agents
 description: Let a coding agent drive the local microfeed CLI while browser consent and destructive actions remain under your control.
 ---
 
-The recommended agent workflow inside a microfeed clone is `yarn microfeed`.
-The local workspace works after `yarn install`, so the agent does not need a
-global CLI or permission to download one from a registry.
+The recommended agent workflow inside a microfeed clone is `yarn microfeed`,
+the repository-local form of the official
+[`@microfeed/cli` package](https://www.npmjs.com/package/@microfeed/cli). The
+local workspace works after `yarn install`, so the agent does not need a global
+CLI or permission to download one from a registry.
 
 The clone also includes the `manage-microfeed-content` agent skill at
 `.agents/skills/manage-microfeed-content/`. It is the agent-focused workflow
@@ -25,6 +27,21 @@ for coding agents:
   self-contained guide containing every operation,
   parameter, request body, response, reusable schema, and the complete OpenAPI
   3.1.1 document.
+
+## Start with a content task
+
+Tell the agent what to publish and which site to use. Do not send it a token.
+For example:
+
+```text
+Use @microfeed/cli to create a published item on https://feed.example.com.
+Use --json for deterministic output, and pause for me if browser authorization
+or confirmation of a destructive action is required.
+```
+
+The agent should inspect command help, show you the selected site before a
+destructive change, and return the resulting public item URL. You complete any
+OAuth login and consent in the browser.
 
 ## Give an agent the contract
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -3,9 +3,11 @@ title: Manage content with the microfeed CLI
 description: Run the local or published @microfeed/cli, authorize an instance in the browser, and manage content safely from a terminal or coding agent.
 ---
 
-The `@microfeed/cli` package gives people and coding agents a consistent way to
-manage one or more microfeed instances without handling OAuth tokens directly.
-For every command, option, output contract, and safety rule, use the canonical
+The official
+[`@microfeed/cli` package](https://www.npmjs.com/package/@microfeed/cli) gives
+people and coding agents a consistent way to publish and manage content on one
+or more microfeed sites without handling OAuth tokens directly. For every
+command, option, output contract, and safety rule, use the canonical
 [`yarn microfeed` command reference](/microfeed-cli/).
 
 ## Choose an invocation
@@ -34,6 +36,21 @@ yarn dlx @microfeed/cli --help
 ```
 
 A global installation is optional and is not required for these workflows.
+
+## Start with a content goal
+
+An agent needs the task and your microfeed site URL—not a credential. For
+example:
+
+```text
+Use @microfeed/cli to create a published item on https://feed.example.com.
+Use --json for deterministic output, and pause for me if browser authorization
+or confirmation of a destructive action is required.
+```
+
+The agent can inspect `--help`, prepare file or standard-input payloads, and
+run the content command. You complete login and permission approval in the
+browser when required.
 
 ## Log in to an instance
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -61,7 +61,8 @@ docs are enabled.
 ## Choose your next step
 
 - [Choose OAuth or an API key](./authentication/).
-- [Manage content with the microfeed CLI](./cli/).
+- [Manage content with the official `@microfeed/cli`](./cli/) ([npm
+  package](https://www.npmjs.com/package/@microfeed/cli)).
 - [Build and test an integration](./build-and-test/).
 - [Give an AI agent the self-contained API contract](./ai-agents/).
 

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -79,7 +79,7 @@ export default defineConfig({
           items: [
             { label: "API overview", link: "/api/" },
             { label: "Authentication and OAuth", link: "/api/authentication/" },
-            { label: "Manage content with the CLI", link: "/api/cli/" },
+            { label: "Manage content with @microfeed/cli", link: "/api/cli/" },
             { label: "Build and test integrations", link: "/api/build-and-test/" },
             { label: "Use the API with AI agents", link: "/api/ai-agents/" },
           ],
@@ -88,7 +88,7 @@ export default defineConfig({
           label: "Reference",
           items: [
             { label: "yarn manage command reference", link: "/manage-cli/" },
-            { label: "yarn microfeed command reference", link: "/microfeed-cli/" },
+            { label: "@microfeed/cli command reference", link: "/microfeed-cli/" },
             { label: "Glossary", link: "/reference/glossary/" },
           ],
         },

--- a/docs/dashboard/publish.md
+++ b/docs/dashboard/publish.md
@@ -1,10 +1,16 @@
 ---
 title: Create and edit items
-description: Publish text, links, images, audio, video, and documents from the dashboard.
+description: Publish text, links, images, audio, video, and documents yourself or with a coding agent.
 ---
 
 An **item** is one entry in your channel. Publishing it can create a public web
 page and add an entry to both RSS and JSON feeds.
+
+People can use the visual admin dashboard described below. For repeatable or
+agent-driven publishing, the official
+[`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli) manages the
+same channel after its owner enables the authenticated API. Start with
+[Manage content with the microfeed CLI](/api/cli/).
 
 ## Create an item
 
@@ -41,6 +47,25 @@ context.
 
 Deletion uses a confirmation dialog because it may remove both the item record
 and associated media. Read the target carefully before confirming.
+
+## Publish with a coding agent
+
+Give the agent a content goal and the root URL of your microfeed site. Do not
+give it an API key or OAuth token. For example:
+
+```text
+Use @microfeed/cli to create a published item on https://feed.example.com.
+Use --json for deterministic output, and pause for me if browser authorization
+or confirmation of a destructive action is required.
+```
+
+Inside a microfeed clone, the agent should prefer `yarn microfeed`. Elsewhere,
+it can use a project-local installation or `yarn dlx @microfeed/cli`. You sign
+in and approve OAuth permissions in the browser; the CLI stores and refreshes
+the credential without printing it. First [enable API access and OAuth for the
+CLI](/api/authentication/), then see the [agent workflow](/api/ai-agents/) and
+complete [`yarn microfeed` command reference](/microfeed-cli/) for media
+vocabulary, deterministic input, and deletion safeguards.
 
 ## Verify distribution
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -40,7 +40,7 @@ hero:
     </article>
     <article class="why-card">
       <h3>Headless</h3>
-      <p>Publish and automate through an authenticated Admin API with OpenAPI and agent-ready references.</p>
+      <p>Publish in the visual dashboard or automate through the authenticated Admin API and the official <a href="https://www.npmjs.com/package/@microfeed/cli"><code>@microfeed/cli</code></a>.</p>
     </article>
   </div>
 </section>
@@ -51,6 +51,7 @@ hero:
     <li><a href="/dashboard/media-and-feeds/"><strong>Open distribution</strong></a> — Publish a website, RSS feed, and JSON Feed.</li>
     <li><a href="/dashboard/publish/"><strong>Media publishing</strong></a> — Share text, links, images, audio, video, and documents.</li>
     <li><a href="/dashboard/"><strong>Private dashboard</strong></a> — Create and manage content from a responsive interface.</li>
+    <li><a href="/api/cli/"><strong>Agentic content management</strong></a> — Let coding agents publish through <a href="https://www.npmjs.com/package/@microfeed/cli"><code>@microfeed/cli</code></a> while browser consent stays with you.</li>
     <li><a href="/dashboard/customize/"><strong>Customization</strong></a> — Control themes, domains, access, and custom code.</li>
     <li><a href="/api/"><strong>Admin API</strong></a> — Automate publishing with named keys and generated references.</li>
     <li><a href="/manage/"><strong>Site management</strong></a> — Update, inspect, snapshot, and migrate an instance safely.</li>

--- a/docs/microfeed-cli.md
+++ b/docs/microfeed-cli.md
@@ -3,9 +3,11 @@ title: yarn microfeed command reference
 description: Canonical commands, options, authentication behavior, output, and safety rules for @microfeed/cli.
 ---
 
-This is the canonical capability reference for `@microfeed/cli`, including the
-`yarn microfeed` command available inside a microfeed clone. For a shorter
-workflow, start with [Manage content with the microfeed CLI](/api/cli/).
+This is the canonical capability reference for the official
+[`@microfeed/cli` package](https://www.npmjs.com/package/@microfeed/cli),
+including the `yarn microfeed` command available inside a microfeed clone. For
+a shorter workflow, start with
+[Manage content with the microfeed CLI](/api/cli/).
 
 ## Contents
 

--- a/docs/start-here/after-deploy.md
+++ b/docs/start-here/after-deploy.md
@@ -31,7 +31,15 @@ Open the dashboard URL printed by the CLI. Then:
 ## Publish a test item
 
 Create a clearly labeled test item, preview its public page, and check the RSS
-and JSON feeds. Delete or unpublish the test when finished.
+and JSON feeds. You can publish it yourself in the admin dashboard. To publish
+with a coding agent, first [enable API access and OAuth](/api/authentication/),
+then ask the agent to use the official
+[`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli). Inside this
+clone, the agent should run `yarn microfeed`; you remain responsible for
+browser authorization and approval of destructive actions. Delete or unpublish
+the test when finished.
+
+Next: [compare the dashboard and agent publishing workflows](/dashboard/publish/).
 
 ## Save the local connection
 

--- a/docs/start-here/ai-agent.md
+++ b/docs/start-here/ai-agent.md
@@ -52,8 +52,10 @@ link into the agent conversation.
 
 Ask the agent to run `yarn manage status`. The final report should show the
 Worker address, dashboard protection, D1 database, and R2 state. Open the
-public address and confirm the site loads, then sign in to the dashboard and
-publish a test item.
+public address and confirm the site loads. You can sign in to the dashboard and
+publish a test item yourself, or follow the
+[post-deployment checklist](../after-deploy/) to enable `yarn microfeed` for
+the agent.
 
 If setup stops partway through, tell the agent to continue the same microfeed
 deployment. Initialization is designed to resume without recreating resources.

--- a/docs/start-here/concepts.md
+++ b/docs/start-here/concepts.md
@@ -3,9 +3,10 @@ title: How microfeed works
 description: Plain-language definitions for the parts of a microfeed installation.
 ---
 
-microfeed is a content management system, or **CMS**. You use a private
-dashboard to publish content, and visitors use the public site or subscribe to
-its feeds.
+microfeed is a content management system, or **CMS**. People can use a private
+dashboard to publish content, while coding agents can use the official
+[`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli). Visitors use
+the public site or subscribe to its feeds.
 
 ## The important words
 
@@ -30,6 +31,11 @@ several instances in one clone and select them by name.
 
 **Admin dashboard** is the private management area where you create items,
 upload media, and customize the channel. It is separate from the public site.
+
+**Content CLI** is the `microfeed` command exposed by the official
+`@microfeed/cli` package. After the instance owner enables API access, it lets
+people or coding agents manage the same channel through OAuth without reading
+or printing the credential.
 
 ## One item, three outputs
 

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -42,8 +42,11 @@ You need:
    the conversation.
 
 5. When deployment finishes, open the private one-time setup page and choose
-   your dashboard password. Then open the public site and publish a test item
-   from the dashboard.
+   your dashboard password. Then open the public site and publish a test item.
+   Use the dashboard yourself, or follow the
+   [post-deployment checklist](./after-deploy/) to enable the official
+   [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli) for a coding
+   agent.
 
 The result is a microfeed site in your Cloudflare account with a public
 website, RSS feed, JSON Feed, and a private admin dashboard.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,18 @@
 # `@microfeed/cli`
 
-Manage content on one or more [microfeed](https://www.microfeed.org/) sites
-from a terminal or coding agent. The CLI uses browser-based OAuth for
-interactive work and accepts an existing API key for unattended CI jobs.
+[Package on npm](https://www.npmjs.com/package/@microfeed/cli) ·
+[Guided workflow](https://docs.microfeed.org/api/cli/) ·
+[Complete command reference](https://docs.microfeed.org/microfeed-cli/)
+
+The official, agent-friendly command for publishing and managing content on
+one or more [microfeed](https://www.microfeed.org/) sites. Use it directly from
+a terminal or let a local coding agent drive it. The CLI uses browser-based
+OAuth for interactive work and accepts an existing API key for unattended CI
+jobs.
+
+Create, read, update, and delete items; upload cover art, inline media, and RSS
+enclosures; update a channel; or call any documented REST operation without
+giving an agent a raw OAuth token.
 
 ## Requirements
 
@@ -38,6 +48,21 @@ yarn dlx @microfeed/cli --help
 ```
 
 A global installation is optional and is not required.
+
+## Ask a coding agent
+
+Give an agent a content goal and the site URL instead of a credential. For
+example:
+
+```text
+Use @microfeed/cli to create a published item on https://feed.example.com.
+Use --json for deterministic output, and pause for me if browser authorization
+or confirmation of a destructive action is required.
+```
+
+Inside a microfeed clone, tell the agent to prefer `yarn microfeed`. Elsewhere,
+it can use a project-local installation or `yarn dlx @microfeed/cli`. You—not
+the agent—approve OAuth permissions in the browser.
 
 ## Site URLs and instance names
 

--- a/tests/unit/docs-site.test.ts
+++ b/tests/unit/docs-site.test.ts
@@ -672,11 +672,46 @@ describe("documentation site", () => {
       "utf8",
     );
     expect(docsConfig).toContain(
-      '{ label: "yarn microfeed command reference", link: "/microfeed-cli/" }',
+      '{ label: "@microfeed/cli command reference", link: "/microfeed-cli/" }',
     );
     expect(docsConfig).toContain(
       'promote: ["index", "start-here/**", "manage-cli", "microfeed-cli"]',
     );
+  });
+
+  it("advertises agentic content publishing from the main discovery paths", async () => {
+    const npmPackageUrl = "https://www.npmjs.com/package/@microfeed/cli";
+    const sources = await Promise.all([
+      readFile(path.join(repositoryRoot, "README.md"), "utf8"),
+      readFile(
+        path.join(repositoryRoot, "packages", "cli", "README.md"),
+        "utf8",
+      ),
+      readFile(path.join(docsRoot, "index.mdx"), "utf8"),
+      readFile(path.join(docsRoot, "dashboard", "publish.md"), "utf8"),
+      readFile(path.join(docsRoot, "start-here", "after-deploy.md"), "utf8"),
+      readFile(path.join(docsRoot, "api", "cli.md"), "utf8"),
+      readFile(path.join(docsRoot, "api", "ai-agents.md"), "utf8"),
+      readFile(path.join(docsRoot, "microfeed-cli.md"), "utf8"),
+      readFile(path.join(docsRoot, "start-here", "index.md"), "utf8"),
+      readFile(path.join(docsRoot, "start-here", "concepts.md"), "utf8"),
+      readFile(path.join(docsRoot, "api", "index.md"), "utf8"),
+    ]);
+
+    for (const source of sources) expect(source).toContain(npmPackageUrl);
+
+    const publishingGuide = sources[3];
+    expect(publishingGuide).toContain("## Publish with a coding agent");
+    expect(publishingGuide).toContain("Use --json for deterministic output");
+    expect(publishingGuide).toContain("You sign");
+    expect(publishingGuide).toContain("approve OAuth permissions");
+
+    const docsConfig = await readFile(
+      path.join(docsRoot, "astro.config.ts"),
+      "utf8",
+    );
+    expect(docsConfig).toContain("Manage content with @microfeed/cli");
+    expect(docsConfig).toContain("@microfeed/cli command reference");
   });
 
   it("isolates the Starlight build and configures asset-only Worker deployment", async () => {


### PR DESCRIPTION
## Summary

- Present the admin dashboard and the official @microfeed/cli as equally supported content-publishing paths for people and AI agents.
- Link the npm package from the root README, npm-facing package README, docs homepage, onboarding, publishing, API, agent, and command-reference pages.
- Add an agent-ready example prompt and clarify that owners enable API access, approve browser OAuth consent, and confirm destructive actions.
- Rename documentation navigation entries so the published package is discoverable by name.
- Add a regression test covering the primary CLI discovery paths.

## Related issue

N/A.

## Testing

- [x] yarn vitest run tests/unit/docs-site.test.ts
- [x] yarn docs:check
- [x] git diff --check
- [x] yarn check

The full check passed 440 unit tests, 66 Worker tests, CLI package parity checks, OpenAPI validation, builds, and documentation generation.

## Screenshots

N/A — documentation copy and navigation labels only; no component or styling changes.

## Risks

Low. The package README change will appear on npm with the next @microfeed/cli release, and the public documentation copy appears after the docs site is deployed from the merged source.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
