### PR TITLE
Automate microfeed release version synchronization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,19 @@ application, and verifies the Worker bundle with a dry run. Also run
 `git diff --check` and review the complete diff for generated files and
 secrets.
 
+## Prepare release metadata
+
+Set the application, published CLI, theme kit, bundled default theme, and
+compatible starter range with one command:
+
+```console
+yarn version:set 1.2.3
+```
+
+Use an exact semantic version. The command verifies every target before it
+writes anything. Private workspace metadata, examples, fixtures, tests, and the
+lockfile do not need patch-release edits.
+
 ## Open a pull request
 
 - Open the pull request as a draft until the change and validation are ready

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfeed",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0",
@@ -13,6 +13,7 @@
     "node": ">=22.12.0"
   },
   "scripts": {
+    "version:set": "node --import tsx scripts/set-version.ts",
     "microfeed": "yarn workspace @microfeed/cli microfeed",
     "manage": "tsx manage-cli/index.ts",
     "theme-kit": "yarn workspace @microfeed/theme-kit theme-kit",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Manage content on a microfeed instance",
   "keywords": [
     "microfeed",

--- a/packages/theme-kit/assets/starter/package.json
+++ b/packages/theme-kit/assets/starter/package.json
@@ -8,6 +8,6 @@
     "validate": "theme-kit validate . --json"
   },
   "devDependencies": {
-    "@microfeed/theme-kit": "^1.0.3"
+    "@microfeed/theme-kit": "^1.0.0"
   }
 }

--- a/packages/theme-kit/package.json
+++ b/packages/theme-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/theme-kit",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Author, validate, test, and preview microfeed themes.",
   "keywords": [
     "microfeed",

--- a/scripts/check-theme-kit-package.ts
+++ b/scripts/check-theme-kit-package.ts
@@ -3,6 +3,7 @@ import {tmpdir} from "node:os";
 import path from "node:path";
 import {spawnSync} from "node:child_process";
 
+import {satisfies} from "semver";
 import {x as extractTar} from "tar";
 
 function run(command: string, args: string[], cwd = process.cwd()): string {
@@ -100,8 +101,10 @@ try {
     devDependencies?: Record<string, string>;
     scripts?: Record<string, string>;
   };
-  if (parsedStarterPackage.devDependencies?.["@microfeed/theme-kit"] !==
-        `^${rootPackage.version}` ||
+  if (!satisfies(
+    rootPackage.version,
+    parsedStarterPackage.devDependencies?.["@microfeed/theme-kit"] ?? "",
+  ) ||
       !parsedStarterPackage.scripts?.validate ||
       !parsedStarterPackage.scripts?.test ||
       !parsedStarterPackage.scripts?.preview ||
@@ -169,8 +172,10 @@ try {
   const initializedPackage = JSON.parse(
     await readFile(path.join(initializedTheme, "package.json"), "utf8"),
   ) as {devDependencies?: Record<string, string>};
-  if (initializedPackage.devDependencies?.["@microfeed/theme-kit"] !==
-      `^${rootPackage.version}`) {
+  if (!satisfies(
+    rootPackage.version,
+    initializedPackage.devDependencies?.["@microfeed/theme-kit"] ?? "",
+  )) {
     throw new Error("The packed init command generated a stale local dependency.");
   }
 

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -1,0 +1,126 @@
+import {readFile, writeFile} from "node:fs/promises";
+import path from "node:path";
+import {fileURLToPath, pathToFileURL} from "node:url";
+
+import {major, prerelease, valid} from "semver";
+
+interface JsonObject {
+  [key: string]: JsonObject | string | number | boolean | null | undefined;
+}
+
+interface VersionTarget {
+  filename: string;
+  identity: {field: string; value: string};
+  update: (document: JsonObject, version: string) => void;
+}
+
+const RELEASE_VERSION_TARGETS: VersionTarget[] = [
+  {
+    filename: "package.json",
+    identity: {field: "name", value: "microfeed"},
+    update: (document, version) => {
+      document.version = version;
+    },
+  },
+  {
+    filename: "packages/cli/package.json",
+    identity: {field: "name", value: "@microfeed/cli"},
+    update: (document, version) => {
+      document.version = version;
+    },
+  },
+  {
+    filename: "packages/theme-kit/package.json",
+    identity: {field: "name", value: "@microfeed/theme-kit"},
+    update: (document, version) => {
+      document.version = version;
+    },
+  },
+  {
+    filename: "themes/default/microfeed-theme.json",
+    identity: {field: "packageId", value: "microfeed.default"},
+    update: (document, version) => {
+      document.version = version;
+    },
+  },
+  {
+    filename: "packages/theme-kit/assets/starter/package.json",
+    identity: {field: "name", value: "microfeed-theme"},
+    update: (document, version) => {
+      const devDependencies = document.devDependencies;
+      if (!devDependencies || typeof devDependencies !== "object") {
+        throw new Error("The theme starter is missing devDependencies.");
+      }
+      devDependencies["@microfeed/theme-kit"] = themeKitCompatibilityRange(version);
+    },
+  },
+];
+
+export function themeKitCompatibilityRange(version: string): string {
+  const releaseMajor = major(version);
+  if (releaseMajor === 0) {
+    return `^${version}`;
+  }
+  if (prerelease(version)) {
+    return `>=${version} <${releaseMajor + 1}.0.0`;
+  }
+  return `^${releaseMajor}.0.0`;
+}
+
+export function validateReleaseVersion(input: string | undefined): string {
+  if (!input || valid(input) !== input) {
+    throw new Error(
+      "Provide one exact semantic version, for example: yarn version:set 1.2.3",
+    );
+  }
+  return input;
+}
+
+export async function setReleaseVersion(
+  repositoryRoot: string,
+  input: string,
+): Promise<string[]> {
+  const version = validateReleaseVersion(input);
+  const documents = await Promise.all(RELEASE_VERSION_TARGETS.map(async (target) => {
+    const filename = path.join(repositoryRoot, target.filename);
+    const document = JSON.parse(await readFile(filename, "utf8")) as JsonObject;
+    if (document[target.identity.field] !== target.identity.value) {
+      throw new Error(
+        `${target.filename} is not the expected ${target.identity.value} metadata file.`,
+      );
+    }
+    return {document, filename, target};
+  }));
+
+  for (const {document, target} of documents) {
+    target.update(document, version);
+  }
+  await Promise.all(documents.map(({document, filename}) =>
+    writeFile(filename, `${JSON.stringify(document, null, 2)}\n`, "utf8")
+  ));
+  return documents.map(({target}) => target.filename);
+}
+
+async function main(): Promise<void> {
+  if (process.argv.length !== 3) {
+    throw new Error(
+      "Provide one exact semantic version, for example: yarn version:set 1.2.3",
+    );
+  }
+  const repositoryRoot = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+  const version = validateReleaseVersion(process.argv[2]);
+  const filenames = await setReleaseVersion(repositoryRoot, version);
+  process.stdout.write(
+    `Synchronized microfeed release ${version}:\n${filenames.map((filename) => `- ${filename}`).join("\n")}\n`,
+  );
+}
+
+const entrypoint = process.argv[1]
+  ? pathToFileURL(path.resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === entrypoint) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/components/admin/themes/ThemeDraftEditorApp.tsx
+++ b/src/components/admin/themes/ThemeDraftEditorApp.tsx
@@ -214,7 +214,7 @@ export default function ThemeDraftEditorApp({draft: initial}: Props) {
     >
       {helpField && <div className="grid gap-4 py-2 text-sm leading-relaxed text-muted-foreground">
         <p>{THEME_FIELD_HELP[helpField].description}</p>
-        {helpField === "microfeed" && <p>For example, <code className="rounded bg-muted px-1 py-0.5">^1.0.3</code> accepts compatible 1.x releases.</p>}
+        {helpField === "microfeed" && <p>For example, <code className="rounded bg-muted px-1 py-0.5">^1.0.0</code> accepts compatible 1.x releases.</p>}
         <a className="font-medium text-primary hover:underline" href="https://docs.microfeed.org/dashboard/themes/" rel="noopener noreferrer" target="_blank">Read the theme guide</a>
       </div>}
     </AdminDialog>

--- a/tests/unit/default-theme.test.ts
+++ b/tests/unit/default-theme.test.ts
@@ -66,11 +66,16 @@ describe("bundled theme packages", () => {
   });
 
   it("ships immutable default and classic package identities without assets", async () => {
-    const [modern, classic] = await Promise.all([
+    const [application, modern, classic] = await Promise.all([
+      readFile(path.join(root, "package.json"), "utf8").then(JSON.parse),
       readFile(path.join(root, "themes/default/microfeed-theme.json"), "utf8").then(JSON.parse),
       readFile(path.join(root, "themes/classic/microfeed-theme.json"), "utf8").then(JSON.parse),
     ]);
-    expect(modern).toMatchObject({assets: [], packageId: "microfeed.default", version: "1.0.3"});
+    expect(modern).toMatchObject({
+      assets: [],
+      packageId: "microfeed.default",
+      version: application.version,
+    });
     expect(classic).toMatchObject({assets: [], packageId: "microfeed.classic", version: "1.0.0"});
   });
 

--- a/tests/unit/manage-cli/instance-management.test.ts
+++ b/tests/unit/manage-cli/instance-management.test.ts
@@ -85,7 +85,7 @@ async function freshModules(
     installDefaultThemeForInitialization: vi.fn(async () => ({
       id: "bundled-default-test",
       packageId: "microfeed.default",
-      version: "1.0.3",
+      version: "1.2.3",
     })),
   }));
   vi.resetModules();

--- a/tests/unit/manage-cli/theme-init.test.ts
+++ b/tests/unit/manage-cli/theme-init.test.ts
@@ -157,13 +157,13 @@ describe("theme repository initialization", () => {
       packageId: "microfeed.default",
       sourceKind: "bundled",
       sourcePath: "default",
-      version: "1.0.3",
+      version: MICROFEED_VERSION,
     });
     expect(stored).toMatchObject({
       package_id: "microfeed.default",
       source_kind: "bundled",
       source_path: "default",
-      version: "1.0.3",
+      version: MICROFEED_VERSION,
     });
   });
 

--- a/tests/unit/package-versions.test.ts
+++ b/tests/unit/package-versions.test.ts
@@ -1,4 +1,5 @@
 import {readFile} from "node:fs/promises";
+import {satisfies} from "semver";
 import {expect, test} from "vitest";
 
 async function metadata(relativePath: string): Promise<{
@@ -24,7 +25,10 @@ test("keeps published microfeed tools on the application release version", async
   expect(contentCli.version).toBe(application.version);
   expect(themeKit.version).toBe(application.version);
   expect(defaultTheme.devDependencies?.["@microfeed/theme-kit"])
-    .toBe(`^${application.version}`);
-  expect(genericStarter.devDependencies?.["@microfeed/theme-kit"])
-    .toBe(`^${application.version}`);
+    .toBe("workspace:^");
+  expect(defaultTheme.version).toBe("0.0.0-use.local");
+  expect(satisfies(
+    application.version,
+    genericStarter.devDependencies?.["@microfeed/theme-kit"] ?? "",
+  )).toBe(true);
 });

--- a/tests/unit/set-version.test.ts
+++ b/tests/unit/set-version.test.ts
@@ -1,0 +1,111 @@
+import {mkdtemp, mkdir, readFile, rm, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import path from "node:path";
+
+import {afterEach, describe, expect, it} from "vitest";
+
+import {
+  setReleaseVersion,
+  themeKitCompatibilityRange,
+  validateReleaseVersion,
+} from "../../scripts/set-version";
+
+const temporaryDirectories: string[] = [];
+
+async function writeJson(root: string, filename: string, value: unknown) {
+  const fullPath = path.join(root, filename);
+  await mkdir(path.dirname(fullPath), {recursive: true});
+  await writeFile(fullPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function readJson(root: string, filename: string) {
+  return JSON.parse(await readFile(path.join(root, filename), "utf8")) as {
+    devDependencies?: Record<string, string>;
+    version?: string;
+  };
+}
+
+async function repositoryFixture(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "microfeed-version-test-"));
+  temporaryDirectories.push(root);
+  await Promise.all([
+    writeJson(root, "package.json", {name: "microfeed", version: "1.0.0"}),
+    writeJson(root, "packages/cli/package.json", {
+      name: "@microfeed/cli",
+      version: "1.0.0",
+    }),
+    writeJson(root, "packages/theme-kit/package.json", {
+      name: "@microfeed/theme-kit",
+      version: "1.0.0",
+    }),
+    writeJson(root, "themes/default/microfeed-theme.json", {
+      packageId: "microfeed.default",
+      version: "1.0.0",
+    }),
+    writeJson(root, "packages/theme-kit/assets/starter/package.json", {
+      devDependencies: {"@microfeed/theme-kit": "^1.0.0"},
+      name: "microfeed-theme",
+      version: "0.1.0",
+    }),
+  ]);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, {force: true, recursive: true})
+  ));
+});
+
+describe("release version synchronization", () => {
+  it("updates published metadata and the bundled theme in one operation", async () => {
+    const root = await repositoryFixture();
+
+    await expect(setReleaseVersion(root, "2.3.4")).resolves.toEqual([
+      "package.json",
+      "packages/cli/package.json",
+      "packages/theme-kit/package.json",
+      "themes/default/microfeed-theme.json",
+      "packages/theme-kit/assets/starter/package.json",
+    ]);
+
+    for (const filename of [
+      "package.json",
+      "packages/cli/package.json",
+      "packages/theme-kit/package.json",
+      "themes/default/microfeed-theme.json",
+    ]) {
+      await expect(readJson(root, filename)).resolves.toMatchObject({version: "2.3.4"});
+    }
+    await expect(readJson(
+      root,
+      "packages/theme-kit/assets/starter/package.json",
+    )).resolves.toMatchObject({
+      devDependencies: {"@microfeed/theme-kit": "^2.0.0"},
+      version: "0.1.0",
+    });
+  });
+
+  it("rejects ambiguous or invalid versions before writing", async () => {
+    expect(() => validateReleaseVersion("v1.2.3")).toThrow("exact semantic version");
+    expect(() => validateReleaseVersion("1.2")).toThrow("exact semantic version");
+    expect(() => validateReleaseVersion(" 1.2.3 ")).toThrow("exact semantic version");
+    expect(validateReleaseVersion("1.2.3-beta.1")).toBe("1.2.3-beta.1");
+    expect(themeKitCompatibilityRange("1.2.3-beta.1"))
+      .toBe(">=1.2.3-beta.1 <2.0.0");
+    expect(themeKitCompatibilityRange("0.4.2")).toBe("^0.4.2");
+  });
+
+  it("verifies target identities before changing any file", async () => {
+    const root = await repositoryFixture();
+    await writeJson(root, "packages/cli/package.json", {
+      name: "not-the-cli",
+      version: "1.0.0",
+    });
+
+    await expect(setReleaseVersion(root, "1.0.1"))
+      .rejects.toThrow("not the expected @microfeed/cli metadata file");
+    await expect(readJson(root, "package.json"))
+      .resolves.toMatchObject({version: "1.0.0"});
+  });
+});

--- a/themes/default/fixtures/editorial.json
+++ b/themes/default/fixtures/editorial.json
@@ -18,7 +18,7 @@
   "_microfeed": {
     "base_url": "https://example.com/",
     "categories": [],
-    "microfeed_version": "1.0.3",
+    "microfeed_version": "1.0.0",
     "subscribe_methods": []
   }
 }

--- a/themes/default/microfeed-theme.json
+++ b/themes/default/microfeed-theme.json
@@ -3,7 +3,7 @@
   "formatVersion": 1,
   "packageId": "microfeed.default",
   "name": "microfeed default",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "microfeed",
   "license": "AGPL-3.0",
   "description": "The familiar microfeed design with a footer that stays at the bottom on short pages.",

--- a/themes/default/package.json
+++ b/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/default-theme-source",
-  "version": "1.0.3",
+  "version": "0.0.0-use.local",
   "private": true,
   "type": "module",
   "scripts": {
@@ -11,7 +11,7 @@
     "preview": "theme-kit preview ."
   },
   "devDependencies": {
-    "@microfeed/theme-kit": "^1.0.3",
+    "@microfeed/theme-kit": "workspace:^",
     "@tailwindcss/vite": "^4.1.14",
     "tailwindcss": "^4.0.14",
     "typescript": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,7 +2875,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@microfeed/default-theme-source@workspace:themes/default"
   dependencies:
-    "@microfeed/theme-kit": "npm:^1.0.3"
+    "@microfeed/theme-kit": "workspace:^"
     "@tailwindcss/vite": "npm:^4.1.14"
     tailwindcss: "npm:^4.0.14"
     typescript: "npm:^6.0.3"
@@ -2883,7 +2883,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@microfeed/theme-kit@npm:^1.0.3, @microfeed/theme-kit@workspace:packages/theme-kit":
+"@microfeed/theme-kit@workspace:^, @microfeed/theme-kit@workspace:packages/theme-kit":
   version: 0.0.0-use.local
   resolution: "@microfeed/theme-kit@workspace:packages/theme-kit"
   dependencies:


### PR DESCRIPTION
## Summary

- Bump the application, @microfeed/cli, @microfeed/theme-kit, and bundled default theme to 1.0.4.
- Add `yarn version:set <version>` as the single release metadata command.
- Keep private workspace metadata, examples, fixtures, tests, and the lockfile stable across patch releases.
- Validate target identities and semantic versions before writing, including prerelease and pre-1.0 compatibility ranges.

## Related issue

N/A

## Testing

- [x] `yarn version:set 1.0.4`
- [x] 37 focused version, theme, and management tests
- [x] `git diff --check`
- [x] `yarn check` (552 unit tests and 96 Worker tests, package checks, OpenAPI, types, production build and dry run, documentation)

## Screenshots

N/A — this changes release tooling and a version-neutral help example only.

## Risks

Low. npm still requires versions in each publishable package manifest, while the new command synchronizes those authoritative files. The starter range changes only when compatibility requires it.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.