### PR TITLE
Bump microfeed versions to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfeed",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Manage content on a microfeed instance",
   "keywords": [
     "microfeed",


### PR DESCRIPTION
## Summary

- Bump the microfeed application version from 1.0.1 to 1.0.2.
- Bump the @microfeed/cli package version from 1.0.1 to 1.0.2.
- Keep runtime-generated version metadata and the published CLI release aligned.

The @microfeed/cli 1.0.2 package is already published to npm with the latest tag.

## Related issue

N/A.

## Testing

- [x] `yarn check`
- [x] Verified the packed CLI package and project-local behavior.
- [x] Installed @microfeed/cli 1.0.2 from npm and verified its help output.

## Screenshots

N/A — metadata-only change.

## Risks

Low. This changes release metadata only; no command or API behavior changes.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
