### PR TITLE
Explain how to enable built-in login

### DIFF
--- a/docs/manage/domains-and-access.md
+++ b/docs/manage/domains-and-access.md
@@ -26,14 +26,52 @@ hostname.
 ## Built-in login
 
 Built-in login stores an administrator email and password verifier in the
-microfeed database. If you are signed in and know the current password, use
-**Account settings** for routine email or password changes. From a connected
-repository clone, use `yarn manage auth` for initial setup, forgotten-password
-recovery, dashboard-path changes, or disabling the built-in login. Always
-include an action:
+microfeed database.
+
+### Enable built-in login
+
+On the computer where you installed microfeed, open the microfeed project
+folder in a terminal. If you do not know the saved name for your site, list the
+available sites first:
 
 ```console
-yarn manage auth setup
+yarn manage instances
+```
+
+Then run this command, replacing `<instance-name>` with the name shown above:
+
+```console
+yarn manage auth setup --instance <instance-name>
+```
+
+Check the site and dashboard shown by the command, then follow its prompts. For
+a deployed site, it opens or prints a private, one-time page where you create
+the administrator password.
+
+The setup command automatically redeploys microfeed when enabling built-in
+login requires a configuration change. If built-in login is already enabled,
+it skips the redeploy. You do not need to run `yarn manage deploy` separately.
+After setup, verify the result:
+
+```console
+yarn manage status --instance <instance-name>
+```
+
+You can also ask an AI coding agent that has access to your microfeed project:
+
+> Enable built-in login for my microfeed site and verify it. If more than one
+> site is saved, ask me which one.
+
+The agent can run the setup command and any required redeploy. You must complete
+Cloudflare browser authorization and create the password in the private browser
+page yourself. Never paste the password or private page URL into a conversation.
+
+If you are signed in and know the current password, use **Account settings**
+for routine email or password changes. From a connected repository clone, use
+`yarn manage auth` for forgotten-password recovery, dashboard-path changes, or
+disabling the built-in login. Always include an action:
+
+```console
 yarn manage auth reset-password
 yarn manage auth change-email
 yarn manage auth change-path

--- a/src/components/admin/account/AccountSettingsApp.tsx
+++ b/src/components/admin/account/AccountSettingsApp.tsx
@@ -57,6 +57,22 @@ interface Confirmation {
 
 type CredentialDialog = "email" | "password";
 
+const BUILT_IN_LOGIN_GUIDE_URL =
+  "https://docs.microfeed.org/manage/domains-and-access/#built-in-login";
+
+function BuiltInLoginGuideLink() {
+  return (
+    <a
+      className="font-medium underline underline-offset-4"
+      href={BUILT_IN_LOGIN_GUIDE_URL}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      Learn how to enable the built-in login.
+    </a>
+  );
+}
+
 async function requestJson<T>(url: string, init: RequestInit): Promise<T> {
   const response = await fetch(url, {
     ...init,
@@ -292,7 +308,7 @@ export default function AccountSettingsApp(props: Props) {
                   <p className="text-sm text-muted-foreground">Passkeys are tied to <strong className="text-foreground">{props.hostname}</strong>. If the site address changes, use your password to recover access and add a new passkey.</p>
                 </CardFooter>
               </>
-            ) : <p className="p-6 text-sm text-muted-foreground">Passkeys require the built-in login. This dashboard uses Cloudflare Access only.</p>}
+            ) : <p className="p-6 text-sm text-muted-foreground">Passkeys require the built-in login. This dashboard uses Cloudflare Access only. <BuiltInLoginGuideLink /></p>}
           </CardContent>
         </SectionCard>
       </section>
@@ -323,7 +339,7 @@ export default function AccountSettingsApp(props: Props) {
                 })}</ul>
                 {application.connections.length === 1 && <Button className="mt-4" onClick={() => void revokeApplication(application.clientId, application.name)} size="sm" type="button" variant="destructive">Revoke all connections</Button>}
               </div>
-            ))}</div> : <p className="p-6 text-sm text-muted-foreground">No applications are authorized. Connect with <code>microfeed login</code> to add microfeed CLI.</p> : <p className="p-6 text-sm text-muted-foreground">App access requires the built-in login.</p>}
+            ))}</div> : <p className="p-6 text-sm text-muted-foreground">No applications are authorized. Connect with <code>microfeed login</code> to add microfeed CLI.</p> : <p className="p-6 text-sm text-muted-foreground">App access requires the built-in login. <BuiltInLoginGuideLink /></p>}
           </CardContent>
         </SectionCard>
       </section>

--- a/tests/unit/components/admin-oauth-apps.test.ts
+++ b/tests/unit/components/admin-oauth-apps.test.ts
@@ -96,6 +96,10 @@ describe("App access", () => {
     }));
     expect(output).toContain("Cloudflare Access");
     expect(output).toContain("managed externally");
+    expect(output.match(/Learn how to enable the built-in login\./gu)).toHaveLength(2);
+    expect(output).toContain(
+      'href="https://docs.microfeed.org/manage/domains-and-access/#built-in-login"',
+    );
     expect(output).not.toContain("Change password");
   });
 

--- a/tests/unit/docs-site.test.ts
+++ b/tests/unit/docs-site.test.ts
@@ -235,6 +235,16 @@ describe("documentation site", () => {
       path.join(docsRoot, "manage/domains-and-access.md"),
       "utf8",
     );
+    expect(authenticationGuide).toContain("### Enable built-in login");
+    expect(authenticationGuide).toContain(
+      "yarn manage auth setup --instance <instance-name>",
+    );
+    expect(authenticationGuide).toContain(
+      "You do not need to run `yarn manage deploy` separately.",
+    );
+    expect(authenticationGuide).toContain(
+      "You can also ask an AI coding agent that has access to your microfeed project",
+    );
     expect(authenticationGuide).toContain("## Change your built-in login");
     expect(authenticationGuide).toContain(
       "select **Account settings**. The **Login & identity** section",


### PR DESCRIPTION
## Summary

- Link the Passkeys and App access unavailable states to the built-in login guide.
- Add a newcomer-focused setup section with the exact command, instance discovery, verification, and redeploy behavior.
- Explain how an AI coding agent can help while keeping Cloudflare authorization, password creation, and private setup links with the owner.

This helps Cloudflare Access-only administrators understand how to enable the features shown on Account settings without having to interpret the full management command reference.

## Related issue

N/A.

## Testing

- [x] `yarn check`
- [x] `yarn vitest run tests/unit/components/admin-oauth-apps.test.ts tests/unit/docs-site.test.ts`
- [x] `yarn docs:check`
- [x] `git diff --check`
- [x] Previewed the documentation at desktop and mobile sizes in light and dark themes; no page-level horizontal overflow was introduced.

## Screenshots

The source report includes a before screenshot of the Cloudflare Access-only Account settings page. The after state is a copy-only addition to the two existing unavailable messages, and the documentation layout was verified locally; no new screenshot is attached from the CLI workflow.

## Risks

Low. This changes explanatory copy and adds an external documentation link; authentication behavior and management CLI behavior are unchanged.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
