### PR TITLE
Improve admin collection loading with AJAX

### DIFF
--- a/src/client/useAdminCollection.ts
+++ b/src/client/useAdminCollection.ts
@@ -1,0 +1,57 @@
+import {useCallback, useEffect, useState} from "react";
+
+interface AdminCollectionState<T> {
+  data: T | null;
+  error: string | null;
+  loading: boolean;
+  retry: () => void;
+}
+
+export function useAdminCollection<T>(
+  url: string,
+  fallbackError: string,
+): AdminCollectionState<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const response = await fetch(url, {
+          cache: "no-store",
+          headers: {accept: "application/json"},
+          signal: controller.signal,
+        });
+        if (response.status === 401) {
+          window.location.reload();
+          return;
+        }
+        const result = await response.json().catch(() => null) as
+          | (T & {error?: string})
+          | null;
+        if (!response.ok || !result) {
+          throw new Error(result?.error || fallbackError);
+        }
+        setData(result);
+      } catch (requestError) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setError(
+          requestError instanceof Error ? requestError.message : fallbackError,
+        );
+      } finally {
+        if (!controller.signal.aborted) setLoading(false);
+      }
+    })();
+    return () => controller.abort();
+  }, [attempt, fallbackError, url]);
+
+  const retry = useCallback(() => setAttempt((value) => value + 1), []);
+  return {data, error, loading, retry};
+}

--- a/src/components/admin/items/AllItemsApp/index.tsx
+++ b/src/components/admin/items/AllItemsApp/index.tsx
@@ -4,6 +4,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import {useMemo, useState, type MouseEvent} from "react";
 import {
   ArrowDownIcon,
   ArrowUpIcon,
@@ -14,6 +15,11 @@ import {
 } from "lucide-react";
 
 import AdminPageApp from "@/components/admin/shared/AdminPageApp";
+import {
+  AdminCollectionError,
+  AdminCollectionLoading,
+} from "@/components/admin/shared/AdminCollectionState";
+import {useAdminCollection} from "@/client/useAdminCollection";
 import {buttonVariants} from "@/components/ui/button";
 import {
   Tooltip,
@@ -44,11 +50,13 @@ import {isValidMediaFile} from "@/shared/MediaFileUtils";
 import {
   ADMIN_URLS,
   PUBLIC_URLS,
-  resolvePublicBucketUrl,
   secondsToHHMMSS,
   urlJoinWithRelative,
 } from "@/shared/StringUtils";
-import type {FeedContent, FeedItem} from "@/types";
+import type {
+  AdminItemListResponse,
+  AdminItemSummary,
+} from "@/shared/AdminCollections";
 
 interface MediaFile {
   category?: string;
@@ -69,8 +77,14 @@ interface ItemTableRow {
 }
 
 interface Props {
-  feedContent: FeedContent;
+  itemsPerPage: number;
+  publicBucketUrl: string;
 }
+
+type ListNavigationHandler = (
+  event: MouseEvent<HTMLAnchorElement>,
+  href: string,
+) => void;
 
 const FILTER_LABELS: Record<ItemStatusFilter, string> = {
   all: "All items",
@@ -89,15 +103,6 @@ const STATUS_CLASSES: Record<number, string> = {
 };
 
 const columnHelper = createColumnHelper<ItemTableRow>();
-
-function currentStatusFilter(): ItemStatusFilter {
-  if (typeof window === "undefined") {
-    return "all";
-  }
-  return normalizeItemStatusFilter(
-    new URLSearchParams(window.location.search).get("status"),
-  );
-}
 
 function statusName(status: number): string {
   const name = ITEM_STATUSES_DICT[
@@ -225,37 +230,38 @@ function MediaCell({row}: {row: ItemTableRow}) {
   );
 }
 
-function tableRows(items: FeedItem[], publicBucketUrl: string): ItemTableRow[] {
+function tableRows(
+  items: AdminItemSummary[],
+  publicBucketUrl: string,
+): ItemTableRow[] {
   return items.map((item) => {
     const image = String(item.image ?? "").trim();
     return {
-      createdAtMs: typeof item.createdAtMs === "number"
-        ? item.createdAtMs
-        : Number(item.createdAtMs),
-      id: String(item.id ?? ""),
+      createdAtMs: item.createdAtMs,
+      id: item.id,
       imageUrl: image
         ? urlJoinWithRelative(publicBucketUrl, image) ?? undefined
         : undefined,
-      mediaFile: item.mediaFile as MediaFile | undefined,
-      pubDateMs: typeof item.pubDateMs === "number"
-        ? item.pubDateMs
-        : Number(item.pubDateMs),
+      mediaFile: item.mediaFile,
+      pubDateMs: item.pubDateMs,
       publicBucketUrl,
-      status: typeof item.status === "number" ? item.status : STATUSES.PUBLISHED,
-      title: String(item.title ?? "").trim() || "Untitled",
-      updatedAtMs: typeof item.updatedAtMs === "number"
-        ? item.updatedAtMs
-        : Number(item.updatedAtMs),
+      status: item.status,
+      title: item.title,
+      updatedAtMs: item.updatedAtMs,
     };
   });
 }
 
 function ItemStatusFilters({
   activeFilter,
+  loading,
+  navigate,
   order,
   sort,
 }: {
   activeFilter: ItemStatusFilter;
+  loading: boolean;
+  navigate: ListNavigationHandler;
   order: ItemOrder;
   sort: ItemSort;
 }) {
@@ -266,17 +272,21 @@ function ItemStatusFilters({
     >
       {ITEM_STATUS_FILTERS.map((statusFilter) => {
         const active = statusFilter === activeFilter;
+        const href = buildItemsListUrl({order, sort, statusFilter});
         return (
           <a
             aria-current={active ? "page" : undefined}
+            aria-disabled={loading ? "true" : undefined}
             className={cn(
               buttonVariants({size: "lg", variant: "outline"}),
               "w-full text-sm sm:text-base",
               active &&
                 "border-brand-light bg-brand-light/10 text-brand-dark ring-1 ring-brand-light/20 hover:bg-brand-light/15 dark:border-brand-light dark:bg-brand-light/20 dark:text-white dark:ring-brand-light/50 dark:hover:bg-brand-light/25",
+              loading && "cursor-not-allowed opacity-70",
             )}
-            href={buildItemsListUrl({order, sort, statusFilter})}
+            href={href}
             key={statusFilter}
+            onClick={(event) => navigate(event, href)}
           >
             {FILTER_LABELS[statusFilter]}
           </a>
@@ -286,22 +296,32 @@ function ItemStatusFilters({
   );
 }
 
-function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) {
-  const activeFilter = currentStatusFilter();
-  const sort = itemSortDefinition(feed.items_sort ?? ITEM_SORTS.UPDATED_AT);
-  const order = feed.items_order ?? ITEM_ORDERS.DESC;
-  const nextUrl = feed.items_next_cursor === undefined
+export function ItemListTable({
+  data,
+  listing,
+  loading = false,
+  navigate = () => {},
+}: {
+  data: ItemTableRow[];
+  listing: AdminItemListResponse;
+  loading?: boolean;
+  navigate?: ListNavigationHandler;
+}) {
+  const activeFilter = normalizeItemStatusFilter(listing.statusFilter);
+  const sort = itemSortDefinition(listing.sort);
+  const order = listing.order;
+  const nextUrl = listing.nextCursor === undefined
     ? undefined
     : buildItemsListUrl({
-        nextCursor: feed.items_next_cursor,
+        nextCursor: listing.nextCursor,
         order,
         sort: sort.sort,
         statusFilter: activeFilter,
       });
-  const prevUrl = feed.items_prev_cursor === undefined
+  const prevUrl = listing.prevCursor === undefined
     ? undefined
     : buildItemsListUrl({
-        prevCursor: feed.items_prev_cursor,
+        prevCursor: listing.prevCursor,
         order,
         sort: sort.sort,
         statusFilter: activeFilter,
@@ -326,8 +346,13 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
         aria-label={active
           ? `${label}, sorted ${descending ? "descending" : "ascending"}. Sort ${descending ? "ascending" : "descending"}.`
           : `${label}. Sort descending.`}
-        className="inline-flex min-w-0 flex-wrap items-center gap-1.5"
+        className={cn(
+          "inline-flex min-w-0 flex-wrap items-center gap-1.5",
+          loading && "cursor-not-allowed",
+        )}
         href={sortUrl}
+        onClick={(event) => navigate(event, sortUrl)}
+        aria-disabled={loading ? "true" : undefined}
       >
         {label}
         {active && (descending
@@ -424,7 +449,13 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
 
   return (
     <div>
-      <ItemStatusFilters activeFilter={activeFilter} order={order} sort={sort.sort} />
+      <ItemStatusFilters
+        activeFilter={activeFilter}
+        loading={loading}
+        navigate={navigate}
+        order={order}
+        sort={sort.sort}
+      />
       <div className="overflow-x-auto rounded-[14px] border bg-card">
         <table className="w-full min-w-[64rem] table-fixed border-collapse text-sm">
           <thead>
@@ -505,8 +536,13 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
         >
           {prevUrl && (
             <a
-              className={buttonVariants({size: "sm", variant: "outline"})}
+              aria-disabled={loading ? "true" : undefined}
+              className={cn(
+                buttonVariants({size: "sm", variant: "outline"}),
+                loading && "cursor-not-allowed",
+              )}
               href={prevUrl}
+              onClick={(event) => navigate(event, prevUrl)}
             >
               <ChevronLeftIcon aria-hidden="true" />
               Previous
@@ -514,8 +550,13 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
           )}
           {nextUrl && (
             <a
-              className={buttonVariants({size: "sm", variant: "outline"})}
+              aria-disabled={loading ? "true" : undefined}
+              className={cn(
+                buttonVariants({size: "sm", variant: "outline"}),
+                loading && "cursor-not-allowed",
+              )}
               href={nextUrl}
+              onClick={(event) => navigate(event, nextUrl)}
             >
               Next
               <ChevronRightIcon aria-hidden="true" />
@@ -527,18 +568,77 @@ function ItemListTable({data, feed}: {data: ItemTableRow[]; feed: FeedContent}) 
   );
 }
 
-export default function AllItemsApp({feedContent}: Props) {
-  const feed = feedContent;
-  const items = feed.items ?? [];
-  const publicBucketUrl = resolvePublicBucketUrl(
-    feed.settings?.webGlobalSettings?.publicBucketUrl,
-    window.location.hostname,
+function collectionUrl(search: string, itemsPerPage: number): string {
+  const parameters = new URLSearchParams(search);
+  parameters.set("limit", String(itemsPerPage));
+  return `${ADMIN_URLS.ajaxItems()}?${parameters.toString()}`;
+}
+
+export default function AllItemsApp({itemsPerPage, publicBucketUrl}: Props) {
+  const [search, setSearch] = useState(() =>
+    typeof window === "undefined" ? "" : window.location.search
   );
-  const data = tableRows(items, publicBucketUrl);
+  const endpoint = collectionUrl(search, itemsPerPage);
+  const {data: listing, error, loading, retry} =
+    useAdminCollection<AdminItemListResponse>(
+      endpoint,
+      "Could not load items.",
+    );
+  const data = useMemo(
+    () => tableRows(listing?.items ?? [], publicBucketUrl),
+    [listing, publicBucketUrl],
+  );
+  const navigate: ListNavigationHandler = (event, href) => {
+    if (loading) {
+      event.preventDefault();
+      return;
+    }
+    if (
+      event.defaultPrevented || event.button !== 0 || event.metaKey ||
+      event.ctrlKey || event.shiftKey || event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    const destination = new URL(href, window.location.href);
+    if (destination.search === search) return;
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${destination.search}${window.location.hash}`,
+    );
+    setSearch(destination.search);
+  };
 
   return (
     <AdminPageApp>
-      <ItemListTable data={data} feed={feed} />
+      {!listing && !error && <AdminCollectionLoading label="Loading items" />}
+      {!listing && error && (
+        <AdminCollectionError message={error} retry={retry} />
+      )}
+      {listing && (
+        <div>
+          {error && (
+            <div className="mb-4">
+              <AdminCollectionError message={error} retry={retry} />
+            </div>
+          )}
+          <div
+            aria-busy={loading}
+            className={cn(
+              "transition-opacity",
+              loading && "opacity-60",
+            )}
+          >
+            <ItemListTable
+              data={data}
+              listing={listing}
+              loading={loading}
+              navigate={navigate}
+            />
+          </div>
+        </div>
+      )}
     </AdminPageApp>
   );
 }

--- a/src/components/admin/pages/PagesApp.tsx
+++ b/src/components/admin/pages/PagesApp.tsx
@@ -12,19 +12,27 @@ import {
 } from "lucide-react";
 
 import {showToast} from "@/client/ToastUtils";
+import {useAdminCollection} from "@/client/useAdminCollection";
+import {
+  AdminCollectionError,
+  AdminCollectionLoading,
+} from "@/components/admin/shared/AdminCollectionState";
 import {Button, buttonVariants} from "@/components/ui/button";
 import {cn} from "@/lib/utils";
 import {ADMIN_URLS} from "@/shared/StringUtils";
-import type {PageRecord} from "@/shared/Pages";
+import type {
+  AdminPageListResponse,
+  AdminPageSummary,
+} from "@/shared/AdminCollections";
 
 type DropPosition = "after" | "before";
 
 export function reorderNavigationPageList(
-  pages: PageRecord[],
+  pages: AdminPageSummary[],
   draggedPageId: string,
   targetPageId: string,
   position: DropPosition,
-): PageRecord[] {
+): AdminPageSummary[] {
   if (draggedPageId === targetPageId) return pages;
   const draggedIndex = pages.findIndex(({id}) => id === draggedPageId);
   const targetIndex = pages.findIndex(({id}) => id === targetPageId);
@@ -54,7 +62,7 @@ async function responseJson(response: Response): Promise<unknown> {
   return data;
 }
 
-function PageDetails({page}: {page: PageRecord}) {
+function PageDetails({page}: {page: AdminPageSummary}) {
   return (
     <>
       <div className="min-w-0 flex-1">
@@ -97,7 +105,7 @@ function NavigationPageRow({
   index: number;
   last: boolean;
   moveWithKeyboard: (pageId: string, direction: -1 | 1) => void;
-  page: PageRecord;
+  page: AdminPageSummary;
 }) {
   return (
     <div
@@ -148,7 +156,7 @@ function NavigationPageRow({
   );
 }
 
-function PageCard({page}: {page: PageRecord}) {
+function PageCard({page}: {page: AdminPageSummary}) {
   return (
     <a
       className="flex items-center gap-3 rounded-[14px] border bg-card p-4 text-card-foreground shadow-xs transition hover:border-primary/40 hover:bg-accent/30"
@@ -159,11 +167,11 @@ function PageCard({page}: {page: PageRecord}) {
   );
 }
 
-export default function PagesApp({
+export function PagesList({
   pages,
   themeSupportsPages,
 }: {
-  pages: PageRecord[];
+  pages: AdminPageSummary[];
   themeSupportsPages: boolean;
 }) {
   const initialNavigationPages = pages
@@ -191,12 +199,12 @@ export default function PagesApp({
   const savedNavigationPagesRef = useRef(navigationPages);
   const savingOrderRef = useRef(false);
 
-  const setOrderedPages = useCallback((orderedPages: PageRecord[]) => {
+  const setOrderedPages = useCallback((orderedPages: AdminPageSummary[]) => {
     navigationPagesRef.current = orderedPages;
     setNavigationPages(orderedPages);
   }, []);
 
-  const persistOrder = useCallback(async (orderedPages: PageRecord[]) => {
+  const persistOrder = useCallback(async (orderedPages: AdminPageSummary[]) => {
     if (savingOrderRef.current) return;
     savingOrderRef.current = true;
     setSavingOrder(true);
@@ -384,6 +392,38 @@ export default function PagesApp({
           </p>
         </section>
       )}
+    </div>
+  );
+}
+
+export default function PagesApp() {
+  const {data, error, loading, retry} =
+    useAdminCollection<AdminPageListResponse>(
+      ADMIN_URLS.ajaxPages(),
+      "Could not load Pages.",
+    );
+  if (!data) {
+    return error
+      ? <AdminCollectionError message={error} retry={retry} />
+      : <AdminCollectionLoading label="Loading Pages" />;
+  }
+  return (
+    <div>
+      {error && (
+        <div className="mb-4">
+          <AdminCollectionError message={error} retry={retry} />
+        </div>
+      )}
+      <div
+        aria-busy={loading}
+        className={cn("transition-opacity", loading && "opacity-60")}
+      >
+        <PagesList
+          key={JSON.stringify(data.items)}
+          pages={data.items}
+          themeSupportsPages={data.themeSupportsPages}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/admin/shared/AdminCollectionState.tsx
+++ b/src/components/admin/shared/AdminCollectionState.tsx
@@ -1,0 +1,37 @@
+import {Button} from "@/components/ui/button";
+import {Skeleton} from "@/components/ui/skeleton";
+
+export function AdminCollectionLoading({label}: {label: string}) {
+  return (
+    <div aria-busy="true" aria-live="polite" role="status">
+      <span className="sr-only">{label}</span>
+      <div aria-hidden="true" className="grid gap-3">
+        {Array.from({length: 6}, (_, index) => (
+          <div className="rounded-[14px] border bg-card p-5" key={index}>
+            <Skeleton className="h-4 w-1/3" />
+            <Skeleton className="mt-4 h-3 w-full" />
+            <Skeleton className="mt-2 h-3 w-4/5" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function AdminCollectionError({
+  message,
+  retry,
+}: {
+  message: string;
+  retry: () => void;
+}) {
+  return (
+    <section
+      className="flex flex-wrap items-center justify-between gap-3 rounded-[14px] border border-destructive/40 bg-destructive/5 p-4"
+      role="alert"
+    >
+      <p className="text-sm text-foreground">{message}</p>
+      <Button onClick={retry} type="button" variant="outline">Retry</Button>
+    </section>
+  );
+}

--- a/src/components/admin/site-files/SiteFilesApp.tsx
+++ b/src/components/admin/site-files/SiteFilesApp.tsx
@@ -1,11 +1,19 @@
 import {FileCode2Icon, PlusIcon} from "lucide-react";
 
+import {useAdminCollection} from "@/client/useAdminCollection";
+import {
+  AdminCollectionError,
+  AdminCollectionLoading,
+} from "@/components/admin/shared/AdminCollectionState";
 import {buttonVariants} from "@/components/ui/button";
 import {cn} from "@/lib/utils";
 import {ADMIN_URLS} from "@/shared/StringUtils";
-import type {SiteFileRecord} from "@/shared/SiteFiles";
+import type {
+  AdminSiteFileListResponse,
+  AdminSiteFileSummary,
+} from "@/shared/AdminCollections";
 
-export default function SiteFilesApp({files}: {files: SiteFileRecord[]}) {
+export function SiteFilesList({files}: {files: AdminSiteFileSummary[]}) {
   return (
     <div className="grid gap-5">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -39,6 +47,34 @@ export default function SiteFilesApp({files}: {files: SiteFileRecord[]}) {
             </div>
           </a>
         ))}
+      </div>
+    </div>
+  );
+}
+
+export default function SiteFilesApp() {
+  const {data, error, loading, retry} =
+    useAdminCollection<AdminSiteFileListResponse>(
+      ADMIN_URLS.ajaxSiteFiles(),
+      "Could not load Site Files.",
+    );
+  if (!data) {
+    return error
+      ? <AdminCollectionError message={error} retry={retry} />
+      : <AdminCollectionLoading label="Loading Site Files" />;
+  }
+  return (
+    <div>
+      {error && (
+        <div className="mb-4">
+          <AdminCollectionError message={error} retry={retry} />
+        </div>
+      )}
+      <div
+        aria-busy={loading}
+        className={cn("transition-opacity", loading && "opacity-60")}
+      >
+        <SiteFilesList files={data.items} />
       </div>
     </div>
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,6 +16,7 @@ import {
   resolvePublicBucketUrl,
 } from "@/shared/StringUtils";
 import {
+  isAdminCollectionListPath,
   isExistingItemEditorPath,
   isPublicPageCandidateForDynamicAdminRoute,
 } from "./server/admin-routes";
@@ -286,10 +287,17 @@ const handleRequest = defineMiddleware(async (context, next) => {
     // precise 404 without fetching the default list first.
     const editingExistingItem = isExistingItemEditorPath(pathname, adminPath);
     if (!editingExistingItem) {
+      const collectionLoadsWithAjax = isAdminCollectionListPath(
+        pathname,
+        adminPath,
+      );
       let query;
       let itemsOrder;
       let itemsSort;
-      if (pathname.startsWith(adminUrl("items/list", adminPath))) {
+      if (
+        !collectionLoadsWithAjax &&
+        pathname.startsWith(adminUrl("items/list", adminPath))
+      ) {
         query = itemQueryForStatusFilter(
           context.url.searchParams.get("status"),
         );
@@ -309,6 +317,7 @@ const handleRequest = defineMiddleware(async (context, next) => {
         context.request,
         {
           adminProtection: protection,
+          includeItems: !collectionLoadsWithAjax,
           itemsOrder,
           itemsSort,
           ...(query

--- a/src/pages/[adminPath]/ajax/items/index.ts
+++ b/src/pages/[adminPath]/ajax/items/index.ts
@@ -1,0 +1,1 @@
+export {listAdminItemSummaries as GET} from "@/server/admin/item-handlers";

--- a/src/pages/[adminPath]/items/list/index.astro
+++ b/src/pages/[adminPath]/items/list/index.astro
@@ -2,12 +2,20 @@
 import AllItemsApp from "@/components/admin/items/AllItemsApp";
 import AdminPageFallback from "@/components/admin/AdminPageFallback.astro";
 import {NAV_ITEMS} from "@/shared/Constants";
+import {normalizeAdminItemListLimit} from "@/shared/AdminCollections";
+import {resolvePublicBucketUrl} from "@/shared/StringUtils";
 import AdminShell from "../../../../layouts/AdminShell.astro";
 
 const {feedContent, onboardingResult} = Astro.locals;
 if (!feedContent || !onboardingResult) {
   throw new Error("Admin feed context was not initialized.");
 }
+const webSettings = feedContent.settings?.webGlobalSettings ?? {};
+const itemsPerPage = normalizeAdminItemListLimit(webSettings.itemsPerPage);
+const publicBucketUrl = resolvePublicBucketUrl(
+  webSettings.publicBucketUrl,
+  Astro.url.hostname,
+);
 ---
 
 <AdminShell
@@ -17,7 +25,7 @@ if (!feedContent || !onboardingResult) {
   {onboardingResult}
   pageTitle="All items"
 >
-  <AllItemsApp client:only="react" {feedContent}>
+  <AllItemsApp client:only="react" {itemsPerPage} {publicBucketUrl}>
     <AdminPageFallback slot="fallback" kind="list" />
   </AllItemsApp>
 </AdminShell>

--- a/src/pages/[adminPath]/pages/index.astro
+++ b/src/pages/[adminPath]/pages/index.astro
@@ -1,18 +1,13 @@
 ---
-import {env} from "cloudflare:workers";
-
 import PagesApp from "@/components/admin/pages/PagesApp";
 import AdminPageFallback from "@/components/admin/AdminPageFallback.astro";
 import AdminShell from "@/layouts/AdminShell.astro";
 import {NAV_ITEMS} from "@/shared/Constants";
-import {activeThemeSupportsPages, listPages} from "@/server/pages/service";
 
-const {feedContent, feedDb, onboardingResult} = Astro.locals;
-if (!feedContent || !feedDb || !onboardingResult) {
+const {feedContent, onboardingResult} = Astro.locals;
+if (!feedContent || !onboardingResult) {
   throw new Error("Admin feed context was not initialized.");
 }
-const pages = await listPages(feedDb, Astro.request, {limit: 100});
-const themeSupportsPages = await activeThemeSupportsPages(env.FEED_DB);
 ---
 
 <AdminShell
@@ -22,7 +17,7 @@ const themeSupportsPages = await activeThemeSupportsPages(env.FEED_DB);
   {onboardingResult}
   pageTitle="Pages"
 >
-  <PagesApp client:load pages={pages.items} {themeSupportsPages}>
+  <PagesApp client:only="react">
     <AdminPageFallback slot="fallback" kind="list" />
   </PagesApp>
 </AdminShell>

--- a/src/pages/[adminPath]/site-files/index.astro
+++ b/src/pages/[adminPath]/site-files/index.astro
@@ -1,21 +1,17 @@
 ---
-import {env} from "cloudflare:workers";
-
 import SiteFilesApp from "@/components/admin/site-files/SiteFilesApp";
 import AdminPageFallback from "@/components/admin/AdminPageFallback.astro";
 import AdminShell from "@/layouts/AdminShell.astro";
 import {NAV_ITEMS} from "@/shared/Constants";
-import {listSiteFiles} from "@/server/site-files/service";
 
 const {feedContent, onboardingResult} = Astro.locals;
 if (!feedContent || !onboardingResult) {
   throw new Error("Admin feed context was not initialized.");
 }
-const files = await listSiteFiles(env.FEED_DB, Astro.request);
 ---
 
 <AdminShell activeNavItem={NAV_ITEMS.SITE_FILES} documentTitle="Site Files | microfeed.org" {feedContent} {onboardingResult} pageTitle="Site Files">
-  <SiteFilesApp client:load {files}>
+  <SiteFilesApp client:only="react">
     <AdminPageFallback slot="fallback" kind="list" />
   </SiteFilesApp>
 </AdminShell>

--- a/src/server/admin-routes.ts
+++ b/src/server/admin-routes.ts
@@ -1,4 +1,15 @@
+import {adminUrl} from "@/shared/AdminPath";
+
 const RESERVED_ITEM_PATHS = new Set(["list", "new"]);
+
+export function isAdminCollectionListPath(
+  pathname: string,
+  adminPath = "admin",
+): boolean {
+  return ["items/list", "pages", "site-files"].some(
+    (path) => pathname === adminUrl(path, adminPath),
+  );
+}
 
 export function isPublicPageCandidateForDynamicAdminRoute(
   pathname: string,

--- a/src/server/admin/item-handlers.ts
+++ b/src/server/admin/item-handlers.ts
@@ -1,0 +1,16 @@
+import {env} from "cloudflare:workers";
+import type {APIRoute} from "astro";
+
+import {normalizeAdminItemListLimit} from "@/shared/AdminCollections";
+import {jsonResponse} from "@/server/http";
+import {listAdminItems} from "@/server/items/admin-list";
+
+export const listAdminItemSummaries: APIRoute = async ({request}) => {
+  const url = new URL(request.url);
+  return jsonResponse(
+    await listAdminItems(env.FEED_DB, request, {
+      limit: normalizeAdminItemListLimit(url.searchParams.get("limit")),
+    }),
+    {headers: {"cache-control": "private, no-store"}},
+  );
+};

--- a/src/server/admin/page-handlers.ts
+++ b/src/server/admin/page-handlers.ts
@@ -10,10 +10,11 @@ import {
 import {jsonResponse} from "@/server/http";
 import FeedDb from "@/server/feed/FeedDb";
 import {
+  activeThemeSupportsPages,
   createPage,
   deletePage,
   getPageById,
-  listPages,
+  listAdminPageSummaries,
   PageConflictError,
   PageRequestError,
   PageThemeUnsupportedError,
@@ -42,10 +43,16 @@ function database(request: Request): FeedDb {
   return new FeedDb(env, request, cache);
 }
 
-export const listAdminPages: APIRoute = async ({request}) => {
-  const db = database(request);
+export const listAdminPages: APIRoute = async () => {
   try {
-    return jsonResponse(await listPages(db, request, {limit: 100}));
+    const [items, themeSupportsPages] = await Promise.all([
+      listAdminPageSummaries(env.FEED_DB),
+      activeThemeSupportsPages(env.FEED_DB),
+    ]);
+    return jsonResponse(
+      {items, themeSupportsPages},
+      {headers: {"cache-control": "private, no-store"}},
+    );
   } catch (error) {
     const response = serviceError(error);
     if (response) return response;

--- a/src/server/admin/site-file-handlers.ts
+++ b/src/server/admin/site-file-handlers.ts
@@ -11,7 +11,7 @@ import {
   createSiteFile,
   deleteSiteFile,
   getSiteFileById,
-  listSiteFiles,
+  listAdminSiteFileSummaries,
   previewSiteFile,
   publishSiteFile,
   resetSiteFile,
@@ -34,8 +34,11 @@ function database(request: Request): FeedDb {
   return new FeedDb(env, request, cache);
 }
 
-export const listAdminSiteFiles: APIRoute = async ({request}) =>
-  jsonResponse({items: await listSiteFiles(env.FEED_DB, request)});
+export const listAdminSiteFiles: APIRoute = async () =>
+  jsonResponse(
+    {items: await listAdminSiteFileSummaries(env.FEED_DB)},
+    {headers: {"cache-control": "private, no-store"}},
+  );
 
 export const createAdminSiteFile: APIRoute = async ({request}) => {
   const parsed = apiSiteFileInputSchema.safeParse(await request.json().catch(

--- a/src/server/feed/feed.ts
+++ b/src/server/feed/feed.ts
@@ -16,6 +16,7 @@ import ThemeStore from "@/server/themes/ThemeStore";
 export interface FeedQuery {
   adminProtection?: AdminProtectionStatus;
   includeActiveTheme?: boolean;
+  includeItems?: boolean;
   itemsOrder?: ItemOrder;
   itemsSort?: ItemSort;
   limit?: number;
@@ -35,7 +36,7 @@ export async function loadFeed(
   publicCachePurger?: PublicCachePurger,
 ): Promise<LoadedFeed> {
   const database = new FeedDb(runtimeEnv, request, publicCachePurger);
-  const fetchItems = query
+  const fetchItems = query && query.includeItems !== false
     ? getFetchItemsParams(
         request,
         query.queryKwargs ?? {},

--- a/src/server/items/admin-list.ts
+++ b/src/server/items/admin-list.ts
@@ -1,0 +1,150 @@
+import type {
+  AdminItemListResponse,
+  AdminItemMediaSummary,
+  AdminItemSummary,
+} from "@/shared/AdminCollections";
+import {normalizeAdminItemListLimit} from "@/shared/AdminCollections";
+import {STATUSES} from "@/shared/Constants";
+import {
+  itemQueryForStatusFilter,
+  normalizeItemStatusFilter,
+} from "@/shared/ItemList";
+import {
+  encodeItemCursor,
+  ITEM_ORDERS,
+  ITEM_SORTS,
+  resolveItemPagination,
+} from "@/shared/ItemPagination";
+import {msToRFC3339, rfc3399ToMs} from "@/shared/TimeUtils";
+
+interface AdminItemRow extends Record<string, unknown> {
+  created_at: string;
+  id: string;
+  image: string | null;
+  media_file: string | null;
+  pub_date: string;
+  status: number;
+  title: string | null;
+  updated_at: string;
+}
+
+function mediaSummary(value: unknown): AdminItemMediaSummary | undefined {
+  try {
+    const parsed = typeof value === "string" ? JSON.parse(value) : value;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const media = parsed as Record<string, unknown>;
+    return {
+      ...(typeof media.category === "string"
+        ? {category: media.category}
+        : {}),
+      ...(typeof media.durationSecond === "number"
+        ? {durationSecond: media.durationSecond}
+        : {}),
+      ...(typeof media.url === "string" ? {url: media.url} : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function itemSummary(row: AdminItemRow): AdminItemSummary {
+  const image = String(row.image ?? "").trim();
+  const mediaFile = mediaSummary(row.media_file);
+  return {
+    createdAtMs: rfc3399ToMs(row.created_at),
+    id: String(row.id),
+    ...(image ? {image} : {}),
+    ...(mediaFile ? {mediaFile} : {}),
+    pubDateMs: rfc3399ToMs(row.pub_date),
+    status: Number(row.status),
+    title: String(row.title ?? "").trim() || "Untitled",
+    updatedAtMs: rfc3399ToMs(row.updated_at),
+  };
+}
+
+export async function listAdminItems(
+  database: D1Database,
+  request: Request,
+  options: {limit?: unknown} = {},
+): Promise<AdminItemListResponse> {
+  const searchParams = new URL(request.url).searchParams;
+  const statusFilter = normalizeItemStatusFilter(searchParams.get("status"));
+  const pagination = resolveItemPagination(searchParams, {
+    order: ITEM_ORDERS.DESC,
+    sort: ITEM_SORTS.UPDATED_AT,
+  });
+  const limit = normalizeAdminItemListLimit(options.limit);
+  const statusQuery = itemQueryForStatusFilter(statusFilter);
+  const statusValue = Object.values(statusQuery)[0] ?? STATUSES.DELETED;
+  const where = "status__!=" in statusQuery ? "status != ?" : "status = ?";
+  const bindings: unknown[] = [statusValue];
+  const requestedCursor = pagination.nextCursor ?? pagination.prevCursor;
+  const previousPage = pagination.prevCursor !== undefined;
+  const displayDescending = pagination.order === ITEM_ORDERS.DESC;
+  const queryDescending = previousPage ? !displayDescending : displayDescending;
+  const queryDirection = queryDescending ? "DESC" : "ASC";
+  const cursorDirection = previousPage
+    ? displayDescending ? ">" : "<"
+    : displayDescending ? "<" : ">";
+  let cursorClause = "";
+  if (requestedCursor !== undefined) {
+    try {
+      if (pagination.mode === "legacy" && typeof requestedCursor === "number") {
+        cursorClause = ` AND ${pagination.column} ${cursorDirection} ?`;
+        bindings.push(msToRFC3339(requestedCursor));
+      } else if (typeof requestedCursor === "object") {
+        cursorClause = ` AND (${pagination.column} ${cursorDirection} ? OR (` +
+          `${pagination.column} = ? AND id ${cursorDirection} ?))`;
+        const timestamp = msToRFC3339(requestedCursor.timestamp);
+        bindings.push(timestamp, timestamp, requestedCursor.id);
+      }
+    } catch {
+      cursorClause = "";
+    }
+  }
+  const idDirection = pagination.mode === "legacy"
+    ? previousPage ? "DESC" : "ASC"
+    : queryDirection;
+  const result = await database.prepare(`
+    SELECT
+      id,
+      status,
+      created_at,
+      pub_date,
+      updated_at,
+      json_extract(data, '$.title') AS title,
+      json_extract(data, '$.image') AS image,
+      json_extract(data, '$.mediaFile') AS media_file
+    FROM items
+    WHERE ${where}${cursorClause}
+    ORDER BY ${pagination.column} ${queryDirection}, id ${idDirection}
+    LIMIT ?
+  `).bind(...bindings, limit + 1).all<AdminItemRow>();
+  const hasLookahead = result.results.length > limit;
+  const items = result.results.slice(0, limit).map(itemSummary);
+  if (previousPage) items.reverse();
+
+  const hasItems = items.length > 0;
+  const requestedNextPage = pagination.nextCursor !== undefined;
+  const hasNextPage = hasItems && (previousPage || hasLookahead);
+  const hasPreviousPage = hasItems && (
+    requestedNextPage || (previousPage && hasLookahead)
+  );
+  const cursorForItem = (item: AdminItemSummary): number | string => {
+    const timestamp = item[pagination.timestampKey];
+    return pagination.mode === "legacy"
+      ? timestamp
+      : encodeItemCursor(timestamp, item.id);
+  };
+
+  return {
+    items,
+    ...(hasNextPage ? {nextCursor: cursorForItem(items.at(-1)!)} : {}),
+    order: pagination.order,
+    ...(hasPreviousPage ? {prevCursor: cursorForItem(items[0]!)} : {}),
+    sort: pagination.sort,
+    statusFilter,
+  };
+}

--- a/src/server/pages/service.ts
+++ b/src/server/pages/service.ts
@@ -13,6 +13,7 @@ import {
   type PageRecord,
   validatePageSlug,
 } from "@/shared/Pages";
+import type {AdminPageSummary} from "@/shared/AdminCollections";
 import {htmlToPlainText, randomShortUUID} from "@/shared/StringUtils";
 import {storedThemeFromRow} from "@/shared/themes/ThemeRows";
 import type FeedDb from "@/server/feed/FeedDb";
@@ -262,6 +263,55 @@ export async function listPages(
       ? {next_cursor: encodeCursor(visible.at(-1)!)}
       : {}),
   };
+}
+
+export async function listAdminPageSummaries(
+  database: D1Database,
+): Promise<AdminPageSummary[]> {
+  const statusValues = [
+    STATUSES.PUBLISHED,
+    STATUSES.UNLISTED,
+    STATUSES.UNPUBLISHED,
+  ];
+  const result = await database.prepare(`
+    SELECT
+      id,
+      slug,
+      status,
+      title,
+      show_in_navigation,
+      navigation_label,
+      navigation_order
+    FROM pages
+    WHERE status IN (${statusValues.map(() => "?").join(", ")})
+    ORDER BY updated_at DESC, id DESC
+    LIMIT 100
+  `).bind(...statusValues).all<Pick<
+    PageRow,
+    | "id"
+    | "navigation_label"
+    | "navigation_order"
+    | "show_in_navigation"
+    | "slug"
+    | "status"
+    | "title"
+  >>();
+  return result.results.map((row) => {
+    const status = statusName(Number(row.status));
+    return {
+      id: String(row.id),
+      is_not_found_page: isNotFoundPageSlug(row.slug),
+      navigation_label: String(row.navigation_label ?? ""),
+      navigation_order: Number(row.navigation_order ?? 0),
+      show_in_navigation: pageNavigationEnabledForStatus(
+        status,
+        Boolean(row.show_in_navigation),
+      ),
+      slug: String(row.slug),
+      status,
+      title: String(row.title),
+    };
+  });
 }
 
 export async function getPageById(

--- a/src/server/site-files/service.ts
+++ b/src/server/site-files/service.ts
@@ -9,6 +9,7 @@ import {
   siteFileMediaTypeForName,
   validateSiteFilename,
 } from "@/shared/SiteFiles";
+import type {AdminSiteFileSummary} from "@/shared/AdminCollections";
 import {
   defaultSiteFileTemplate,
   validateSiteFileTemplateSource,
@@ -111,6 +112,27 @@ export async function listSiteFiles(
   return result.results.map((row) =>
     recordFromRow(row as SiteFileRow, baseUrl)
   );
+}
+
+export async function listAdminSiteFileSummaries(
+  database: D1Database,
+): Promise<AdminSiteFileSummary[]> {
+  const result = await database.prepare(`
+    SELECT id, filename, content_type, enabled
+    FROM site_files
+    ORDER BY generator IS NULL, filename COLLATE NOCASE, id
+  `).all<{
+    content_type: SiteFileMediaType;
+    enabled: number;
+    filename: string;
+    id: string;
+  }>();
+  return result.results.map((row) => ({
+    content_type: row.content_type,
+    enabled: Boolean(row.enabled),
+    filename: String(row.filename),
+    id: String(row.id),
+  }));
 }
 
 export async function getSiteFileById(

--- a/src/shared/AdminCollections.ts
+++ b/src/shared/AdminCollections.ts
@@ -1,0 +1,69 @@
+import {
+  DEFAULT_ITEMS_PER_PAGE,
+  MAX_ITEMS_PER_PAGE,
+} from "./Constants";
+import type {ItemOrder, ItemSort} from "./ItemPagination";
+import type {PageRecord} from "./Pages";
+import type {SiteFileMediaType} from "./SiteFiles";
+
+export interface AdminItemMediaSummary {
+  category?: string;
+  durationSecond?: number;
+  url?: string;
+}
+
+export interface AdminItemSummary {
+  createdAtMs: number;
+  id: string;
+  image?: string;
+  mediaFile?: AdminItemMediaSummary;
+  pubDateMs: number;
+  status: number;
+  title: string;
+  updatedAtMs: number;
+}
+
+export interface AdminItemListResponse {
+  items: AdminItemSummary[];
+  nextCursor?: number | string;
+  order: ItemOrder;
+  prevCursor?: number | string;
+  sort: ItemSort;
+  statusFilter: "all" | "published" | "unlisted" | "unpublished";
+}
+
+export type AdminPageSummary = Pick<
+  PageRecord,
+  | "id"
+  | "is_not_found_page"
+  | "navigation_label"
+  | "navigation_order"
+  | "show_in_navigation"
+  | "slug"
+  | "status"
+  | "title"
+>;
+
+export interface AdminPageListResponse {
+  items: AdminPageSummary[];
+  themeSupportsPages: boolean;
+}
+
+export interface AdminSiteFileSummary {
+  content_type: SiteFileMediaType;
+  enabled: boolean;
+  filename: string;
+  id: string;
+}
+
+export interface AdminSiteFileListResponse {
+  items: AdminSiteFileSummary[];
+}
+
+export function normalizeAdminItemListLimit(value: unknown): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_ITEMS_PER_PAGE;
+  }
+  return Math.min(Math.trunc(parsed), MAX_ITEMS_PER_PAGE);
+}

--- a/src/shared/StringUtils.ts
+++ b/src/shared/StringUtils.ts
@@ -433,6 +433,7 @@ export const ADMIN_URLS = {
   logout: () => adminUrl("logout", browserAdminPath()),
 
   ajaxFeed: () => adminUrl("ajax/feed", browserAdminPath()),
+  ajaxItems: () => adminUrl("ajax/items", browserAdminPath()),
   ajaxPages: () => adminUrl("ajax/pages", browserAdminPath()),
   ajaxPageOrder: () => adminUrl("ajax/pages/order", browserAdminPath()),
   ajaxPage: (id: string) => adminUrl(`ajax/pages/${id}`, browserAdminPath()),

--- a/tests/unit/components/admin-collection-shells.test.ts
+++ b/tests/unit/components/admin-collection-shells.test.ts
@@ -1,0 +1,34 @@
+import {readFile} from "node:fs/promises";
+import {describe, expect, it} from "vitest";
+
+const routeSource = (path: string) => readFile(
+  new URL(`../../../src/pages/[adminPath]/${path}/index.astro`, import.meta.url),
+  "utf8",
+);
+
+describe("admin collection shells", () => {
+  it("renders lightweight shells and lets client islands fetch list data", async () => {
+    const [items, pages, siteFiles] = await Promise.all([
+      routeSource("items/list"),
+      routeSource("pages"),
+      routeSource("site-files"),
+    ]);
+
+    expect(items).toContain('<AllItemsApp client:only="react"');
+    expect(items).toContain("{itemsPerPage} {publicBucketUrl}");
+    expect(items).not.toContain(
+      '<AllItemsApp client:only="react" {feedContent}>',
+    );
+
+    expect(pages).toContain('<PagesApp client:only="react"');
+    expect(pages).not.toContain("await listPages");
+    expect(pages).not.toContain("await activeThemeSupportsPages");
+
+    expect(siteFiles).toContain('<SiteFilesApp client:only="react"');
+    expect(siteFiles).not.toContain("await listSiteFiles");
+
+    for (const source of [items, pages, siteFiles]) {
+      expect(source).toContain('<AdminPageFallback slot="fallback" kind="list"');
+    }
+  });
+});

--- a/tests/unit/components/admin-items-list.test.ts
+++ b/tests/unit/components/admin-items-list.test.ts
@@ -1,9 +1,14 @@
 import React from "react";
 import {renderToStaticMarkup} from "react-dom/server";
-import {afterEach, describe, expect, it, vi} from "vitest";
+import {describe, expect, it} from "vitest";
 
-import AllItemsApp from "@/components/admin/items/AllItemsApp";
+import {ItemListTable} from "@/components/admin/items/AllItemsApp";
+import type {
+  AdminItemListResponse,
+  AdminItemMediaSummary,
+} from "@/shared/AdminCollections";
 import {STATUSES} from "@/shared/Constants";
+import {normalizeItemStatusFilter} from "@/shared/ItemList";
 import {ITEM_ORDERS, ITEM_SORTS} from "@/shared/ItemPagination";
 import type {FeedItem} from "@/types";
 
@@ -35,32 +40,34 @@ const ITEMS: FeedItem[] = [
 function renderItemsList(
   search = "?status=published&sort=updated_at&order=desc",
   items: FeedItem[] = ITEMS,
+  loading = false,
 ) {
-  vi.stubGlobal("window", {
-    location: {
-      hostname: "feed.example.com",
-      search,
-    },
-  });
+  const searchParams = new URLSearchParams(search);
+  const listing: AdminItemListResponse = {
+    items: [],
+    nextCursor: "cursor_value",
+    order: ITEM_ORDERS.DESC,
+    sort: ITEM_SORTS.UPDATED_AT,
+    statusFilter: normalizeItemStatusFilter(searchParams.get("status")),
+  };
+  const data = items.map((item) => ({
+    createdAtMs: Number(item.createdAtMs),
+    id: String(item.id),
+    ...(item.image
+      ? {imageUrl: `https://media.example.com/${item.image}`}
+      : {}),
+    mediaFile: item.mediaFile as AdminItemMediaSummary | undefined,
+    pubDateMs: Number(item.pubDateMs),
+    publicBucketUrl: "https://media.example.com/",
+    status: Number(item.status),
+    title: String(item.title),
+    updatedAtMs: Number(item.updatedAtMs),
+  }));
 
   return renderToStaticMarkup(
-    React.createElement(AllItemsApp, {
-      feedContent: {
-        items,
-        items_next_cursor: "cursor_value",
-        items_order: ITEM_ORDERS.DESC,
-        items_sort: ITEM_SORTS.UPDATED_AT,
-        settings: {
-          webGlobalSettings: {
-            publicBucketUrl: "https://media.example.com/",
-          },
-        },
-      },
-    }),
+    React.createElement(ItemListTable, {data, listing, loading}),
   );
 }
-
-afterEach(() => vi.unstubAllGlobals());
 
 describe("admin items list", () => {
   it("renders the requested filters and six-column layout", () => {
@@ -155,5 +162,16 @@ describe("admin items list", () => {
     expect(output).toContain("No unlisted items yet.");
     expect(output).toContain("Add a new item");
     expect(output).toContain("mt-4 !text-white hover:!text-white");
+  });
+
+  it("disables list navigation while refreshed rows are loading", () => {
+    const output = renderItemsList(
+      "?status=published&sort=updated_at&order=desc",
+      ITEMS,
+      true,
+    );
+
+    expect(output).toContain('aria-disabled="true"');
+    expect(output).toContain("cursor-not-allowed opacity-70");
   });
 });

--- a/tests/unit/components/admin-site-files.test.ts
+++ b/tests/unit/components/admin-site-files.test.ts
@@ -6,7 +6,7 @@ import {describe, expect, it} from "vitest";
 import SiteFileEditorApp, {
   siteFileEditorLanguage,
 } from "@/components/admin/site-files/SiteFileEditorApp";
-import SiteFilesApp from "@/components/admin/site-files/SiteFilesApp";
+import {SiteFilesList} from "@/components/admin/site-files/SiteFilesApp";
 import type {SiteFileRecord} from "@/shared/SiteFiles";
 
 describe("Site File editor", () => {
@@ -126,20 +126,21 @@ describe("Site File editor", () => {
       system: true,
       url: "https://example.com/robots.txt",
     };
-    const output = renderToStaticMarkup(React.createElement(SiteFilesApp, {
-      files: [
-        baseFile,
-        {
-          ...baseFile,
-          enabled: false,
-          filename: "security.txt",
-          generator: undefined,
-          id: "security-file",
-          mode: "override",
-          system: false,
-        },
-      ],
-    }));
+    const files: SiteFileRecord[] = [
+      baseFile,
+      {
+        ...baseFile,
+        enabled: false,
+        filename: "security.txt",
+        generator: undefined,
+        id: "security-file",
+        mode: "override",
+        system: false,
+      },
+    ];
+    const output = renderToStaticMarkup(
+      React.createElement(SiteFilesList, {files}),
+    );
 
     expect(output).toContain("bg-emerald-500/12");
     expect(output).toContain(">Published</span>");

--- a/tests/unit/server/admin-routes.test.ts
+++ b/tests/unit/server/admin-routes.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 
 import {
+  isAdminCollectionListPath,
   isExistingItemEditorPath,
   isPublicPageCandidateForDynamicAdminRoute,
 } from "@/server/admin-routes";
@@ -46,5 +47,30 @@ describe("admin item routes", () => {
     "/admin/items/new-item/",
   ])("lets the existing item page load its own context for %s", (pathname) => {
     expect(isExistingItemEditorPath(pathname)).toBe(true);
+  });
+});
+
+describe("admin collection routes", () => {
+  it.each([
+    "/admin/items/list/",
+    "/admin/pages/",
+    "/admin/site-files/",
+  ])("loads %s as an AJAX-backed collection shell", (pathname) => {
+    expect(isAdminCollectionListPath(pathname)).toBe(true);
+  });
+
+  it.each([
+    "/admin/items/list/extra/",
+    "/admin/pages/new/",
+    "/admin/pages/page-id/",
+    "/admin/site-files/new/",
+    "/admin/settings/",
+  ])("keeps %s on its existing server data path", (pathname) => {
+    expect(isAdminCollectionListPath(pathname)).toBe(false);
+  });
+
+  it("supports a custom admin path", () => {
+    expect(isAdminCollectionListPath("/studio/pages/", "studio")).toBe(true);
+    expect(isAdminCollectionListPath("/admin/pages/", "studio")).toBe(false);
   });
 });

--- a/tests/unit/shared/AdminCollections.test.ts
+++ b/tests/unit/shared/AdminCollections.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from "vitest";
+
+import {normalizeAdminItemListLimit} from "@/shared/AdminCollections";
+import {
+  DEFAULT_ITEMS_PER_PAGE,
+  MAX_ITEMS_PER_PAGE,
+} from "@/shared/Constants";
+
+describe("admin collection settings", () => {
+  it("normalizes the configured item page size", () => {
+    expect(normalizeAdminItemListLimit(undefined)).toBe(DEFAULT_ITEMS_PER_PAGE);
+    expect(normalizeAdminItemListLimit(0)).toBe(DEFAULT_ITEMS_PER_PAGE);
+    expect(normalizeAdminItemListLimit(-1)).toBe(DEFAULT_ITEMS_PER_PAGE);
+    expect(normalizeAdminItemListLimit("30")).toBe(30);
+    expect(normalizeAdminItemListLimit(30.9)).toBe(30);
+    expect(normalizeAdminItemListLimit(MAX_ITEMS_PER_PAGE + 1)).toBe(
+      MAX_ITEMS_PER_PAGE,
+    );
+  });
+});

--- a/tests/unit/source-architecture.test.ts
+++ b/tests/unit/source-architecture.test.ts
@@ -283,7 +283,9 @@ describe("source architecture", () => {
 
     expect(itemsList).not.toContain('@/components/ui/card');
     expect(itemsList).not.toContain("NAV_ITEMS_DICT");
-    expect(itemsList).toContain("<ItemListTable data={data} feed={feed} />");
+    expect(itemsList).toContain("useAdminCollection<AdminItemListResponse>");
+    expect(itemsList).toContain("listing={listing}");
+    expect(itemsList).not.toContain("feed={feed}");
   });
 
   it("keeps web settings as three independent cards", async () => {

--- a/tests/worker/admin-collections.test.ts
+++ b/tests/worker/admin-collections.test.ts
@@ -1,0 +1,185 @@
+import {env} from "cloudflare:workers";
+import type {APIContext, APIRoute} from "astro";
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {GET as listAdminItems} from "@/pages/[adminPath]/ajax/items/index";
+import {GET as listAdminPages} from "@/pages/[adminPath]/ajax/pages/index";
+import {GET as listAdminSiteFiles} from "@/pages/[adminPath]/ajax/site-files/index";
+import FeedDb from "@/server/feed/FeedDb";
+import {loadFeed} from "@/server/feed/feed";
+import {STATUSES} from "@/shared/Constants";
+
+const ORIGIN = "https://feed.example.com";
+const NOW = "2026-08-14T20:00:00.000Z";
+
+async function responseFrom(handler: APIRoute, pathname: string) {
+  const request = new Request(`${ORIGIN}${pathname}`);
+  const response = await handler({
+    locals: {},
+    params: {adminPath: "admin"},
+    request,
+    url: new URL(request.url),
+  } as unknown as APIContext);
+  if (!(response instanceof Response)) throw new Error("Expected a response.");
+  return response;
+}
+
+beforeEach(async () => {
+  await new FeedDb(
+    env,
+    new Request(`${ORIGIN}/admin/`),
+  ).getContent();
+  await env.FEED_DB.batch([
+    env.FEED_DB.prepare("DELETE FROM items WHERE id = ?").bind(
+      "admin-summary-item",
+    ),
+    env.FEED_DB.prepare("DELETE FROM pages WHERE id = ?").bind(
+      "admin-summary-page",
+    ),
+    env.FEED_DB.prepare("DELETE FROM site_files WHERE id = ?").bind(
+      "admin-summary-file",
+    ),
+  ]);
+  await env.FEED_DB.batch([
+    env.FEED_DB.prepare(`
+      INSERT INTO items (id, status, data, content_text, pub_date, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      "admin-summary-item",
+      STATUSES.UNLISTED,
+      JSON.stringify({
+        contentHtml: "<p>This body must not be listed.</p>",
+        image: "images/summary.png",
+        mediaFile: {category: "audio", durationSecond: 42, url: "audio/summary.mp3"},
+        title: "Summary item",
+      }),
+      "This body must not be listed.",
+      NOW,
+      NOW,
+      NOW,
+    ),
+    env.FEED_DB.prepare(`
+      INSERT INTO pages (
+        id, slug, title, content_html, content_text, status,
+        meta_description, show_in_navigation, navigation_label,
+        navigation_order, published_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      "admin-summary-page",
+      "summary-page",
+      "Summary Page",
+      "<p>This Page body must not be listed.</p>",
+      "This Page body must not be listed.",
+      STATUSES.PUBLISHED,
+      "Private list metadata",
+      1,
+      "Summary",
+      20,
+      NOW,
+      NOW,
+      NOW,
+    ),
+    env.FEED_DB.prepare(`
+      INSERT INTO site_files (
+        id, filename, mode, draft_content, content_type, enabled,
+        created_at, updated_at
+      ) VALUES (?, ?, 'override', ?, 'text/plain', 1, ?, ?)
+    `).bind(
+      "admin-summary-file",
+      "summary.txt",
+      "This Site File body must not be listed.",
+      NOW,
+      NOW,
+    ),
+  ]);
+});
+
+describe("admin collection endpoints", () => {
+  it("omits items from the shared feed context used by list shells", async () => {
+    const loaded = await loadFeed(
+      env,
+      new Request(`${ORIGIN}/admin/items/list/`),
+      {includeItems: false},
+    );
+
+    expect(loaded.content.channel).toBeDefined();
+    expect(loaded.content.settings).toBeDefined();
+    expect(loaded.content.items).toBeUndefined();
+  });
+
+  it("returns only fields needed by the item list", async () => {
+    const response = await responseFrom(
+      listAdminItems,
+      "/admin/ajax/items/?status=unlisted&sort=updated_at&order=desc&limit=20",
+    );
+    const body = await response.json() as Record<string, any>;
+    const item = body.items.find(({id}: {id: string}) =>
+      id === "admin-summary-item"
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(body).toMatchObject({
+      order: "desc",
+      sort: "updated_at",
+      statusFilter: "unlisted",
+    });
+    expect(item).toMatchObject({
+      id: "admin-summary-item",
+      image: "images/summary.png",
+      mediaFile: {
+        category: "audio",
+        durationSecond: 42,
+        url: "audio/summary.mp3",
+      },
+      title: "Summary item",
+    });
+    expect(item).not.toHaveProperty("contentHtml");
+    expect(item).not.toHaveProperty("contentText");
+  });
+
+  it("returns Page summaries and theme compatibility together", async () => {
+    const response = await responseFrom(
+      listAdminPages,
+      "/admin/ajax/pages/",
+    );
+    const body = await response.json() as Record<string, any>;
+    const page = body.items.find(({id}: {id: string}) =>
+      id === "admin-summary-page"
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(typeof body.themeSupportsPages).toBe("boolean");
+    expect(page).toMatchObject({
+      id: "admin-summary-page",
+      navigation_label: "Summary",
+      show_in_navigation: true,
+      slug: "summary-page",
+      status: "published",
+      title: "Summary Page",
+    });
+    expect(page).not.toHaveProperty("content_html");
+    expect(page).not.toHaveProperty("content_text");
+    expect(page).not.toHaveProperty("meta_description");
+  });
+
+  it("returns Site File metadata without template bodies", async () => {
+    const response = await responseFrom(
+      listAdminSiteFiles,
+      "/admin/ajax/site-files/",
+    );
+    const body = await response.json() as Record<string, any>;
+    const file = body.items.find(({id}: {id: string}) =>
+      id === "admin-summary-file"
+    );
+
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(file).toEqual({
+      content_type: "text/plain",
+      enabled: true,
+      filename: "summary.txt",
+      id: "admin-summary-file",
+    });
+    expect(file).not.toHaveProperty("draft_content");
+    expect(file).not.toHaveProperty("published_content");
+  });
+});

--- a/tests/worker/items-list.test.ts
+++ b/tests/worker/items-list.test.ts
@@ -2,6 +2,7 @@ import {env} from "cloudflare:workers";
 import {describe, expect, it} from "vitest";
 
 import FeedDb, {getFetchItemsParams} from "@/server/feed/FeedDb";
+import {listAdminItems} from "@/server/items/admin-list";
 import {ITEMS_SORT_ORDERS, STATUSES} from "@/shared/Constants";
 import {
   decodeItemCursor,
@@ -103,6 +104,13 @@ async function page(
     {"status__!=": STATUSES.DELETED},
     2,
   ));
+}
+
+async function adminPage(searchParams: Record<string, string>) {
+  const request = new Request(
+    `https://feed.example.com/admin/ajax/items/?${new URLSearchParams(searchParams)}`,
+  );
+  return listAdminItems(env.FEED_DB, request, {limit: 2});
 }
 
 describe("deterministic item pagination", () => {
@@ -223,5 +231,51 @@ describe("deterministic item pagination", () => {
     expect(malformed.items.map(({id}: {id: string}) => id)).toEqual(expected);
     expect(numeric.items.map(({id}: {id: string}) => id)).toEqual(expected);
     expect(malformed.items_prev_cursor).toBeUndefined();
+  });
+});
+
+describe("admin item summary pagination", () => {
+  it("navigates both directions for every canonical key and order", async () => {
+    await databaseWithItems();
+
+    for (const sort of Object.values(ITEM_SORTS)) {
+      for (const order of Object.values(ITEM_ORDERS)) {
+        const forwardPages: string[][] = [];
+        const seenIds: string[] = [];
+        let response = await adminPage({order, sort});
+
+        while (true) {
+          const ids = response.items.map(({id}) => id);
+          expect(ids).not.toHaveLength(0);
+          forwardPages.push(ids);
+          seenIds.push(...ids);
+          expect(response.sort).toBe(sort);
+          expect(response.order).toBe(order);
+          if (!response.nextCursor) break;
+          expect(decodeItemCursor(String(response.nextCursor))).toBeDefined();
+          response = await adminPage({
+            next_cursor: String(response.nextCursor),
+            order,
+            sort,
+          });
+        }
+
+        expect(seenIds).toEqual(expectedIds(sort, order));
+        expect(new Set(seenIds).size).toBe(ITEMS.length);
+
+        for (let index = forwardPages.length - 2; index >= 0; index -= 1) {
+          expect(response.prevCursor).toBeDefined();
+          response = await adminPage({
+            order,
+            prev_cursor: String(response.prevCursor),
+            sort,
+          });
+          expect(response.items.map(({id}) => id)).toEqual(
+            forwardPages[index],
+          );
+        }
+        expect(response.prevCursor).toBeUndefined();
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Render lightweight server shells for the Items, Pages, and Site Files admin lists.
- Load purpose-built collection summaries from authenticated, private no-store AJAX endpoints instead of embedding complete records in the initial HTML.
- Update item filtering, sorting, and pagination in place while preserving a shareable URL, retaining and dimming current rows during refresh, aborting stale requests, and offering retry states.
- Add focused unit and Worker coverage for shell rendering, summary payloads, status filters, pagination, and loading behavior.

This reduces initial admin-page work and avoids full route reloads when sorting or navigating the item list.

## Related issue

N/A

## Testing

- [x] yarn check
- 636 unit tests passed.
- 114 Worker tests passed.
- Production application build, Worker dry run, theme tooling, OpenAPI validation, CLI package checks, and documentation build passed.

## Screenshots

N/A — existing list layouts are preserved; this changes loading and navigation behavior.

## Risks

Low. The changed endpoints are internal authenticated dashboard routes and are not part of the public REST/OpenAPI contract. Existing editor mutation routes remain unchanged.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation is not required because commands and public API behavior are unchanged.
- [x] No secrets, private configuration, production data, or generated files are included.