### PR TITLE
Make theme exports standalone repositories

### DIFF
--- a/docs/dashboard/themes.md
+++ b/docs/dashboard/themes.md
@@ -112,11 +112,53 @@ copies the theme's six slots and declared assets and creates a separate
 `--package-id`, `--name`, `--version`, and `--author` to set publish-ready
 metadata, or `--no-git` if another tool owns Git initialization.
 
+Use `theme init` when you want to fork the site's effective appearance under a
+new identity, including an older imported design or the internal fallback. Use
+`theme export` when an exact installed immutable version already exists and its
+package ID and version must be preserved as the development baseline.
+
 This is a rendered-package export: it does not recreate private build tools or
 source files used by the package author. The generated repository includes the
 `develop-microfeed-theme` skill so a coding agent follows the manifest,
 schemas, build scripts when present, validation, tests, and inactive-install
 workflow. The skill never creates screenshots unless explicitly requested.
+
+### Export an installed theme with an AI coding agent
+
+Open the main microfeed checkout in a local coding agent. Replace the instance,
+output directory, and public feed URL in this prompt, then paste it into the
+agent:
+
+```text
+Export an existing installed theme from the saved microfeed instance
+<instance-name> into a verified standalone repository at
+<absolute-empty-directory>.
+
+First run `yarn manage theme list --instance <instance-name> --json` and report
+each plausible theme's ID, package ID, version, and whether it is active. If
+more than one theme is plausible, stop and ask me to choose. Export the selected
+version with `yarn manage theme export <theme-id> --instance <instance-name> --output <absolute-empty-directory>`.
+
+Do not activate, deactivate, install, delete, or otherwise change the live
+site. Keep the output outside the microfeed checkout. In the exported directory,
+read README.md, THEME.md, microfeed-theme.json, and the generated schemas. Run
+`yarn install`, `yarn validate`, and `yarn test`, then start
+`yarn preview --feed-url https://example.com/json/` and report the local preview
+URL. Stop the preview server after verification.
+
+After the baseline checks pass, initialize local Git on main. Show me `git
+status` and a proposed initial commit message, then stop before staging,
+committing, pushing, creating a GitHub repository, or opening a pull request.
+```
+
+The result is a verified local Git repository. Export does not initialize Git,
+publish the repository, install the exported package, or change the active
+theme. Request each of those later actions separately if you want them.
+
+Keep the first verified export unchanged until you review it. After making
+theme edits, increment `microfeed-theme.json` SemVer, validate and test again,
+install the new version as inactive, and preview it before separately approving
+activation. Never reuse one package ID and version for different content.
 
 ### Develop with an AI coding agent
 
@@ -428,10 +470,11 @@ for update, export, rollback, local/preview, and deletion behavior.
 Use `theme update` when an installed version still points to a bundled, local,
 or GitHub source that can provide a newer release. Use `theme export` for an
 Admin-derived version or another installation without an updateable source.
-Export writes the installed six-file package and inherited assets to a
-standalone directory for backup, inspection, or continued development in its
-own repository. It does not install, activate, or otherwise change the public
-site.
+Export preserves the installed package ID and version and writes its templates,
+inherited assets, README, package scripts, fixture, schemas, and agent skill to
+an empty standalone directory. The result is Git-ready but is not initialized
+as a Git repository. Export does not install, activate, or otherwise change the
+public site.
 
 An environment can hold 50 non-deleted installed versions and 20 drafts.
 Deleted inactive versions do not count toward the installed limit. If an Admin

--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -406,7 +406,7 @@ yarn manage theme init ~/microfeed-themes/my-theme --instance <instance-name>
 `init` resolves the same effective selection as the live site: a valid active
 D1 version, then the internal classic fallback. The command copies the six theme slots
 and any declared packaged assets into an empty directory, adds the authoring
-kit, schemas, fixture, npm scripts, and instructions, and initializes a Git
+kit, schemas, fixture, local package scripts, and instructions, and initializes a Git
 repository on `main`. It recursively creates the destination and any missing
 parent directories, so `~/microfeed-themes/` does not need to exist first. It
 refuses to write into a non-empty destination. Keeping the generated directory
@@ -424,6 +424,25 @@ The generated repository also contains the `develop-microfeed-theme` coding
 agent skill. It exports the rendered six-slot package, not the build sources of
 the original project. To use microfeed's complete Tailwind/Vite starter, copy
 or clone `themes/default` from the microfeed repository instead.
+
+Use `init` to derive a new `local.<name>@0.1.0` identity from the site's
+effective active, imported, or fallback appearance. Use `export` when you want
+an exact installed immutable version and need to preserve its current package
+ID and version:
+
+```console
+yarn manage theme list --instance personal --json
+yarn manage theme export <theme-id> --instance personal \
+  --output ~/microfeed-themes/exported-theme
+```
+
+Export writes the templates, inherited assets, README, local package scripts,
+fixture, schemas, and `develop-microfeed-theme` skill into an empty directory.
+It does not initialize Git, install or activate a theme, or otherwise change
+the public site. Keep the directory outside the microfeed checkout, validate
+the untouched baseline, and initialize Git only after those checks pass. See
+[Export an installed theme with an AI coding agent](/dashboard/themes/#export-an-installed-theme-with-an-ai-coding-agent)
+for a copy-paste prompt that stops before commit or publication.
 
 Use this command to install a theme package from a local directory or a public
 GitHub repository, directory, or `microfeed-theme.json` URL. GitHub branches
@@ -502,7 +521,7 @@ yarn manage theme activate <theme-id> --instance personal
 yarn manage theme rollback --instance personal
 yarn manage theme deactivate --instance personal
 
-# Export or explicitly delete an inactive version.
+# Export one exact installed version as a Git-ready standalone repository, or delete it.
 yarn manage theme export <theme-id> --instance personal \
   --output ~/microfeed-themes/theme-export
 yarn manage theme delete <theme-id> --instance personal --confirm <theme-id>

--- a/docs/theme-kit-cli.md
+++ b/docs/theme-kit-cli.md
@@ -109,9 +109,9 @@ machine-readable success and error output for coding agents and CI.
 theme-kit init <directory>
 ```
 
-Creates a generic theme package containing the manifest, six required theme
-files, schemas, fixtures, local package scripts, `THEME.md`, and the
-`develop-microfeed-theme` agent skill.
+Creates a generic theme repository scaffold containing `README.md`, the
+manifest, six required theme files, schemas, fixtures, local package scripts,
+`THEME.md`, and the `develop-microfeed-theme` agent skill.
 
 - Missing parent directories are created.
 - The destination must be empty; existing files are never overwritten.

--- a/manage-cli/help.ts
+++ b/manage-cli/help.ts
@@ -162,6 +162,7 @@ export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
     details: [
       "Actions are init, install, list, update, activate, deactivate, rollback, export, and delete.",
       "Init copies the selected instance's active D1 theme, or the internal classic fallback, into a new standalone repository. It creates missing parent directories, assigns a separate local package identity, adds the theme-development skill, and initializes Git unless --no-git is passed.",
+      "Export preserves one exact installed package identity and writes a complete Git-ready authoring scaffold into an empty directory. It never initializes Git or changes the live site.",
       "Install accepts default, a local directory, or a public GitHub repository, directory, or microfeed-theme.json URL. The reserved default source loads the bundled rendered package from themes/default; GitHub refs resolve to an exact commit before any package file is fetched.",
       "Every install is inactive. Activate separately after previewing in Settings → Themes.",
       "An environment can keep 50 non-deleted installed versions and 20 drafts. Deleted inactive versions free installation slots.",

--- a/manage-cli/theme.ts
+++ b/manage-cli/theme.ts
@@ -39,7 +39,11 @@ import {
   sha256Hex,
 } from "@/shared/themes/ThemeRenderer";
 import {validateThemePackage} from "@/shared/themes/ThemeValidation";
-import {generatedThemeReadme} from "../packages/theme-kit/src/readme";
+import {
+  generatedExportedThemeRepositoryReadme,
+  generatedInitializedThemeRepositoryReadme,
+  generatedThemeReadme,
+} from "../packages/theme-kit/src/readme";
 import {
   loadThemePackage,
   type LoadedThemePackage,
@@ -95,7 +99,7 @@ interface ThemePackageFiles {
 
 interface WriteThemePackageOptions {
   readme?: string;
-  repositoryScaffold?: {source: EffectiveTheme};
+  repositoryScaffold?: {readme: string};
 }
 
 const CANONICAL_THEME_FILES: ThemeManifestV1["files"] = {
@@ -1185,30 +1189,6 @@ function withFinalNewline(value: string): string {
   return value.endsWith("\n") ? value : `${value}\n`;
 }
 
-function initializedRepositoryReadme(
-  manifest: ThemeManifestV1,
-  source: EffectiveTheme,
-): string {
-  return `# ${manifest.name}
-
-This microfeed theme repository was initialized from
-\`${source.manifest.packageId}@${source.manifest.version}\` (${source.kind}).
-It has a separate package identity so edits never overwrite the source version.
-
-## Develop
-
-\`\`\`console
-npm install
-npm run validate
-npm test
-npm run preview
-\`\`\`
-
-Read [THEME.md](./THEME.md) before editing. Increment the semantic version in
-\`microfeed-theme.json\` before installing changed content.
-`;
-}
-
 async function writeThemePackage(
   target: Target,
   theme: ThemePackageFiles,
@@ -1264,10 +1244,7 @@ async function writeThemePackage(
   await writeRelative(".microfeed/schemas/manifest.schema.json", `${JSON.stringify(z.toJSONSchema(themeManifestV1Schema), null, 2)}\n`);
   await writeRelative(".microfeed/schemas/theme-context.schema.json", `${JSON.stringify(z.toJSONSchema(themeContextSchema), null, 2)}\n`);
   if (options.repositoryScaffold) {
-    await writeRelative("README.md", initializedRepositoryReadme(
-      theme.manifest,
-      options.repositoryScaffold.source,
-    ));
+    await writeRelative("README.md", options.repositoryScaffold.readme);
     await writeRelative(".gitignore", "node_modules/\n");
     await writeRelative("package.json", `${JSON.stringify({
       devDependencies: {"@microfeed/theme-kit": `^${MICROFEED_VERSION}`},
@@ -1346,7 +1323,13 @@ async function initializeThemeRepository(
       manifest: validated.manifest,
     },
     outputDirectory,
-    {repositoryScaffold: {source}},
+    {repositoryScaffold: {
+      readme: generatedInitializedThemeRepositoryReadme(manifest, {
+        kind: source.kind,
+        packageId: source.manifest.packageId,
+        version: source.manifest.version,
+      }),
+    }},
   );
   const gitInitialized = !flagBoolean(flags, "no-git");
   if (gitInitialized) {
@@ -1427,7 +1410,11 @@ export async function themeCommand(
   if (action === "export") {
     const output = flagString(flags, "output");
     if (!output) throw new Error("theme export requires --output <directory>.");
-    await writeThemePackage(target, theme!, output);
+    await writeThemePackage(target, theme!, output, {
+      repositoryScaffold: {
+        readme: generatedExportedThemeRepositoryReadme(theme!.manifest),
+      },
+    });
     writeOutput(flags, {output: path.resolve(output), themeId: theme!.id}, `Exported ${theme!.packageId}@${theme!.version} to ${path.resolve(output)}.`);
     return;
   }

--- a/packages/theme-kit/README.md
+++ b/packages/theme-kit/README.md
@@ -76,6 +76,7 @@ workspace from the microfeed repository into its own repository.
 A theme is a directory with `microfeed-theme.json` and six required text files:
 
 ```text
+README.md
 microfeed-theme.json
 THEME.md
 web-feed.mustache

--- a/packages/theme-kit/assets/starter/README.md
+++ b/packages/theme-kit/assets/starter/README.md
@@ -1,0 +1,37 @@
+# My microfeed theme
+
+This is a generic standalone microfeed theme repository with the initial
+identity `example.my-theme@0.1.0`.
+
+This repository contains the rendered files installed by microfeed. It does not
+recreate private build tools or source files used by the original theme author.
+
+## Develop
+
+Use Node.js 22.12 or newer and Yarn 4:
+
+```console
+yarn install
+yarn validate
+yarn test
+yarn preview
+```
+
+To preview against a public microfeed JSON Feed instead of a bundled fixture:
+
+```console
+yarn preview --feed-url https://example.com/json/
+```
+
+Read [THEME.md](./THEME.md), `microfeed-theme.json`, and the schemas under
+`.microfeed/schemas/` before editing. Establish a clean validation and test
+baseline first. If this directory is not already a Git repository, initialize
+it only after those checks pass:
+
+```console
+git init --initial-branch main
+```
+
+Before installing changed content, increment the semantic version in
+`microfeed-theme.json`. Install the new version as inactive, preview it, and
+activate it only as a separate confirmed action.

--- a/packages/theme-kit/scripts/build.ts
+++ b/packages/theme-kit/scripts/build.ts
@@ -9,7 +9,11 @@ import {
   themeContextSchema,
   themeManifestV1Schema,
 } from "../../../src/shared/themes/ThemeContract";
-import {generatedThemeReadme} from "../src/readme";
+import starterManifest from "../assets/starter/microfeed-theme.json";
+import {
+  generatedGenericThemeRepositoryReadme,
+  generatedThemeReadme,
+} from "../src/readme";
 
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const repositoryRoot = path.resolve(packageRoot, "../..");
@@ -23,6 +27,10 @@ const manifestSchema = `${JSON.stringify(z.toJSONSchema(themeManifestV1Schema), 
 const contextSchema = `${JSON.stringify(z.toJSONSchema(themeContextSchema), null, 2)}\n`;
 await Promise.all([
   writeFile(path.join(packageRoot, "assets", "starter", "THEME.md"), generatedThemeReadme()),
+  writeFile(
+    path.join(packageRoot, "assets", "starter", "README.md"),
+    generatedGenericThemeRepositoryReadme(starterManifest),
+  ),
   writeFile(path.join(schemaDirectory, "manifest.schema.json"), manifestSchema),
   writeFile(path.join(schemaDirectory, "theme-context.schema.json"), contextSchema),
   writeFile(path.join(defaultSchemaDirectory, "manifest.schema.json"), manifestSchema),

--- a/packages/theme-kit/src/help.ts
+++ b/packages/theme-kit/src/help.ts
@@ -1,9 +1,10 @@
 const COMMAND_HELP: Record<string, string> = {
   init: `Usage: theme-kit init <directory>
 
-Create a complete generic theme package in a new or empty directory. Missing
-parent directories are created. The command refuses to overwrite a non-empty
-directory.`,
+Create a complete generic theme repository scaffold, including README,
+package scripts, fixtures, schemas, and agent guidance, in a new or empty
+directory. Missing parent directories are created. The command refuses to
+overwrite a non-empty directory and does not initialize Git.`,
   preview: `Usage: theme-kit preview <directory> [options]
 
 Start an isolated local preview with feed, item, RSS, mobile, and desktop views.

--- a/packages/theme-kit/src/readme.ts
+++ b/packages/theme-kit/src/readme.ts
@@ -1,3 +1,94 @@
+import type {ThemeManifestV1} from "../../../src/shared/themes/ThemeContract";
+
+type ThemeRepositoryIdentity = Pick<
+  ThemeManifestV1,
+  "name" | "packageId" | "version"
+>;
+
+interface ThemeRepositorySourceIdentity {
+  kind: string;
+  packageId: string;
+  version: string;
+}
+
+export function generatedThemeRepositoryReadme(
+  manifest: ThemeRepositoryIdentity,
+  provenance: string,
+): string {
+  return `# ${manifest.name}
+
+${provenance}
+
+This repository contains the rendered files installed by microfeed. It does not
+recreate private build tools or source files used by the original theme author.
+
+## Develop
+
+Use Node.js 22.12 or newer and Yarn 4:
+
+\`\`\`console
+yarn install
+yarn validate
+yarn test
+yarn preview
+\`\`\`
+
+To preview against a public microfeed JSON Feed instead of a bundled fixture:
+
+\`\`\`console
+yarn preview --feed-url https://example.com/json/
+\`\`\`
+
+Read [THEME.md](./THEME.md), \`microfeed-theme.json\`, and the schemas under
+\`.microfeed/schemas/\` before editing. Establish a clean validation and test
+baseline first. If this directory is not already a Git repository, initialize
+it only after those checks pass:
+
+\`\`\`console
+git init --initial-branch main
+\`\`\`
+
+Before installing changed content, increment the semantic version in
+\`microfeed-theme.json\`. Install the new version as inactive, preview it, and
+activate it only as a separate confirmed action.
+`;
+}
+
+export function generatedGenericThemeRepositoryReadme(
+  manifest: ThemeRepositoryIdentity,
+): string {
+  return generatedThemeRepositoryReadme(
+    manifest,
+    `This is a generic standalone microfeed theme repository with the initial
+identity \`${manifest.packageId}@${manifest.version}\`.`,
+  );
+}
+
+export function generatedInitializedThemeRepositoryReadme(
+  manifest: ThemeRepositoryIdentity,
+  source: ThemeRepositorySourceIdentity,
+): string {
+  return generatedThemeRepositoryReadme(
+    manifest,
+    `This standalone microfeed theme repository was initialized from
+\`${source.packageId}@${source.version}\` (${source.kind}). It has the separate
+identity \`${manifest.packageId}@${manifest.version}\`, so edits cannot overwrite
+the source version.`,
+  );
+}
+
+export function generatedExportedThemeRepositoryReadme(
+  manifest: ThemeRepositoryIdentity,
+): string {
+  return generatedThemeRepositoryReadme(
+    manifest,
+    `This standalone microfeed theme repository was exported from the exact
+installed package \`${manifest.packageId}@${manifest.version}\`. The manifest
+preserves that immutable identity as a clean baseline; increment its version
+before installing any changed content.`,
+  );
+}
+
 export function generatedThemeReadme(): string {
   return `# microfeed theme
 

--- a/scripts/check-theme-kit-package.ts
+++ b/scripts/check-theme-kit-package.ts
@@ -74,12 +74,19 @@ try {
     throw new Error("The packed theme kit is missing its npm discovery metadata.");
   }
 
-  const [packedReadme, rootLicense, packedLicense, starterPackage, packedSkill] =
-    await Promise.all([
+  const [
+    packedReadme,
+    rootLicense,
+    packedLicense,
+    starterPackage,
+    starterReadme,
+    packedSkill,
+  ] = await Promise.all([
       readFile(path.join(packageDirectory, "README.md"), "utf8"),
       readFile(path.join(process.cwd(), "LICENSE"), "utf8"),
       readFile(path.join(packageDirectory, "LICENSE"), "utf8"),
       readFile(path.join(packageDirectory, "assets/starter/package.json"), "utf8"),
+      readFile(path.join(packageDirectory, "assets/starter/README.md"), "utf8"),
       readFile(path.join(
         packageDirectory,
         "assets/starter/.agents/skills/develop-microfeed-theme/SKILL.md",
@@ -108,6 +115,8 @@ try {
       !parsedStarterPackage.scripts?.validate ||
       !parsedStarterPackage.scripts?.test ||
       !parsedStarterPackage.scripts?.preview ||
+      !starterReadme.includes("generic standalone microfeed theme repository") ||
+      !starterReadme.includes("yarn preview --feed-url https://example.com/json/") ||
       !packedSkill.includes("Never create screenshots unless the user explicitly asks")) {
     throw new Error("The packed generic theme scaffold is incomplete or stale.");
   }

--- a/tests/unit/docs-site.test.ts
+++ b/tests/unit/docs-site.test.ts
@@ -749,6 +749,7 @@ describe("documentation site", () => {
       "utf8",
     );
     expect(themes).toContain("### Develop with an AI coding agent");
+    expect(themes).toContain("### Export an installed theme with an AI coding agent");
     expect(themes).toContain("### Bundle CSS and JavaScript");
     expect(themes).toContain("#### Inline compiled output in D1");
     expect(themes).toContain("#### Emit packaged assets with Vite");
@@ -757,6 +758,15 @@ describe("documentation site", () => {
     expect(themes).toContain(
       "yarn manage theme init ~/microfeed-themes/my-theme --instance <instance-name>",
     );
+    expect(themes).toContain(
+      "yarn manage theme list --instance <instance-name> --json",
+    );
+    expect(themes).toContain(
+      "yarn manage theme export <theme-id> --instance <instance-name>",
+    );
+    expect(themes).toContain("Do not activate, deactivate, install, delete");
+    expect(themes).toContain("stop before staging");
+    expect(themes).toContain("yarn preview --feed-url https://example.com/json/");
     expect(themes).toContain(
       "You do not need to create `~/microfeed-themes/` first.",
     );
@@ -769,6 +779,26 @@ describe("documentation site", () => {
       "yarn manage deploy --enable-r2 --instance <instance-name>",
     );
     expect(themes).not.toContain("## Upgrade from the old custom theme");
+
+    const manageCli = await readFile(
+      path.join(docsRoot, "manage-cli.md"),
+      "utf8",
+    );
+    expect(manageCli).toContain(
+      "Use `init` to derive a new `local.<name>@0.1.0` identity",
+    );
+    expect(manageCli).toContain(
+      "Export writes the templates, inherited assets, README, local package scripts",
+    );
+    expect(manageCli).toContain("It does not initialize Git");
+
+    const themeKitCli = await readFile(
+      path.join(docsRoot, "theme-kit-cli.md"),
+      "utf8",
+    );
+    expect(themeKitCli).toContain(
+      "Creates a generic theme repository scaffold containing `README.md`",
+    );
   });
 
   it("advertises agentic content publishing from the main discovery paths", async () => {

--- a/tests/unit/manage-cli/theme-init.test.ts
+++ b/tests/unit/manage-cli/theme-init.test.ts
@@ -1,7 +1,9 @@
 import {createHash} from "node:crypto";
+import {execFile} from "node:child_process";
 import {mkdtemp, readFile, rm} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import path from "node:path";
+import {promisify} from "node:util";
 
 import {afterEach, describe, expect, it, vi} from "vitest";
 
@@ -10,6 +12,8 @@ import {MICROFEED_VERSION} from "@/shared/Version";
 import type {CommandRunner, MicrofeedConfig} from "../../../manage-cli/types";
 
 const temporaryDirectories: string[] = [];
+const execFileAsync = promisify(execFile);
+const repositoryRoot = path.resolve(import.meta.dirname, "../../..");
 
 const manifest: ThemeManifestV1 = {
   assets: [],
@@ -243,6 +247,12 @@ describe("theme repository initialization", () => {
     ) as {devDependencies?: Record<string, string>};
     expect(initializedPackage.devDependencies?.["@microfeed/theme-kit"])
       .toBe(`^${MICROFEED_VERSION}`);
+    const initializedReadme = await readFile(path.join(output, "README.md"), "utf8");
+    expect(initializedReadme).toContain(
+      "initialized from\n`example.active@2.3.4` (installed)",
+    );
+    expect(initializedReadme).toContain("`local.my-active-theme@0.1.0`");
+    expect(initializedReadme).toContain("yarn validate");
     await expect(readFile(
       path.join(output, ".agents/skills/develop-microfeed-theme/SKILL.md"),
       "utf8",
@@ -261,6 +271,123 @@ describe("theme repository initialization", () => {
       kind: "installed",
       packageId: "example.active",
       themeId: "active-theme-id",
+    });
+  });
+
+  it("exports an installed version as a complete Git-ready repository", async () => {
+    const {directory, theme} = await freshModules();
+    const output = path.join(directory, "exported-theme");
+    const runner = commandRunner();
+    const assetBytes = new TextEncoder().encode(
+      "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>",
+    );
+    const assetPath = "assets/logo.svg";
+    const exportedManifest = {...manifest, assets: [assetPath]};
+    const exportedBundle = {
+      ...bundle,
+      assets: [{
+        contentType: "image/svg+xml",
+        key: "production/themes/export-theme-id/assets/logo.svg",
+        path: assetPath,
+        sha256: createHash("sha256").update(assetBytes).digest("hex"),
+        size: assetBytes.byteLength,
+      }],
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: URL | RequestInfo, init?: RequestInit) => {
+      if (String(input).includes("/r2/buckets/feed-media/objects/")) {
+        return new Response(assetBytes, {headers: {"content-type": "image/svg+xml"}});
+      }
+      const request = JSON.parse(String(init?.body)) as {sql: string};
+      if (request.sql.includes("SELECT * FROM themes WHERE id = ?")) {
+        return d1Response([{
+          asset_owner_theme_id: "export-theme-id",
+          bundle_json: JSON.stringify(exportedBundle),
+          checksum_sha256: "c".repeat(64),
+          created_at: "2026-08-10T00:00:00.000Z",
+          deleted_at: null,
+          id: "export-theme-id",
+          manifest_json: JSON.stringify(exportedManifest),
+          name: manifest.name,
+          origin_theme_id: null,
+          package_id: manifest.packageId,
+          source_commit: "d".repeat(40),
+          source_kind: "github",
+          source_path: null,
+          source_ref: "main",
+          source_url: "https://github.com/example/active",
+          version: manifest.version,
+        }]);
+      }
+      throw new Error(`Unexpected request: ${String(input)}`);
+    }));
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await theme.themeCommand({
+      action: "export",
+      instance: "personal",
+      output,
+      "theme-id": "export-theme-id",
+      json: true,
+    }, runner);
+
+    const writtenManifest = JSON.parse(
+      await readFile(path.join(output, "microfeed-theme.json"), "utf8"),
+    ) as ThemeManifestV1;
+    expect(writtenManifest).toEqual(exportedManifest);
+    await expect(readFile(path.join(output, assetPath), "utf8"))
+      .resolves.toContain("<svg");
+    const repositoryReadme = await readFile(path.join(output, "README.md"), "utf8");
+    expect(repositoryReadme).toContain(
+      "exported from the exact\ninstalled package `example.active@2.3.4`",
+    );
+    expect(repositoryReadme).toContain("yarn preview --feed-url https://example.com/json/");
+    const exportedPackage = JSON.parse(
+      await readFile(path.join(output, "package.json"), "utf8"),
+    ) as {devDependencies?: Record<string, string>; scripts?: Record<string, string>};
+    expect(exportedPackage).toMatchObject({
+      devDependencies: {"@microfeed/theme-kit": `^${MICROFEED_VERSION}`},
+      scripts: {
+        preview: "theme-kit preview .",
+        test: "theme-kit test . --json",
+        validate: "theme-kit validate . --json",
+      },
+    });
+    for (const relativePath of [
+      ".gitignore",
+      ".microfeed/schemas/manifest.schema.json",
+      ".microfeed/schemas/theme-context.schema.json",
+      ".agents/skills/develop-microfeed-theme/SKILL.md",
+      ".agents/skills/develop-microfeed-theme/agents/openai.yaml",
+      "fixtures/custom.json",
+      "THEME.md",
+    ]) {
+      await expect(readFile(path.join(output, relativePath), "utf8"))
+        .resolves.not.toHaveLength(0);
+    }
+    const conformance = JSON.parse((await execFileAsync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        path.join(repositoryRoot, "packages/theme-kit/src/cli.ts"),
+        "test",
+        output,
+        "--json",
+      ],
+      {cwd: repositoryRoot},
+    )).stdout) as {ok: boolean; tests: Array<{fixture: string; ok: boolean}>};
+    expect(conformance.ok).toBe(true);
+    expect(conformance.tests).toHaveLength(9);
+    expect(conformance.tests).toContainEqual({fixture: "package:custom.json", ok: true});
+    expect(conformance.tests.every(({ok}) => ok)).toBe(true);
+    expect(runner).not.toHaveBeenCalledWith(
+      "git",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(JSON.parse(stdout.mock.calls.flat().join(""))).toEqual({
+      output,
+      themeId: "export-theme-id",
     });
   });
 

--- a/tests/unit/theme-kit.test.ts
+++ b/tests/unit/theme-kit.test.ts
@@ -8,7 +8,10 @@ import * as z from "zod";
 import {loadThemePackage} from "../../packages/theme-kit/src/package";
 import {jsonFeedFixtureToRss} from "../../packages/theme-kit/src/cli";
 import {renderThemeKitHelp} from "../../packages/theme-kit/src/help";
-import {generatedThemeReadme} from "../../packages/theme-kit/src/readme";
+import {
+  generatedGenericThemeRepositoryReadme,
+  generatedThemeReadme,
+} from "../../packages/theme-kit/src/readme";
 import {
   THEME_MAX_TEMPLATE_BYTES,
   themeContextSchema,
@@ -97,14 +100,18 @@ describe("@microfeed/theme-kit package loading", () => {
       "../../packages/theme-kit/assets/starter/",
       import.meta.url,
     );
-    const [manifestSchema, contextSchema, readme] = await Promise.all([
+    const [manifestSchema, contextSchema, readme, repositoryReadme, manifest] =
+      await Promise.all([
       readFile(new URL(".microfeed/schemas/manifest.schema.json", starter), "utf8"),
       readFile(new URL(".microfeed/schemas/theme-context.schema.json", starter), "utf8"),
       readFile(new URL("THEME.md", starter), "utf8"),
+      readFile(new URL("README.md", starter), "utf8"),
+      readFile(new URL("microfeed-theme.json", starter), "utf8").then(JSON.parse),
     ]);
     expect(JSON.parse(manifestSchema)).toEqual(z.toJSONSchema(themeManifestV1Schema));
     expect(JSON.parse(contextSchema)).toEqual(z.toJSONSchema(themeContextSchema));
     expect(readme).toBe(generatedThemeReadme());
+    expect(repositoryReadme).toBe(generatedGenericThemeRepositoryReadme(manifest));
   });
 
   it("loads the starter as a complete text-only package", async () => {


### PR DESCRIPTION
## Summary

- make `yarn manage theme export` generate a complete Git-ready authoring scaffold while preserving the exact installed package identity
- share human README generation across managed init, managed export, and the generic theme-kit starter
- document a safe copy-paste AI-agent export workflow, including theme selection, baseline verification, local Git initialization, and explicit stops before publishing or activation
- verify exported assets, package scripts, fixtures, schemas, agent guidance, package contents, and documentation stay synchronized

## Safety

Export still does not initialize Git, install or activate a theme, or otherwise change the live site. Existing CLI flags and JSON output remain compatible.

## Testing

- focused theme initialization, theme-kit, and documentation tests: 27 passed
- theme-kit packed artifact verification passed
- `yarn check` passed, including 553 standard tests, 96 Worker tests, type checks, application build, Worker dry-run, and documentation build
- `git diff --check` passed