### PR TITLE
Guide users when API access is disabled

### DIFF
--- a/.agents/skills/manage-microfeed-content/SKILL.md
+++ b/.agents/skills/manage-microfeed-content/SKILL.md
@@ -57,6 +57,14 @@ Use the named site the user supplied. If several saved sites exist and the
 target is unclear, show their instance names and site URLs and ask the user to
 choose. Never silently select the first one.
 
+New microfeed instances keep API access disabled by default. OAuth login may
+succeed while content commands still return `404`. When that happens, pause
+and ask the site owner to sign in to the admin dashboard, open **API → API
+Settings**, and turn on **Enable API access**. This is a browser-only owner
+action. Never ask for the dashboard password, an API key, or an OAuth token.
+After the owner confirms access is enabled, retry the same content command;
+the saved OAuth login does not need to be recreated.
+
 When authorization is missing, run:
 
 ```console
@@ -141,8 +149,10 @@ item blindly.
     --confirm <item-id> --json
   ```
 
-- A `404` can mean the resource is absent or API access is disabled. Do not
-  infer which one without further evidence.
+- A `404` can mean the resource is absent or API access is disabled. Follow the
+  CLI's `recovery` instructions: pause for the owner to enable access under
+  **API → API Settings**, then retry the same command. If access is already on,
+  verify the resource and `/api/v1/` path instead of repeatedly retrying.
 
 For a REST operation that has no dedicated command, use `yarn microfeed api`
 with a relative `/api/v1/...` path. Never supply `Authorization`, `Cookie`, or

--- a/docs/api/ai-agents.md
+++ b/docs/api/ai-agents.md
@@ -35,8 +35,9 @@ For example:
 
 ```text
 Use @microfeed/cli to create a published item on https://feed.example.com.
-Use --json for deterministic output, and pause for me if browser authorization
-or confirmation of a destructive action is required.
+Use --json for deterministic output, and pause for me if API access must be
+enabled, browser authorization is required, or a destructive action needs
+confirmation.
 ```
 
 The agent should inspect command help, show you the selected site before a

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -44,8 +44,9 @@ example:
 
 ```text
 Use @microfeed/cli to create a published item on https://feed.example.com.
-Use --json for deterministic output, and pause for me if browser authorization
-or confirmation of a destructive action is required.
+Use --json for deterministic output, and pause for me if API access must be
+enabled, browser authorization is required, or a destructive action needs
+confirmation.
 ```
 
 The agent can inspect `--help`, prepare file or standard-input payloads, and
@@ -53,6 +54,13 @@ run the content command. You complete login and permission approval in the
 browser when required.
 
 ## Log in to an instance
+
+New microfeed instances keep API access disabled by default. Before content
+commands can succeed, the site owner signs in to the admin dashboard, opens
+**API → API Settings**, and turns on **Enable API access**. This is a
+browser-only owner action; an agent must pause and ask the owner to complete it
+without requesting a dashboard password, API key, or OAuth token. See
+[Enable the API](../authentication/#enable-the-api).
 
 ```console
 yarn microfeed login https://feed.example.com --instance production
@@ -71,7 +79,8 @@ public site URL changes, log in again.
 The command opens a browser for administrator login and permission approval.
 The terminal or coding agent cannot approve the browser prompt for you. The
 callback uses `127.0.0.1:8977`; if that port is unavailable, close the process
-using it and retry.
+using it and retry. OAuth login can be saved while API access is disabled; the
+first content command then returns `404` with recovery instructions.
 
 Manage saved instances with:
 
@@ -159,6 +168,9 @@ art.
 
 Content commands require API access to be enabled on the selected instance. A
 `404` can mean the requested resource does not exist or API access is disabled.
+The CLI prints the exact dashboard navigation and agent handoff to standard
+error. With `--json`, stdout also contains a `recovery` object with a stable
+code, documentation URL, and safe next steps.
 
 ## Use an API key in CI
 

--- a/docs/dashboard/publish.md
+++ b/docs/dashboard/publish.md
@@ -55,8 +55,9 @@ give it an API key or OAuth token. For example:
 
 ```text
 Use @microfeed/cli to create a published item on https://feed.example.com.
-Use --json for deterministic output, and pause for me if browser authorization
-or confirmation of a destructive action is required.
+Use --json for deterministic output, and pause for me if API access must be
+enabled, browser authorization is required, or a destructive action needs
+confirmation.
 ```
 
 Inside a microfeed clone, the agent should prefer `yarn microfeed`. Elsewhere,

--- a/docs/microfeed-cli.md
+++ b/docs/microfeed-cli.md
@@ -83,6 +83,12 @@ A coding agent may start login, but must pause for that user-controlled step.
 Login requires HTTPS except for `http://localhost` and `http://127.0.0.1` test
 instances. If a site's public URL changes, log in again.
 
+New instances keep API access disabled by default. OAuth login can be saved
+while access is off, but content commands return `404` until the site owner
+signs in to the admin dashboard, opens **API → API Settings**, and turns on
+**Enable API access**. An AI agent must pause for this browser-only change and
+must not request the owner's dashboard password, API key, or OAuth token.
+
 For every authenticated REST request, the CLI:
 
 - injects the selected Bearer credential and refreshes OAuth tokens when
@@ -115,7 +121,7 @@ Global options may appear before or after a command and its arguments.
 | Option | Meaning |
 | --- | --- |
 | `--instance <name>` | Use a saved instance instead of the current one. This takes precedence over `MICROFEED_INSTANCE`. |
-| `--json` | Write deterministic JSON to standard output. API responses include `status`, `ok`, safe response `headers`, and `body`. |
+| `--json` | Write deterministic JSON to standard output. API responses include `status`, `ok`, safe response `headers`, and `body`; a `404` also includes safe `recovery` guidance. |
 | `-h`, `--help` | Show help for the selected command or subcommand without running it. |
 
 When `MICROFEED_API_KEY` is set, `--instance` selects its site URL from a saved
@@ -145,6 +151,11 @@ the generated `workers.dev` address; do not use a dashboard path such as
 Login requests the official `microfeed-cli` public client with the fixed
 loopback callback. The callback port must be available, and browser approval
 must complete within five minutes.
+
+Login may succeed while API access is disabled. Before running a content
+command on a new instance, the site owner signs in to the admin dashboard,
+opens **API → API Settings**, and turns on **Enable API access**. If an agent is
+operating the CLI, it pauses and asks the owner to complete that browser step.
 
 ```console
 yarn microfeed login https://feed.example.com --instance production
@@ -575,6 +586,32 @@ With `--json`, API commands return one JSON object:
 }
 ```
 
+A `404` result adds a structured `recovery` object with a stable `code`, a
+documentation URL, and safe instructions for the owner or agent. It does not
+contain a credential or assume the dashboard uses the default `/admin/` path.
+
+```json
+{
+  "body": "404",
+  "headers": {
+    "content-type": "text/plain; charset=utf-8"
+  },
+  "ok": false,
+  "status": 404,
+  "recovery": {
+    "code": "api_access_or_resource_not_found",
+    "documentationUrl": "https://docs.microfeed.org/api/authentication/#enable-the-api",
+    "instructions": [
+      "New microfeed instances keep API access disabled by default.",
+      "The site owner should sign in to the admin dashboard, open API → API Settings, and turn on Enable API access.",
+      "If you are an AI agent, pause and ask the site owner to complete that browser step; do not request their dashboard password, API key, or OAuth token.",
+      "After API access is enabled, retry the same command. If it is already enabled, verify that the requested resource and /api/v1/ path exist."
+    ],
+    "message": "API access may be disabled, or the requested resource may not exist."
+  }
+}
+```
+
 Only safe response headers are included: `cache-control`, `content-length`,
 `content-type`, `etag`, `last-modified`, and `x-request-id`. Saved-instance
 commands also return one deterministic JSON object when `--json` is present.
@@ -586,7 +623,10 @@ non-success API responses set a nonzero exit status. Missing authentication is
 never an interactive token prompt; the error tells you to run `login` or select
 a saved instance. Content commands require API access to be enabled. Because a
 disabled API intentionally returns `404`, that status can mean either that the
-requested resource does not exist or that API access is disabled.
+requested resource does not exist or that API access is disabled. The CLI
+explains that new instances default to disabled, directs the owner to **API →
+API Settings → Enable API access**, tells an AI agent to pause for that browser
+step, and links to the [API setup guide](/api/authentication/#enable-the-api).
 
 ## Saved instances and credentials
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,8 +22,16 @@ giving an agent a raw OAuth token.
 
 Instances without built-in login can continue using an API key.
 
-If a content command returns `404`, the requested resource may not exist or API
-access may be disabled for the selected instance.
+New microfeed instances keep API access disabled by default. The site owner
+must sign in to the admin dashboard, open **API → API Settings**, and turn on
+**Enable API access** before content commands can succeed. OAuth login itself
+can be saved while API access is off.
+
+If a content command returns `404`, the CLI prints these steps and a link to
+the [API setup guide](https://docs.microfeed.org/api/authentication/#enable-the-api).
+With `--json`, the result also includes a structured `recovery` object. An AI
+agent must pause and ask the owner to complete the dashboard step in the
+browser; it must never request a dashboard password, API key, or OAuth token.
 
 ## Run the CLI
 
@@ -56,8 +64,9 @@ example:
 
 ```text
 Use @microfeed/cli to create a published item on https://feed.example.com.
-Use --json for deterministic output, and pause for me if browser authorization
-or confirmation of a destructive action is required.
+Use --json for deterministic output, and pause for me if API access must be
+enabled, browser authorization is required, or a destructive action needs
+confirmation.
 ```
 
 Inside a microfeed clone, tell the agent to prefer `yarn microfeed`. Elsewhere,

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -31,8 +31,12 @@ const instanceOption = option(
 );
 const jsonOption = option(
   "--json",
-  "Write one deterministic JSON result to stdout; diagnostics still use stderr.",
+  "Write one deterministic JSON result to stdout; a 404 adds recovery guidance, while diagnostics still use stderr.",
 );
+const apiAccessDetails = [
+  "New microfeed instances keep API access disabled by default. Before running content commands, the site owner signs in to the admin dashboard, opens API → API Settings, and turns on Enable API access.",
+  "If a command returns 404, API access may still be disabled or the requested resource may not exist. An AI agent must pause and ask the site owner to complete the dashboard step in the browser; it must not request a dashboard password, API key, or OAuth token.",
+] as const;
 
 const itemInputOptions = [
   option("--title <text>", "Set the item title."),
@@ -72,6 +76,8 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "Use the URL that opens the public microfeed site. It may be a custom-domain URL or the generated workers.dev URL.",
       "<name> is the local saved-instance name, not a user account, OAuth identity, or Wrangler profile. It uses 1–64 ASCII letters, numbers, dots, underscores, or hyphens; production and personal-feed are valid examples.",
       "Login verifies the microfeed identity and OAuth metadata at the same site URL, opens administrator sign-in and consent in a browser, and stores only encrypted tokens. The person using the instance must approve the browser step.",
+      "OAuth login can be saved while API access is disabled, but content commands return 404 until the site owner enables access.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed login https://feed.example.com --instance production",
@@ -173,7 +179,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "<item-id> is the stable ID returned by `item list` or `item get`, for example 0HGJLSML3P1.",
       "Create and update accept either common flags or one JSON object from --input; they reject mixed input forms.",
       "An item image is cover art or a thumbnail. A media attachment is the item's one main audio, video, document, or image file; it becomes JSON Feed attachments[0] and the RSS enclosure.",
-      "Content commands require API access to be enabled on the selected instance. A 404 can mean either that a requested item does not exist or that API access is disabled.",
+      ...apiAccessDetails,
       "Delete is permanent and requires an exact item-ID confirmation. Run help for a subcommand before changing content.",
     ],
     examples: [
@@ -198,6 +204,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
     details: [
       "Reads GET /api/v1/feed/ from the selected instance. It does not change content.",
       "Use a cursor exactly as returned by the API. Do not combine next and previous cursors unless the target API explicitly documents that behavior.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed item list --instance production --limit 25 --json",
@@ -223,6 +230,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
     details: [
       "<item-id> is the ID shown in an item response, for example 0HGJLSML3P1. An item-page slug ending in that ID is also accepted by the API.",
       "Reads GET /api/v1/items/{item-id}/ and does not change content.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed item get 0HGJLSML3P1 --instance production",
@@ -242,6 +250,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "Use --image-file only for item cover art or a thumbnail. It does not create a JSON Feed attachment or RSS enclosure.",
       "For either file option, the CLI prepares a same-site upload, sends the bytes without a Bearer credential, never prints the short-lived upload URL, and rejects redirects or another-site upload URLs.",
       "With --input -, the CLI reads UTF-8 JSON from stdin. It never reads a credential from stdin.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed item create --instance production --title \"Release notes\" --status published --json",
@@ -263,6 +272,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "Choose exactly one input form: common item flags, or --input with a JSON object. Use JSON input for fields not represented by common flags.",
       "Use --attachment-file for a local main media attachment. The CLI infers audio, video, document, or image category and MIME type from the extension, records the file size, and replaces any existing attachment.",
       "Use --image-file for local cover art or a thumbnail, and --image only for cover art already hosted at an absolute URL. Neither option changes the media attachment or RSS enclosure.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed item update 0HGJLSML3P1 --instance production --status unlisted --json",
@@ -282,6 +292,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "Permanently deletes DELETE /api/v1/items/{item-id}/ on the selected instance.",
       "In an interactive terminal, omitting --confirm prompts you to type the exact item ID. In non-interactive use, --confirm is required and must exactly match the positional ID.",
       "There is no generic --yes option. Before an agent runs this command, it must report the selected saved-instance name and item ID, explain the permanent effect, and obtain approval.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed item delete 0HGJLSML3P1 --instance production",
@@ -304,6 +315,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "Uploads a supported local file through POST /api/v1/media_files/presigned_urls/ without changing an item. Use the returned permanent media_url in rich HTML, JSON input, or another supported API field.",
       "This is the command for an image embedded inside content_html. It is different from --image-file, which sets item cover art, and --attachment-file, which sets the item's main JSON Feed attachment and RSS enclosure.",
       "Run help for the upload subcommand to see supported file types, item-ID requirements, security behavior, and complete examples.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed media upload ./diagram.png --instance production --json",
@@ -325,6 +337,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "The command creates a stored media object but does not edit an item. Read media_url from the JSON result, insert it into content_html or another field, and save the item. An uploaded object remains stored if it is never referenced; there is no CLI media-delete command.",
       "The CLI requests a same-site prepared upload, streams the bytes without a Bearer credential, rejects redirects and another-site upload URLs, and never prints the short-lived presigned URL.",
       "Human output is only the permanent media URL followed by a newline. With --json, stdout contains category, media_url, mime_type, and size_in_bytes. Diagnostics use stderr.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed media upload ./diagram.png --instance production --json",
@@ -350,6 +363,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "The CLI injects and refreshes its Bearer credential. It blocks caller-provided Authorization, Cookie, and Host headers and refuses redirects so credentials never cross origins.",
       "--input is for UTF-8 request bodies, not binary files. Use `media upload` for inline or standalone media, --attachment-file for a media attachment/RSS enclosure, and --image-file for item cover art.",
       "Without --json, the response body goes to stdout and diagnostics to stderr. With --json, stdout contains status, ok, safe response headers, and body.",
+      ...apiAccessDetails,
     ],
     examples: [
       "yarn microfeed api GET \"/api/v1/feed/?limit=3\" --instance production --json",
@@ -474,12 +488,15 @@ export function renderCliHelp(path?: readonly string[]): string {
     "  are encrypted; the encryption key stays in the OS keychain.",
     "  For CI, MICROFEED_API_KEY takes precedence and is never persisted. Set",
     "  MICROFEED_URL when no saved instance supplies the target site URL.",
-    "  Content commands require API access on the selected instance. A 404",
-    "  may mean the resource is absent or API access is disabled.",
+    "  New instances keep API access disabled by default. The site owner",
+    "  enables it in the dashboard under API → API Settings → Enable API access.",
+    "  If a command returns 404, an AI agent pauses for that browser step and",
+    "  never asks for a dashboard password, API key, or OAuth token.",
     "",
     "Global options:",
     "  --instance <name>  On login, save this name; otherwise use this instance.",
-    "  --json             Write deterministic JSON to stdout.",
+    "  --json             Write deterministic JSON to stdout; 404 API results",
+    "                     include safe recovery guidance.",
     "  -h, --help         Show help without running a command.",
     "",
     "Start here:",

--- a/packages/cli/src/http.ts
+++ b/packages/cli/src/http.ts
@@ -22,6 +22,19 @@ const SAFE_RESPONSE_HEADERS = new Set([
   "last-modified",
   "x-request-id",
 ]);
+const API_ACCESS_HELP_URL =
+  "https://docs.microfeed.org/api/authentication/#enable-the-api";
+const API_NOT_FOUND_RECOVERY = {
+  code: "api_access_or_resource_not_found",
+  documentationUrl: API_ACCESS_HELP_URL,
+  instructions: [
+    "New microfeed instances keep API access disabled by default.",
+    "The site owner should sign in to the admin dashboard, open API → API Settings, and turn on Enable API access.",
+    "If you are an AI agent, pause and ask the site owner to complete that browser step; do not request their dashboard password, API key, or OAuth token.",
+    "After API access is enabled, retry the same command. If it is already enabled, verify that the requested resource and /api/v1/ path exist.",
+  ],
+  message: "API access may be disabled, or the requested resource may not exist.",
+} as const;
 
 export interface GlobalOptions {
   instance?: string;
@@ -170,7 +183,10 @@ export async function apiRequest(
 
 export function writeApiResponse(response: ApiResponse, json: boolean): void {
   if (json) {
-    process.stdout.write(`${JSON.stringify(response)}\n`);
+    const output = response.status === 404
+      ? {...response, recovery: API_NOT_FOUND_RECOVERY}
+      : response;
+    process.stdout.write(`${JSON.stringify(output)}\n`);
   } else if (typeof response.body === "string") {
     process.stdout.write(response.body);
     if (response.body && !response.body.endsWith("\n")) process.stdout.write("\n");
@@ -178,12 +194,15 @@ export function writeApiResponse(response: ApiResponse, json: boolean): void {
     process.stdout.write(`${JSON.stringify(response.body, null, 2)}\n`);
   }
   if (!response.ok) {
-    const recovery = response.status === 404
-      ? " The resource may not exist, or API access may be disabled for this instance."
-      : "";
-    process.stderr.write(
-      `microfeed API request failed (${response.status}).${recovery}\n`,
-    );
+    const diagnostic = response.status === 404
+      ? [
+        `microfeed API request failed (${response.status}).`,
+        API_NOT_FOUND_RECOVERY.message,
+        ...API_NOT_FOUND_RECOVERY.instructions,
+        `Guide: ${API_NOT_FOUND_RECOVERY.documentationUrl}`,
+      ].join("\n")
+      : `microfeed API request failed (${response.status}).`;
+    process.stderr.write(`${diagnostic}\n`);
     process.exitCode = 1;
   }
 }

--- a/tests/unit/cli/credentials.test.ts
+++ b/tests/unit/cli/credentials.test.ts
@@ -203,9 +203,10 @@ describe("CLI credentials", () => {
 });
 
 describe("CLI API diagnostics", () => {
-  it("explains the two intentional meanings of a 404 response", () => {
+  it("gives people and agents actionable recovery for a 404 response", () => {
     const previousExitCode = process.exitCode;
-    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stdout = vi.spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
     const write = vi.spyOn(process.stderr, "write")
       .mockImplementation(() => true);
     try {
@@ -215,9 +216,29 @@ describe("CLI API diagnostics", () => {
         ok: false,
         status: 404,
       }, true);
-      expect(write).toHaveBeenCalledWith(expect.stringContaining(
-        "resource may not exist, or API access may be disabled",
-      ));
+      const diagnostic = String(write.mock.calls[0]?.[0]);
+      expect(diagnostic).toContain("API access may be disabled");
+      expect(diagnostic).toContain("disabled by default");
+      expect(diagnostic).toContain("API → API Settings");
+      expect(diagnostic).toContain("turn on Enable API access");
+      expect(diagnostic).toContain("AI agent, pause");
+      expect(diagnostic).toContain("do not request their dashboard password");
+      expect(diagnostic).toContain("retry the same command");
+      expect(diagnostic).toContain(
+        "https://docs.microfeed.org/api/authentication/#enable-the-api",
+      );
+
+      const output = JSON.parse(String(stdout.mock.calls[0]?.[0])) as {
+        recovery: {
+          code: string;
+          documentationUrl: string;
+          instructions: string[];
+        };
+      };
+      expect(output.recovery.code).toBe("api_access_or_resource_not_found");
+      expect(output.recovery.documentationUrl).toContain("#enable-the-api");
+      expect(output.recovery.instructions.join(" "))
+        .toContain("site owner should sign in");
     } finally {
       process.exitCode = previousExitCode;
     }

--- a/tests/unit/cli/help.test.ts
+++ b/tests/unit/cli/help.test.ts
@@ -70,6 +70,33 @@ describe("microfeed CLI help", () => {
     expect(help).toContain("--attachment-file");
   });
 
+  it("explains how owners enable API access and when agents must pause", () => {
+    const remoteTopics = [
+      ["login"],
+      ["item"],
+      ["item", "list"],
+      ["item", "get"],
+      ["item", "create"],
+      ["item", "update"],
+      ["item", "delete"],
+      ["media"],
+      ["media", "upload"],
+      ["api"],
+    ];
+
+    for (const topic of remoteTopics) {
+      const help = renderCliHelp(topic);
+      expect(help).toContain("disabled by default");
+      expect(help).toContain("API → API Settings");
+      expect(help).toContain("Enable API access");
+      expect(help).toContain("AI agent must pause");
+      expect(help).toContain("must not request a dashboard password");
+    }
+    expect(HELP).toContain("API → API Settings → Enable API access");
+    expect(HELP).toContain("AI agent pauses");
+    expect(HELP).toContain("include safe recovery guidance");
+  });
+
   it("renders comprehensive help for every command and subcommand", () => {
     for (const topic of CLI_HELP_TOPICS) {
       const help = renderCliHelp(topic.path);
@@ -145,6 +172,12 @@ describe("microfeed CLI help", () => {
         ).toContain(`\`${optionName}`);
       }
     }
+    expect(reference).toContain("api_access_or_resource_not_found");
+    expect(reference).toContain("API → API Settings");
+    expect(reference).toContain("AI agent to pause");
+    expect(reference).toContain(
+      "https://docs.microfeed.org/api/authentication/#enable-the-api",
+    );
   });
 
   it("rejects unknown and overlong help topics", async () => {


### PR DESCRIPTION
## Summary

- Explain in top-level and per-command help that new microfeed instances keep API access disabled by default.
- Give a 404 response actionable owner steps: sign in to the dashboard, open API → API Settings, enable API access, and retry.
- Tell AI agents to pause for that browser-only action and never request a dashboard password, API key, or OAuth token.
- Add a structured recovery object to 404 output under --json while preserving the existing status, headers, and body fields.
- Synchronize the npm README, canonical CLI reference, guided docs, publishing prompt, and bundled content-management skill.

## Related issue

N/A.

## Testing

- [x] yarn vitest run tests/unit/cli/credentials.test.ts tests/unit/cli/help.test.ts
- [x] yarn vitest run tests/unit/docs-site.test.ts
- [x] yarn cli:check
- [x] yarn docs:check
- [x] git diff --check
- [x] yarn check

The full check passed 443 unit tests, 66 Worker tests, packed CLI parity checks, OpenAPI validation, builds, and documentation generation.

## Screenshots

N/A — terminal diagnostics, structured output, help text, and documentation only.

## Risks

Low. Successful response output is unchanged. JSON 404 responses gain one additive recovery property, and human 404 diagnostics become more detailed. The guidance uses dashboard navigation labels instead of assuming the default dashboard path.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
