### PR TITLE
Add current-year template variable

### DIFF
--- a/docs/dashboard/edit-channel.md
+++ b/docs/dashboard/edit-channel.md
@@ -21,6 +21,27 @@ are saved.
 
 ![Editing a microfeed channel image, title, publisher, website, categories, language, and description](/images/screenshots/2-dashboard-2-edit-channel.png)
 
+## Keep the copyright year current
+
+In **Podcast-specific fields**, the **Copyright** field accepts the built-in
+`{{current_year}}` variable. For example, enter:
+
+```text
+© {{current_year}} Example Publisher
+```
+
+microfeed saves that text with the variable intact. When it produces the
+public website, JSON feed, or RSS feed, it replaces the variable with the
+current UTC year. In 2026, the example publishes as
+`© 2026 Example Publisher`. The value changes at midnight UTC on January 1;
+the existing public cache can retain the previous year for about five minutes.
+
+Only `{{current_year}}` is supported in the Copyright field. Other expressions,
+including feed fields such as `{{_microfeed.base_url}}`, remain unchanged.
+Existing channels with a fixed year are not changed automatically. Replace the
+year with `{{current_year}}` once if you want that channel to update itself in
+future years.
+
 ## Check the public destinations
 
 Use the **Public access** links beside the form to open the website, RSS feed,

--- a/docs/dashboard/edit-channel.md
+++ b/docs/dashboard/edit-channel.md
@@ -36,8 +36,7 @@ current UTC year. In 2026, the example publishes as
 `© 2026 Example Publisher`. The value changes at midnight UTC on January 1;
 the existing public cache can retain the previous year for about five minutes.
 
-Only `{{current_year}}` is supported in the Copyright field. Other expressions,
-including feed fields such as `{{_microfeed.base_url}}`, remain unchanged.
+Only `{{current_year}}` is supported in the Copyright field.
 Existing channels with a fixed year are not changed automatically. Replace the
 year with `{{current_year}}` once if you want that channel to update itself in
 future years.

--- a/src/components/admin/channel/EditChannelApp/FormExplainTexts.ts
+++ b/src/components/admin/channel/EditChannelApp/FormExplainTexts.ts
@@ -1,3 +1,7 @@
+import {getBuiltInTemplateVariables} from "@/shared/TemplateVariables";
+
+const {current_year: currentYear} = getBuiltInTemplateVariables();
+
 export const CHANNEL_CONTROLS = {
   TITLE: 'channel_title',
   IMAGE: 'channel_image',
@@ -101,10 +105,12 @@ export const CONTROLS_TEXTS_DICT = {
     linkName: 'Copyright',
     modalTitle: 'Channel / Copyright',
     text: "The show copyright details.<br>" +
-      "If your show is copyrighted you should use this tag. For example:<br>" +
-      "<em>Copyright 1995-2019 John John Appleseed</em>",
-    rss: '<channel><copyright>©2023</copyright></channel>',
-    json: '{ "_microfeed": {"itunes:type": "©2023"} }',
+      "Use <code>{{current_year}}</code> to keep the year current automatically. " +
+      "microfeed saves the variable as typed and replaces it with the current UTC year in public pages and feeds.<br>" +
+      "For example, <code>© {{current_year}} Publisher</code> currently publishes as " +
+      `<em>© ${currentYear} Publisher</em>. Only <code>{{current_year}}</code> is supported here.`,
+    rss: `<channel><copyright>© ${currentYear} Publisher</copyright></channel>`,
+    json: `{ "_microfeed": {"copyright": "© ${currentYear} Publisher"} }`,
   },
   [CHANNEL_CONTROLS.ITUNES_TITLE]: {
     linkName: '<itunes:title>',

--- a/src/server/feed/FeedDb.ts
+++ b/src/server/feed/FeedDb.ts
@@ -198,7 +198,7 @@ export default class FeedDb {
       'itunes:type': 'episodic',
       'itunes:complete': false,
       'itunes:block': false,
-      'copyright': `©${(new Date()).getFullYear()}`,
+      'copyright': '©{{current_year}}',
     };
 
     const batchStatements = [

--- a/src/server/feed/FeedPublicJsonBuilder.ts
+++ b/src/server/feed/FeedPublicJsonBuilder.ts
@@ -12,6 +12,7 @@ import {isValidMediaFile} from "@/shared/MediaFileUtils";
 import {MICROFEED_VERSION} from "@/shared/Version";
 import {buildItemPaginationUrl} from "@/shared/ItemPagination";
 import {resolveEffectiveFavicon} from "@/shared/Favicon";
+import {resolveBuiltInTemplateVariables} from "@/shared/TemplateVariables";
 
 export default class FeedPublicJsonBuilder {
   [member: string]: any;
@@ -174,7 +175,9 @@ export default class FeedPublicJsonBuilder {
       (microfeedExtra as any)['itunes:title'] = channel['itunes:title'];
     }
     if (channel['copyright']) {
-      (microfeedExtra as any)['copyright'] = channel['copyright'];
+      (microfeedExtra as any)['copyright'] = resolveBuiltInTemplateVariables(
+        channel['copyright'],
+      );
     }
     if (channel['itunes:title']) {
       (microfeedExtra as any)['itunes:title'] = channel['itunes:title'];

--- a/src/server/feed/FeedPublicRssBuilder.ts
+++ b/src/server/feed/FeedPublicRssBuilder.ts
@@ -3,6 +3,7 @@ import {PUBLIC_URLS, secondsToHHMMSS} from "@/shared/StringUtils";
 import {msToUtcString} from "@/shared/TimeUtils";
 import {OUR_BRAND} from "@/shared/Constants";
 import {buildItemPaginationUrl} from "@/shared/ItemPagination";
+import {resolveBuiltInTemplateVariables} from "@/shared/TemplateVariables";
 
 export default class FeedPublicRssBuilder {
   [member: string]: any;
@@ -168,7 +169,9 @@ export default class FeedPublicRssBuilder {
       };
     }
     if (_microfeed.copyright && _microfeed.copyright.trim().length > 0) {
-      (channelRss as any).copyright = _microfeed.copyright.trim();
+      (channelRss as any).copyright = resolveBuiltInTemplateVariables(
+        _microfeed.copyright,
+      ).trim();
     }
     if (_microfeed['itunes:email'] && _microfeed['itunes:email'].trim().length > 0) {
       (channelRss as any)['itunes:owner'] = {

--- a/src/server/themes/Theme.ts
+++ b/src/server/themes/Theme.ts
@@ -7,6 +7,7 @@ import DEFAULT_RSS_STYLESHEET from "./defaults/rss_stylesheet.html?raw";
 import DEFAULT_WEB_FEED from "./defaults/web_feed.html?raw";
 import DEFAULT_WEB_ITEM from "./defaults/web_item.html?raw";
 import Mustache from "mustache";
+import {getBuiltInTemplateVariables} from "@/shared/TemplateVariables";
 
 export default class Theme {
   [member: string]: any;
@@ -14,6 +15,7 @@ export default class Theme {
   constructor(jsonData: any, settings: any = null, themeName: string | null = null) {
     this.jsonData = jsonData;
     this.settings = settings;
+    this.templateVariables = getBuiltInTemplateVariables();
 
     this.theme = 'custom';
     if (!themeName) {
@@ -35,9 +37,17 @@ export default class Theme {
     return this.theme;
   }
 
+  renderContext(extra: Record<string, unknown> = {}) {
+    return {
+      ...this.jsonData,
+      ...this.templateVariables,
+      ...extra,
+    };
+  }
+
   getWebHeader() {
     const tmpl = this.getWebHeaderTmpl();
-    const html = Mustache.render(tmpl, {...this.jsonData,});
+    const html = Mustache.render(tmpl, this.renderContext());
     return {html};
   }
 
@@ -54,7 +64,7 @@ export default class Theme {
 
   getWebBodyEnd() {
     const tmpl = this.getWebBodyEndTmpl();
-    const html = Mustache.render(tmpl, {...this.jsonData,});
+    const html = Mustache.render(tmpl, this.renderContext());
     return {html};
   }
 
@@ -71,7 +81,7 @@ export default class Theme {
 
   getWebBodyStart() {
     const tmpl = this.getWebBodyStartTmpl();
-    const html = Mustache.render(tmpl, {...this.jsonData,});
+    const html = Mustache.render(tmpl, this.renderContext());
     return {html};
   }
 
@@ -94,7 +104,7 @@ export default class Theme {
 
   getRssStylesheet() {
     const tmpl = this.getRssStylesheetTmpl();
-    const stylesheet = Mustache.render(tmpl, {});
+    const stylesheet = Mustache.render(tmpl, this.renderContext());
     return {
       stylesheet,
     };
@@ -102,9 +112,7 @@ export default class Theme {
 
   getWebFeed() {
     const tmpl = this.getWebFeedTmpl();
-    const html = Mustache.render(tmpl, {
-      ...this.jsonData,
-    });
+    const html = Mustache.render(tmpl, this.renderContext());
     return {
       html,
     };
@@ -116,12 +124,10 @@ export default class Theme {
 
   getWebItem(item: any) {
     const tmpl = this.getWebItemTmpl();
-    const html = Mustache.render(tmpl, {
-      ...this.jsonData,
-
+    const html = Mustache.render(tmpl, this.renderContext({
       // TODO: Remove "item". We don't need this "item" field any more. Use "items.0" instead.
       item,
-    });
+    }));
     return {
       html,
     };

--- a/src/shared/ApiSchemas.ts
+++ b/src/shared/ApiSchemas.ts
@@ -80,8 +80,15 @@ export const apiItemOutputSchema = apiItemInputSchema.extend({
   url: z.string().optional(),
 }).meta({id: "Item"});
 
+export const apiFeedMicrofeedSchema = z.object({
+  copyright: z.string().optional().meta({
+    description: "Rendered channel copyright. A supported {{current_year}} variable in the saved channel has already been replaced with the current UTC year.",
+    example: "© 2026 Example Publisher",
+  }),
+}).loose().meta({id: "FeedMicrofeed"});
+
 export const apiFeedSchema = z.object({
-  _microfeed: z.record(z.string(), z.unknown()).optional(),
+  _microfeed: apiFeedMicrofeedSchema.optional(),
   description: z.string().optional(),
   favicon: z.string().optional(),
   feed_url: z.string().optional(),
@@ -94,8 +101,15 @@ export const apiFeedSchema = z.object({
   version: z.string(),
 }).loose().meta({id: "Feed"});
 
+export const apiChannelMicrofeedInputSchema = z.object({
+  copyright: z.string().optional().meta({
+    description: "Channel copyright text. Use the allowlisted {{current_year}} variable to publish the current UTC year automatically; the expression is saved literally and resolved in public output.",
+    example: "© {{current_year}} Example Publisher",
+  }),
+}).loose().meta({id: "ChannelMicrofeedInput"});
+
 export const apiChannelInputSchema = z.object({
-  _microfeed: z.record(z.string(), z.unknown()).optional(),
+  _microfeed: apiChannelMicrofeedInputSchema.optional(),
   authors: z.array(z.object({name: z.string()})).optional(),
   description: z.string().optional(),
   expired: z.boolean().optional(),

--- a/src/shared/TemplateVariables.ts
+++ b/src/shared/TemplateVariables.ts
@@ -1,0 +1,27 @@
+export interface BuiltInTemplateVariables {
+  current_year: number;
+}
+
+const TEMPLATE_VARIABLE_PATTERN =
+  /(?<!\{)\{\{\s*([a-z][a-z0-9_]*)\s*\}\}(?!\})/gu;
+
+export function getBuiltInTemplateVariables(
+  now: Date = new Date(),
+): BuiltInTemplateVariables {
+  return {
+    current_year: now.getUTCFullYear(),
+  };
+}
+
+export function resolveBuiltInTemplateVariables(
+  value: string,
+  variables: BuiltInTemplateVariables = getBuiltInTemplateVariables(),
+): string {
+  return value.replace(
+    TEMPLATE_VARIABLE_PATTERN,
+    (expression, variableName: string) => {
+      if (!Object.hasOwn(variables, variableName)) return expression;
+      return String(variables[variableName as keyof BuiltInTemplateVariables]);
+    },
+  );
+}

--- a/tests/unit/components/admin-channel-form-text.test.ts
+++ b/tests/unit/components/admin-channel-form-text.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from "vitest";
+
+import {
+  CHANNEL_CONTROLS,
+  CONTROLS_TEXTS_DICT,
+} from "@/components/admin/channel/EditChannelApp/FormExplainTexts";
+
+describe("Edit Channel copyright explanation", () => {
+  it("explains current_year and shows its resolved output", () => {
+    const copyright = CONTROLS_TEXTS_DICT[CHANNEL_CONTROLS.COPYRIGHT]!;
+    const currentYear = new Date().getUTCFullYear();
+
+    expect(copyright.text).toContain("{{current_year}}");
+    expect(copyright.text).toContain("current UTC year");
+    expect(copyright.text).toContain(`© ${currentYear} Publisher`);
+    expect(copyright.rss).toContain(`© ${currentYear} Publisher`);
+    expect(copyright.json).toContain('"copyright"');
+    expect(copyright.json).not.toContain('"itunes:type"');
+  });
+});

--- a/tests/unit/docs-site.test.ts
+++ b/tests/unit/docs-site.test.ts
@@ -191,6 +191,12 @@ describe("documentation site", () => {
     expect(editChannelGuide).toContain(
       "Channel changes are never saved on a timer",
     );
+    expect(editChannelGuide).toContain("## Keep the copyright year current");
+    expect(editChannelGuide).toContain("`{{current_year}}`");
+    expect(editChannelGuide).toContain("current UTC year");
+    expect(editChannelGuide).toContain(
+      "Existing channels with a fixed year are not changed automatically.",
+    );
     expect(editChannelGuide).not.toContain(
       "Open **Settings** for the controls on this page.",
     );

--- a/tests/unit/openapi.test.ts
+++ b/tests/unit/openapi.test.ts
@@ -134,6 +134,11 @@ describe("generated API reference", () => {
     expect(apiChannelInputSchema.safeParse({
       home_page_url: "https://example.com/",
     }).success).toBe(true);
+    expect(apiChannelInputSchema.safeParse({
+      _microfeed: {
+        copyright: "© {{current_year}} Example Publisher",
+      },
+    }).success).toBe(true);
     expect(apiItemInputSchema.safeParse({
       attachments: [{
         category: "audio",
@@ -155,5 +160,12 @@ describe("generated API reference", () => {
       }],
       image: "https://example.com/cover.png",
     }).success).toBe(true);
+  });
+
+  it("documents resolved current-year copyright output", () => {
+    const specification = JSON.stringify(OPENAPI_DOCUMENT);
+    expect(specification).toContain("{{current_year}}");
+    expect(specification).toContain("current UTC year");
+    expect(specification).toContain("Rendered channel copyright");
   });
 });

--- a/tests/unit/server/FeedPublicJsonBuilder.test.ts
+++ b/tests/unit/server/FeedPublicJsonBuilder.test.ts
@@ -1,6 +1,7 @@
-import {describe, expect, it} from "vitest";
+import {afterEach, describe, expect, it, vi} from "vitest";
 
 import FeedPublicJsonBuilder from "@/server/feed/FeedPublicJsonBuilder";
+import FeedPublicRssBuilder from "@/server/feed/FeedPublicRssBuilder";
 import {LEGACY_DEFAULT_FAVICON_URL} from "@/shared/Favicon";
 
 function buildChannel(faviconUrl: string) {
@@ -40,5 +41,63 @@ describe("public JSON feed favicon", () => {
       favicon: "/media/uploads/favicon.png",
       icon: "/media/channel/image.png",
     });
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("public channel copyright", () => {
+  it("resolves current_year in JSON and RSS output", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-01-01T00:00:00.000Z"));
+
+    const json = new FeedPublicJsonBuilder(
+      {
+        channel: {
+          copyright: "© {{ current_year }} Example Publisher",
+          title: "Example feed",
+        },
+        items: [],
+        settings: {},
+      },
+      "https://feed.example.com",
+      new Request("https://feed.example.com/json/"),
+    ).getJsonData() as any;
+
+    expect(json._microfeed.copyright).toBe("© 2027 Example Publisher");
+    const rss = new FeedPublicRssBuilder(
+      json,
+      "https://feed.example.com",
+    ).getRssData();
+    expect(rss).toContain(
+      "<copyright>© 2027 Example Publisher</copyright>",
+    );
+
+    const directRss = new FeedPublicRssBuilder({
+      _microfeed: {copyright: "©{{ current_year }}"},
+      items: [],
+      title: "Example feed",
+    }, "https://feed.example.com").getRssData();
+    expect(directRss).toContain("<copyright>©2027</copyright>");
+  });
+
+  it("keeps static and unsupported copyright expressions unchanged", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-01-01T00:00:00.000Z"));
+
+    const copyright = "© 2024 / {{unknown}} / {{_microfeed.base_url}}";
+    const json = new FeedPublicJsonBuilder(
+      {
+        channel: {copyright, title: "Example feed"},
+        items: [],
+        settings: {},
+      },
+      "https://feed.example.com",
+      new Request("https://feed.example.com/json/"),
+    ).getJsonData() as any;
+
+    expect(json._microfeed.copyright).toBe(copyright);
   });
 });

--- a/tests/unit/server/Theme.test.ts
+++ b/tests/unit/server/Theme.test.ts
@@ -1,0 +1,40 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+import {CODE_FILES, SETTINGS_CATEGORIES} from "@/shared/Constants";
+import Theme from "@/server/themes/Theme";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("theme built-in variables", () => {
+  it("renders current_year in every custom Mustache template", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2027-01-01T00:00:00.000Z"));
+
+    const variable = "{{current_year}}";
+    const settings = {
+      [SETTINGS_CATEGORIES.CUSTOM_CODE]: {
+        currentTheme: "custom",
+        themes: {
+          custom: {
+            [CODE_FILES.RSS_STYLESHEET]: variable,
+            [CODE_FILES.WEB_BODY_END]: variable,
+            [CODE_FILES.WEB_BODY_START]: variable,
+            [CODE_FILES.WEB_FEED]: variable,
+            [CODE_FILES.WEB_HEADER]: variable,
+            [CODE_FILES.WEB_ITEM]: variable,
+          },
+        },
+      },
+    };
+    const theme = new Theme({}, settings);
+
+    expect(theme.getWebHeader().html).toBe("2027");
+    expect(theme.getWebBodyStart().html).toBe("2027");
+    expect(theme.getWebBodyEnd().html).toBe("2027");
+    expect(theme.getWebFeed().html).toBe("2027");
+    expect(theme.getWebItem({}).html).toBe("2027");
+    expect(theme.getRssStylesheet().stylesheet).toBe("2027");
+  });
+});

--- a/tests/unit/shared/TemplateVariables.test.ts
+++ b/tests/unit/shared/TemplateVariables.test.ts
@@ -1,0 +1,33 @@
+import {describe, expect, it} from "vitest";
+
+import {
+  getBuiltInTemplateVariables,
+  resolveBuiltInTemplateVariables,
+} from "@/shared/TemplateVariables";
+
+describe("built-in template variables", () => {
+  it("uses the UTC year across the New Year boundary", () => {
+    expect(getBuiltInTemplateVariables(
+      new Date("2026-12-31T23:59:59.999Z"),
+    )).toEqual({current_year: 2026});
+    expect(getBuiltInTemplateVariables(
+      new Date("2027-01-01T00:00:00.000Z"),
+    )).toEqual({current_year: 2027});
+  });
+
+  it("resolves allowlisted variables with optional whitespace", () => {
+    expect(resolveBuiltInTemplateVariables(
+      "©{{current_year}} / {{ current_year }} Publisher",
+      {current_year: 2027},
+    )).toBe("©2027 / 2027 Publisher");
+  });
+
+  it("preserves static text and unsupported expressions", () => {
+    const copyright =
+      "© 2024 Publisher / {{unknown}} / {{_microfeed.base_url}} / {{{current_year}}}";
+    expect(resolveBuiltInTemplateVariables(
+      copyright,
+      {current_year: 2027},
+    )).toBe(copyright);
+  });
+});

--- a/tests/worker/media.test.ts
+++ b/tests/worker/media.test.ts
@@ -430,6 +430,7 @@ describe("R2 media responses", () => {
     );
     const content = contents[0];
     expect(content.channel).toBeTruthy();
+    expect(content.channel.copyright).toBe("©{{current_year}}");
     expect(content.settings.webGlobalSettings.publicBucketUrl).toBe("/media/");
     const rows = await env.FEED_DB.prepare(
       "SELECT COUNT(*) AS count FROM channels WHERE is_primary = 1",


### PR DESCRIPTION
## Summary

- add an allowlisted `{{current_year}}` variable for channel copyright
- resolve the UTC year in public JSON, RSS, and every custom Mustache theme surface
- explain the variable in the Copyright modal, Edit Channel guide, and generated API contract
- keep existing channel values unchanged while giving new channels a variable-based default

## Related issue

N/A

## Testing

- [x] `yarn check`
- focused unit tests for UTC New Year behavior, allowlisting, feeds, themes, modal copy, docs, and OpenAPI
- focused Worker initialization test

## Screenshots

N/A — the visible change is explanatory text inside the existing Copyright popup; layout and controls are unchanged.

## Risks

- Existing channels retain fixed copyright years until an administrator opts in.
- Public edge caching can retain the prior year for about five minutes after midnight UTC.
- Unsupported expressions are deliberately preserved as literal text.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
