### PR TITLE
Improve webhook onboarding and Admin status UX

### DIFF
--- a/src/components/admin/webhooks/WebhookDeliveriesApp.tsx
+++ b/src/components/admin/webhooks/WebhookDeliveriesApp.tsx
@@ -4,11 +4,66 @@ import AdminSectionCard from "@/components/admin/shared/AdminSectionCard";
 import {Button} from "@/components/ui/button";
 import {showToast} from "@/client/ToastUtils";
 import type {
+  WebhookAttemptSummary,
+  WebhookDeliveryStatus,
   WebhookDeliverySummary,
   WebhookEndpointSummary,
 } from "@/shared/Webhooks";
 import {adminUrl, browserAdminPath} from "@/shared/AdminPath";
 import {WEBHOOK_DELIVERY_STATUSES, WEBHOOK_EVENT_TYPES} from "@/shared/Webhooks";
+
+const deliveryStatusClasses: Record<WebhookDeliveryStatus, string> = {
+  canceled_endpoint_disabled: "bg-slate-500/10 text-slate-700 dark:text-slate-300",
+  canceled_endpoint_paused: "bg-slate-500/10 text-slate-700 dark:text-slate-300",
+  canceled_webhooks_disabled: "bg-slate-500/10 text-slate-700 dark:text-slate-300",
+  failed: "bg-red-500/10 text-red-700 dark:text-red-300",
+  pending: "bg-sky-500/10 text-sky-700 dark:text-sky-300",
+  retrying: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  succeeded: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+  suppressed_budget: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+  suppressed_endpoint_paused: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
+};
+
+function humanizeStatus(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function DeliveryStatus({status}: {status: WebhookDeliveryStatus}) {
+  return (
+    <span className={`inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-medium ${deliveryStatusClasses[status]}`}>
+      {humanizeStatus(status)}
+    </span>
+  );
+}
+
+function responseStatusClass(status: number): string {
+  if (status >= 200 && status < 300) {
+    return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300";
+  }
+  if (status === 408 || status === 425 || status === 429 || status >= 500) {
+    return "bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  }
+  return "bg-red-500/10 text-red-700 dark:text-red-300";
+}
+
+function ResponseStatus({status}: {status?: number}) {
+  if (status === undefined) return <>—</>;
+  return (
+    <span className={`inline-flex w-fit rounded-full px-2 py-0.5 text-xs font-medium ${responseStatusClass(status)}`}>
+      {status}
+    </span>
+  );
+}
+
+function attemptOutcomeClass(outcome: string): string {
+  if (outcome === "succeeded") {
+    return "text-emerald-700 dark:text-emerald-300";
+  }
+  if (outcome === "network_error" || outcome === "retryable_response") {
+    return "text-amber-700 dark:text-amber-300";
+  }
+  return "text-red-700 dark:text-red-300";
+}
 
 function ajax(path: string): string {
   return adminUrl(`ajax/webhooks/${path}`, browserAdminPath());
@@ -82,7 +137,7 @@ export default function WebhookDeliveriesApp({initialDeliveries, endpoints, init
               <li key={delivery.id}>
                 <button className="grid w-full gap-1 p-4 text-left hover:bg-muted/50 sm:grid-cols-[1fr_auto]" onClick={() => inspect(delivery.id)} type="button">
                   <span><span className="font-medium">{delivery.eventType}</span>{delivery.isTest && <span className="ml-2 rounded-full border px-1.5 py-0.5 text-[10px] font-medium uppercase">test</span>}<span className="ml-2 text-xs text-muted-foreground">{delivery.endpointName ?? delivery.endpointUrl}</span></span>
-                  <span className="text-xs font-medium">{delivery.status}</span>
+                  <DeliveryStatus status={delivery.status} />
                   <span className="text-xs text-muted-foreground">{new Date(delivery.createdAt).toLocaleString()} · {delivery.attemptCount} attempts</span>
                 </button>
               </li>
@@ -96,13 +151,13 @@ export default function WebhookDeliveriesApp({initialDeliveries, endpoints, init
             <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2">
               <dt className="text-muted-foreground">Delivery</dt><dd className="break-all font-mono text-xs">{selected.id}</dd>
               <dt className="text-muted-foreground">Event</dt><dd className="break-all font-mono text-xs">{selected.eventId}</dd>
-              <dt className="text-muted-foreground">Status</dt><dd>{selected.status}</dd>
+              <dt className="text-muted-foreground">Status</dt><dd><DeliveryStatus status={selected.status} /></dd>
               <dt className="text-muted-foreground">Test</dt><dd>{selected.isTest ? "Yes" : "No"}</dd>
-              <dt className="text-muted-foreground">Response</dt><dd>{selected.responseStatus ?? "—"}</dd>
+              <dt className="text-muted-foreground">Response</dt><dd><ResponseStatus status={selected.responseStatus} /></dd>
             </dl>
             <Button disabled={busy || selected.status === "pending" || selected.status === "retrying"} onClick={redeliver} type="button" variant="outline">Manual redelivery</Button>
             <div><h3 className="mb-2 font-medium">Payload</h3><pre className="max-h-80 overflow-auto rounded-lg bg-muted p-3 text-xs">{JSON.stringify(selected.payload, null, 2)}</pre></div>
-            <div><h3 className="mb-2 font-medium">Attempts</h3><ul className="grid gap-2">{selected.attempts.map((attempt: any) => <li className="rounded-lg border p-3" key={attempt.attemptNumber}><p>Attempt {attempt.attemptNumber}: {attempt.outcome} {attempt.responseStatus ?? ""}</p>{(attempt.error || attempt.responseBody) && <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground">{attempt.error ?? attempt.responseBody}</pre>}</li>)}</ul></div>
+            <div><h3 className="mb-2 font-medium">Attempts</h3><ul className="grid gap-2">{selected.attempts.map((attempt: WebhookAttemptSummary) => <li className="rounded-lg border p-3" key={attempt.attemptNumber}><p className="flex flex-wrap items-center gap-2">Attempt {attempt.attemptNumber}: <span className={`font-medium ${attemptOutcomeClass(attempt.outcome)}`}>{humanizeStatus(attempt.outcome)}</span> <ResponseStatus status={attempt.responseStatus} /></p>{(attempt.error || attempt.responseBody) && <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground">{attempt.error ?? attempt.responseBody}</pre>}</li>)}</ul></div>
           </div>
         )}
       </AdminSectionCard>

--- a/src/components/admin/webhooks/WebhookEndpointsApp.tsx
+++ b/src/components/admin/webhooks/WebhookEndpointsApp.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import {Input} from "@/components/ui/input";
 import {Label} from "@/components/ui/label";
+import {Switch} from "@/components/ui/switch";
 import {showToast} from "@/client/ToastUtils";
 import type {WebhookEndpointSummary} from "@/shared/Webhooks";
 import {adminUrl, browserAdminPath} from "@/shared/AdminPath";
@@ -145,15 +146,18 @@ export default function WebhookEndpointsApp({
       setBusy(false);
     }
   };
-  const setStatus = async (endpoint: WebhookEndpointSummary) => {
+  const setStatus = async (
+    endpoint: WebhookEndpointSummary,
+    active: boolean,
+  ) => {
     setBusy(true);
     try {
       await requestJson(`endpoints/${endpoint.id}`, {
-        body: JSON.stringify({status: endpoint.status === "active" ? "disabled" : "active"}),
+        body: JSON.stringify({status: active ? "active" : "disabled"}),
         method: "PUT",
       });
       await refresh();
-      showToast(endpoint.status === "active" ? "Endpoint disabled." : "Endpoint enabled.", "success");
+      showToast(active ? "Endpoint enabled." : "Endpoint disabled.", "success");
     } catch (error) {
       showToast(error instanceof Error ? error.message : String(error), "error");
     } finally {
@@ -365,7 +369,29 @@ export default function WebhookEndpointsApp({
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
                       <h3 className="font-semibold">{endpoint.name}</h3>
-                      <Status value={endpoint.status} />
+                      <div className="flex items-center gap-2">
+                        <Switch
+                          aria-label={`${endpoint.name} endpoint status`}
+                          checked={endpoint.status === "active"}
+                          disabled={busy || endpoint.status === "auto_paused"}
+                          id={`webhook-endpoint-status-${endpoint.id}`}
+                          onCheckedChange={(checked) => void setStatus(endpoint, checked)}
+                        />
+                        <Label
+                          className={endpoint.status === "auto_paused"
+                            ? "text-amber-700 dark:text-amber-300"
+                            : endpoint.status === "active"
+                            ? "text-emerald-700 dark:text-emerald-300"
+                            : "text-muted-foreground"}
+                          htmlFor={`webhook-endpoint-status-${endpoint.id}`}
+                        >
+                          {endpoint.status === "auto_paused"
+                            ? "Auto-paused"
+                            : endpoint.status === "active"
+                            ? "Active"
+                            : "Disabled"}
+                        </Label>
+                      </div>
                     </div>
                     <p className="mt-1 break-all text-sm text-muted-foreground">{endpoint.url}</p>
                     <p className="mt-2 text-xs text-muted-foreground">{endpoint.events.join(", ")} · {endpoint.consecutiveTerminalFailures} consecutive terminal failures</p>
@@ -376,9 +402,7 @@ export default function WebhookEndpointsApp({
                     <Button disabled={busy} onClick={() => openSecret(endpoint)} size="sm" type="button" variant="outline">Signing secret</Button>
                     {endpoint.status === "auto_paused" ? (
                       <Button disabled={busy || !endpoint.resumeTestedAt} onClick={() => action(endpoint, "resume")} size="sm" type="button">Resume</Button>
-                    ) : (
-                      <Button disabled={busy} onClick={() => setStatus(endpoint)} size="sm" type="button" variant="outline">{endpoint.status === "active" ? "Disable" : "Enable"}</Button>
-                    )}
+                    ) : null}
                     <Button disabled={busy} onClick={() => action(endpoint, "delete")} size="sm" type="button" variant="destructive">Delete</Button>
                   </div>
                 </div>
@@ -457,8 +481,4 @@ function EndpointForm({
       </div>
     </form>
   );
-}
-
-function Status({value}: {value: string}) {
-  return <span className="rounded-full border px-2 py-0.5 text-xs font-medium capitalize">{value.replace("_", " ")}</span>;
 }

--- a/src/components/admin/webhooks/WebhookEventExplorerApp.tsx
+++ b/src/components/admin/webhooks/WebhookEventExplorerApp.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useMemo, useState} from "react";
 
+import AdminCodeEditor from "@/components/admin/shared/AdminCodeEditor";
 import AdminSectionCard from "@/components/admin/shared/AdminSectionCard";
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
@@ -69,7 +70,9 @@ export default function WebhookEventExplorerApp({
   const [query, setQuery] = useState("");
   const [subjects, setSubjects] = useState<WebhookExplorerSubject[]>([]);
   const [subjectId, setSubjectId] = useState("");
-  const [endpointId, setEndpointId] = useState(initialEndpointId ?? "");
+  const [endpointId, setEndpointId] = useState(() =>
+    initialEndpointId ?? endpoints.find(({status}) => status === "active")?.id ?? ""
+  );
   const [preview, setPreview] = useState<WebhookExplorerPreview>();
   const [view, setView] = useState<ViewName>("payload");
   const [busy, setBusy] = useState(false);
@@ -195,6 +198,11 @@ export default function WebhookEventExplorerApp({
     : view === "headers"
     ? preview?.headers
     : preview?.schema;
+  const displayedJson = preview
+    ? JSON.stringify(displayed, null, 2)
+    : busy
+    ? "Generating preview…"
+    : "Choose content to preview.";
   const deliveriesUrl = deliveryId
     ? `${adminUrl("webhooks/deliveries", browserAdminPath())}?delivery_id=${encodeURIComponent(deliveryId)}`
     : "";
@@ -289,7 +297,14 @@ export default function WebhookEventExplorerApp({
               <Button disabled={!preview} onClick={() => void copy(true)} size="sm" type="button" variant="outline">Copy formatted JSON</Button>
             </div>
           </div>
-          <pre className="min-h-96 max-h-[44rem] overflow-auto rounded-xl bg-muted p-4 text-xs leading-5">{preview ? JSON.stringify(displayed, null, 2) : busy ? "Generating preview…" : "Choose content to preview."}</pre>
+          <AdminCodeEditor
+            ariaLabel={`${view.charAt(0).toUpperCase() + view.slice(1)} JSON`}
+            code={displayedJson}
+            language="json"
+            maxHeight="44rem"
+            minHeight="24rem"
+            readOnly
+          />
         </div>
       </AdminSectionCard>
     </div>

--- a/src/components/admin/webhooks/WebhookOverviewApp.tsx
+++ b/src/components/admin/webhooks/WebhookOverviewApp.tsx
@@ -199,73 +199,205 @@ export default function WebhookOverviewApp({
       )}
 
       <AdminSectionCard
-        description="Run a complete receiver locally, create an endpoint, and send a real signed test."
+        description={localDevelopment
+          ? "Run a complete receiver locally, create an endpoint, and send a real signed test."
+          : "Open a temporary public listener on this computer and send it a real signed test."}
         title="Build and test your first endpoint"
       >
-        <div className="grid gap-5 lg:grid-cols-[minmax(0,0.85fr)_minmax(22rem,1.15fr)]">
-          <div className="grid content-start gap-3 text-sm leading-6">
+        {localDevelopment
+          ? <div className="grid gap-5 lg:grid-cols-[minmax(0,0.85fr)_minmax(22rem,1.15fr)]">
+            <div className="grid content-start gap-3 text-sm leading-6">
+              <QuickstartStep
+                description={`Create the ${quickstart.label} receiver project in the repository root.`}
+                number={1}
+                title={`Scaffold the ${quickstart.label} receiver`}
+              >
+                <p>
+                  From the microfeed repository root, run the command below. It
+                  writes to the ignored <code>.microfeed/webhooks/</code>
+                  {" "}workspace—not <code>packages/cli/.microfeed/</code>—and does
+                  not install or start anything.
+                </p>
+                <QuickstartCommand onCopy={copy} value={quickstart.scaffoldCommand} />
+                <p>
+                  After it starts in step 3, this receiver will listen at
+                  {" "}<code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
+                </p>
+              </QuickstartStep>
+
+              <QuickstartStep
+                description="Register the local URL and reveal its signing secret."
+                number={2}
+                title="Create the webhook endpoint"
+              >
+                <p>
+                  Open the prefilled endpoint form, enter a name, choose the
+                  events you want, and create the endpoint for
+                  {" "}<code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
+                </p>
+                <Button
+                  render={<a href={endpointCreateUrl} rel="noreferrer" target="_blank" />}
+                  size="sm"
+                >
+                  Create endpoint
+                </Button>
+                <p>
+                  Open <strong>Signing secret</strong> for the endpoint and
+                  reveal the <code>whsec_…</code> value. This is your
+                  {" "}<code>MICROFEED_WEBHOOK_SECRET</code>. It authenticates
+                  microfeed and detects changed request bytes, so no additional
+                  passcode is needed. You can return to reveal or rotate it
+                  later.
+                </p>
+              </QuickstartStep>
+
+              <QuickstartStep
+                description={`Install ${quickstart.label} dependencies and start the loopback server.`}
+                number={3}
+                title={`Install and run the ${quickstart.label} receiver`}
+              >
+                <p>
+                  In a terminal, enter the generated directory, install its
+                  dependencies, and replace <code>whsec_...</code> with the secret
+                  revealed in step 2.
+                </p>
+                <QuickstartCommand onCopy={copy} value={quickstart.directoryCommand} />
+                {quickstart.installCommands.map((command) => (
+                  <QuickstartCommand key={command} onCopy={copy} value={command} />
+                ))}
+                <QuickstartCommand onCopy={copy} value={quickstart.runCommand} />
+                <p>
+                  Keep this terminal open. It should print
+                  {" "}<code>Listening at {WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
+                </p>
+              </QuickstartStep>
+
+              <QuickstartStep
+                description="Send a signed webhook.test and confirm it reaches the terminal."
+                number={4}
+                title="Send and verify a test event"
+              >
+                <p>
+                  With the receiver still running, open Event Explorer. Select
+                  the endpoint from step 2 and <code>webhook.test</code>, keep the
+                  generated example, then choose <strong>Send test delivery</strong>
+                  {" "}and confirm the budgeted delivery.
+                </p>
+                <Button
+                  render={<a href={explorerUrl} rel="noreferrer" target="_blank" />}
+                  size="sm"
+                  variant="outline"
+                >
+                  Open Event Explorer
+                </Button>
+                <p>
+                  The receiver terminal should print the delivery ID, event type,
+                  {" "}<code>test: true</code>, duplicate status, and formatted
+                  payload. A <code>204</code> response marks the delivery as
+                  accepted in microfeed.
+                </p>
+              </QuickstartStep>
+            </div>
+            <div className="min-w-0">
+              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                <div className="flex gap-2" role="tablist" aria-label="Receiver language">
+                  {(["javascript", "python"] as const).map((language) => (
+                    <Button
+                      aria-selected={previewLanguage === language}
+                      key={language}
+                      onClick={() => setPreviewLanguage(language)}
+                      role="tab"
+                      size="sm"
+                      type="button"
+                      variant={previewLanguage === language ? "default" : "outline"}
+                    >
+                      {WEBHOOK_QUICKSTARTS[language].label}
+                    </Button>
+                  ))}
+                </div>
+                <Button
+                  onClick={() => void copy(quickstart.source, `${quickstart.label} receiver code`)}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  <CopyIcon aria-hidden="true" className="size-4" />
+                  Copy {quickstart.filename}
+                </Button>
+              </div>
+              <AdminCodeEditor
+                ariaLabel={`${quickstart.label} webhook receiver code`}
+                code={quickstart.source}
+                language={quickstart.highlightLanguage}
+                maxHeight="36rem"
+                minHeight="36rem"
+                readOnly
+              />
+              <div className="mt-3 rounded-xl border border-amber-500/35 bg-amber-500/8 p-4 text-sm leading-6">
+                <p className="font-medium">Local inspector, not production infrastructure</p>
+                <p className="mt-1 text-muted-foreground">
+                  Duplicate state resets on restart, no job is durably queued,
+                  and production effects are intentionally absent. Add durable
+                  acknowledgement, background work, idempotency, loop
+                  prevention, approvals, audit logs, and cost alerts before
+                  deployment.
+                </p>
+              </div>
+            </div>
+          </div>
+          : <div className="grid max-w-4xl content-start gap-3 text-sm leading-6">
             <QuickstartStep
-              description={`Create the ${quickstart.label} receiver project in the repository root.`}
+              description="Start a verified local inspector and expose it through a temporary public URL."
               number={1}
-              title={`Scaffold the ${quickstart.label} receiver`}
+              title="Start the temporary webhook listener"
             >
               <p>
                 From the microfeed repository root, run the command below. It
-                writes to the ignored <code>.microfeed/webhooks/</code>
-                {" "}workspace—not <code>packages/cli/.microfeed/</code>—and does
-                not install or start anything.
+                starts a loopback listener and a free Cloudflare Quick Tunnel.
+                If <code>cloudflared</code> is unavailable, the CLI can download
+                a pinned, verified copy after asking for approval.
               </p>
-              <QuickstartCommand onCopy={copy} value={quickstart.scaffoldCommand} />
+              <QuickstartCommand onCopy={copy} value="yarn microfeed webhook listen --tunnel" />
               <p>
-                After it starts in step 3, this receiver will listen at
-                {" "}<code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
+                Wait for <strong>Temporary public webhook endpoint</strong> and
+                copy the printed <code>https://…trycloudflare.com/webhook</code>
+                {" "}URL. Keep this terminal open; the URL exists only while the
+                command is running.
               </p>
             </QuickstartStep>
 
             <QuickstartStep
-              description="Register the local URL and reveal its signing secret."
+              description="Register the printed HTTPS URL and copy its endpoint-specific secret."
               number={2}
               title="Create the webhook endpoint"
             >
               <p>
-                Open the prefilled endpoint form, enter a name, choose the
-                events you want, and create the endpoint for
-                {" "}<code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
+                In another tab, open Endpoints, choose <strong>Add endpoint</strong>,
+                paste the exact public URL from step 1, enter a name, and select
+                the events you want to test.
               </p>
               <Button
-                render={<a href={endpointCreateUrl} rel="noreferrer" target="_blank" />}
+                render={<a href={endpointUrl} rel="noreferrer" target="_blank" />}
                 size="sm"
               >
-                Create endpoint
+                Open Endpoints
               </Button>
               <p>
-                Open <strong>Signing secret</strong> for the endpoint and
-                reveal the <code>whsec_…</code> value. This is your
-                {" "}<code>MICROFEED_WEBHOOK_SECRET</code>. It authenticates
-                microfeed and detects changed request bytes, so no additional
-                passcode is needed. You can return to reveal or rotate it
-                later.
+                After creation, copy the one-time <code>whsec_…</code> signing
+                secret. If you close it, use the endpoint's
+                {" "}<strong>Signing secret</strong> action to reveal it again.
               </p>
             </QuickstartStep>
 
             <QuickstartStep
-              description={`Install ${quickstart.label} dependencies and start the loopback server.`}
+              description="Authenticate the listener before it accepts or prints deliveries."
               number={3}
-              title={`Install and run the ${quickstart.label} receiver`}
+              title="Enter the signing secret"
             >
               <p>
-                In a terminal, enter the generated directory, install its
-                dependencies, and replace <code>whsec_...</code> with the secret
-                revealed in step 2.
-              </p>
-              <QuickstartCommand onCopy={copy} value={quickstart.directoryCommand} />
-              {quickstart.installCommands.map((command) => (
-                <QuickstartCommand key={command} onCopy={copy} value={command} />
-              ))}
-              <QuickstartCommand onCopy={copy} value={quickstart.runCommand} />
-              <p>
-                Keep this terminal open. It should print
-                {" "}<code>Listening at {WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
+                Return to the listener terminal, paste the signing secret into
+                its prompt, and submit it. The CLI does not print the secret.
+                Wait for <strong>Listening for verified microfeed webhooks</strong>.
               </p>
             </QuickstartStep>
 
@@ -294,54 +426,15 @@ export default function WebhookOverviewApp({
                 accepted in microfeed.
               </p>
             </QuickstartStep>
-          </div>
-          <div className="min-w-0">
-            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-              <div className="flex gap-2" role="tablist" aria-label="Receiver language">
-                {(["javascript", "python"] as const).map((language) => (
-                  <Button
-                    aria-selected={previewLanguage === language}
-                    key={language}
-                    onClick={() => setPreviewLanguage(language)}
-                    role="tab"
-                    size="sm"
-                    type="button"
-                    variant={previewLanguage === language ? "default" : "outline"}
-                  >
-                    {WEBHOOK_QUICKSTARTS[language].label}
-                  </Button>
-                ))}
-              </div>
-              <Button
-                onClick={() => void copy(quickstart.source, `${quickstart.label} receiver code`)}
-                size="sm"
-                type="button"
-                variant="outline"
-              >
-                <CopyIcon aria-hidden="true" className="size-4" />
-                Copy {quickstart.filename}
-              </Button>
-            </div>
-            <AdminCodeEditor
-              ariaLabel={`${quickstart.label} webhook receiver code`}
-              code={quickstart.source}
-              language={quickstart.highlightLanguage}
-              maxHeight="36rem"
-              minHeight="36rem"
-              readOnly
-            />
-            <div className="mt-3 rounded-xl border border-amber-500/35 bg-amber-500/8 p-4 text-sm leading-6">
-              <p className="font-medium">Local inspector, not production infrastructure</p>
+            <div className="rounded-xl border border-amber-500/35 bg-amber-500/8 p-4">
+              <p className="font-medium">Temporary testing only</p>
               <p className="mt-1 text-muted-foreground">
-                Duplicate state resets on restart, no job is durably queued,
-                and production effects are intentionally absent. Add durable
-                acknowledgement, background work, idempotency, loop
-                prevention, approvals, audit logs, and cost alerts before
-                deployment.
+                Quick Tunnels have no uptime guarantee and are not a deployed
+                receiver. Pressing Ctrl+C stops the listener and tunnel. Delete
+                the temporary endpoint afterward; the next run receives a new URL.
               </p>
             </div>
-          </div>
-        </div>
+          </div>}
       </AdminSectionCard>
 
       <AdminSectionCard

--- a/src/components/admin/webhooks/WebhookOverviewApp.tsx
+++ b/src/components/admin/webhooks/WebhookOverviewApp.tsx
@@ -32,6 +32,7 @@ import {WEBHOOK_EVENT_TYPES, WEBHOOK_LIMITS} from "@/shared/Webhooks";
 
 interface Props {
   deploymentEnvironment?: "preview" | "production";
+  initialQuickstartMode?: FirstEndpointMode;
   instanceName?: string;
   localDevelopment?: boolean;
   overview: WebhookOverview;
@@ -55,14 +56,12 @@ async function requestJson(path: string, init?: RequestInit): Promise<any> {
 
 export default function WebhookOverviewApp({
   deploymentEnvironment = "production",
+  initialQuickstartMode = "no_code",
   instanceName = "<name>",
   localDevelopment = false,
   overview: initialOverview,
 }: Props) {
   const [overview, setOverview] = useState(initialOverview);
-  const [previewLanguage, setPreviewLanguage] =
-    useState<WebhookQuickstartLanguage>("javascript");
-  const quickstart = WEBHOOK_QUICKSTARTS[previewLanguage];
   const remaining = Math.max(
     overview.dailyLimit - overview.deliveriesToday,
     0,
@@ -198,244 +197,14 @@ export default function WebhookOverviewApp({
         </AdminSectionCard>
       )}
 
-      <AdminSectionCard
-        description={localDevelopment
-          ? "Run a complete receiver locally, create an endpoint, and send a real signed test."
-          : "Open a temporary public listener on this computer and send it a real signed test."}
-        title="Build and test your first endpoint"
-      >
-        {localDevelopment
-          ? <div className="grid gap-5 lg:grid-cols-[minmax(0,0.85fr)_minmax(22rem,1.15fr)]">
-            <div className="grid content-start gap-3 text-sm leading-6">
-              <QuickstartStep
-                description={`Create the ${quickstart.label} receiver project in the repository root.`}
-                number={1}
-                title={`Scaffold the ${quickstart.label} receiver`}
-              >
-                <p>
-                  From the microfeed repository root, run the command below. It
-                  writes to the ignored <code>.microfeed/webhooks/</code>
-                  {" "}workspace—not <code>packages/cli/.microfeed/</code>—and does
-                  not install or start anything.
-                </p>
-                <QuickstartCommand onCopy={copy} value={quickstart.scaffoldCommand} />
-                <p>
-                  After it starts in step 3, this receiver will listen at
-                  {" "}<code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
-                </p>
-              </QuickstartStep>
-
-              <QuickstartStep
-                description="Register the local URL and reveal its signing secret."
-                number={2}
-                title="Create the webhook endpoint"
-              >
-                <p>
-                  Open the prefilled endpoint form, enter a name, choose the
-                  events you want, and create the endpoint for
-                  {" "}<code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
-                </p>
-                <Button
-                  render={<a href={endpointCreateUrl} rel="noreferrer" target="_blank" />}
-                  size="sm"
-                >
-                  Create endpoint
-                </Button>
-                <p>
-                  Open <strong>Signing secret</strong> for the endpoint and
-                  reveal the <code>whsec_…</code> value. This is your
-                  {" "}<code>MICROFEED_WEBHOOK_SECRET</code>. It authenticates
-                  microfeed and detects changed request bytes, so no additional
-                  passcode is needed. You can return to reveal or rotate it
-                  later.
-                </p>
-              </QuickstartStep>
-
-              <QuickstartStep
-                description={`Install ${quickstart.label} dependencies and start the loopback server.`}
-                number={3}
-                title={`Install and run the ${quickstart.label} receiver`}
-              >
-                <p>
-                  In a terminal, enter the generated directory, install its
-                  dependencies, and replace <code>whsec_...</code> with the secret
-                  revealed in step 2.
-                </p>
-                <QuickstartCommand onCopy={copy} value={quickstart.directoryCommand} />
-                {quickstart.installCommands.map((command) => (
-                  <QuickstartCommand key={command} onCopy={copy} value={command} />
-                ))}
-                <QuickstartCommand onCopy={copy} value={quickstart.runCommand} />
-                <p>
-                  Keep this terminal open. It should print
-                  {" "}<code>Listening at {WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
-                </p>
-              </QuickstartStep>
-
-              <QuickstartStep
-                description="Send a signed webhook.test and confirm it reaches the terminal."
-                number={4}
-                title="Send and verify a test event"
-              >
-                <p>
-                  With the receiver still running, open Event Explorer. Select
-                  the endpoint from step 2 and <code>webhook.test</code>, keep the
-                  generated example, then choose <strong>Send test delivery</strong>
-                  {" "}and confirm the budgeted delivery.
-                </p>
-                <Button
-                  render={<a href={explorerUrl} rel="noreferrer" target="_blank" />}
-                  size="sm"
-                  variant="outline"
-                >
-                  Open Event Explorer
-                </Button>
-                <p>
-                  The receiver terminal should print the delivery ID, event type,
-                  {" "}<code>test: true</code>, duplicate status, and formatted
-                  payload. A <code>204</code> response marks the delivery as
-                  accepted in microfeed.
-                </p>
-              </QuickstartStep>
-            </div>
-            <div className="min-w-0">
-              <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-                <div className="flex gap-2" role="tablist" aria-label="Receiver language">
-                  {(["javascript", "python"] as const).map((language) => (
-                    <Button
-                      aria-selected={previewLanguage === language}
-                      key={language}
-                      onClick={() => setPreviewLanguage(language)}
-                      role="tab"
-                      size="sm"
-                      type="button"
-                      variant={previewLanguage === language ? "default" : "outline"}
-                    >
-                      {WEBHOOK_QUICKSTARTS[language].label}
-                    </Button>
-                  ))}
-                </div>
-                <Button
-                  onClick={() => void copy(quickstart.source, `${quickstart.label} receiver code`)}
-                  size="sm"
-                  type="button"
-                  variant="outline"
-                >
-                  <CopyIcon aria-hidden="true" className="size-4" />
-                  Copy {quickstart.filename}
-                </Button>
-              </div>
-              <AdminCodeEditor
-                ariaLabel={`${quickstart.label} webhook receiver code`}
-                code={quickstart.source}
-                language={quickstart.highlightLanguage}
-                maxHeight="36rem"
-                minHeight="36rem"
-                readOnly
-              />
-              <div className="mt-3 rounded-xl border border-amber-500/35 bg-amber-500/8 p-4 text-sm leading-6">
-                <p className="font-medium">Local inspector, not production infrastructure</p>
-                <p className="mt-1 text-muted-foreground">
-                  Duplicate state resets on restart, no job is durably queued,
-                  and production effects are intentionally absent. Add durable
-                  acknowledgement, background work, idempotency, loop
-                  prevention, approvals, audit logs, and cost alerts before
-                  deployment.
-                </p>
-              </div>
-            </div>
-          </div>
-          : <div className="grid max-w-4xl content-start gap-3 text-sm leading-6">
-            <QuickstartStep
-              description="Start a verified local inspector and expose it through a temporary public URL."
-              number={1}
-              title="Start the temporary webhook listener"
-            >
-              <p>
-                From the microfeed repository root, run the command below. It
-                starts a loopback listener and a free Cloudflare Quick Tunnel.
-                If <code>cloudflared</code> is unavailable, the CLI can download
-                a pinned, verified copy after asking for approval.
-              </p>
-              <QuickstartCommand onCopy={copy} value="yarn microfeed webhook listen --tunnel" />
-              <p>
-                Wait for <strong>Temporary public webhook endpoint</strong> and
-                copy the printed <code>https://…trycloudflare.com/webhook</code>
-                {" "}URL. Keep this terminal open; the URL exists only while the
-                command is running.
-              </p>
-            </QuickstartStep>
-
-            <QuickstartStep
-              description="Register the printed HTTPS URL and copy its endpoint-specific secret."
-              number={2}
-              title="Create the webhook endpoint"
-            >
-              <p>
-                In another tab, open Endpoints, choose <strong>Add endpoint</strong>,
-                paste the exact public URL from step 1, enter a name, and select
-                the events you want to test.
-              </p>
-              <Button
-                render={<a href={endpointUrl} rel="noreferrer" target="_blank" />}
-                size="sm"
-              >
-                Open Endpoints
-              </Button>
-              <p>
-                After creation, copy the one-time <code>whsec_…</code> signing
-                secret. If you close it, use the endpoint's
-                {" "}<strong>Signing secret</strong> action to reveal it again.
-              </p>
-            </QuickstartStep>
-
-            <QuickstartStep
-              description="Authenticate the listener before it accepts or prints deliveries."
-              number={3}
-              title="Enter the signing secret"
-            >
-              <p>
-                Return to the listener terminal, paste the signing secret into
-                its prompt, and submit it. The CLI does not print the secret.
-                Wait for <strong>Listening for verified microfeed webhooks</strong>.
-              </p>
-            </QuickstartStep>
-
-            <QuickstartStep
-              description="Send a signed webhook.test and confirm it reaches the terminal."
-              number={4}
-              title="Send and verify a test event"
-            >
-              <p>
-                With the receiver still running, open Event Explorer. Select
-                the endpoint from step 2 and <code>webhook.test</code>, keep the
-                generated example, then choose <strong>Send test delivery</strong>
-                {" "}and confirm the budgeted delivery.
-              </p>
-              <Button
-                render={<a href={explorerUrl} rel="noreferrer" target="_blank" />}
-                size="sm"
-                variant="outline"
-              >
-                Open Event Explorer
-              </Button>
-              <p>
-                The receiver terminal should print the delivery ID, event type,
-                {" "}<code>test: true</code>, duplicate status, and formatted
-                payload. A <code>204</code> response marks the delivery as
-                accepted in microfeed.
-              </p>
-            </QuickstartStep>
-            <div className="rounded-xl border border-amber-500/35 bg-amber-500/8 p-4">
-              <p className="font-medium">Temporary testing only</p>
-              <p className="mt-1 text-muted-foreground">
-                Quick Tunnels have no uptime guarantee and are not a deployed
-                receiver. Pressing Ctrl+C stops the listener and tunnel. Delete
-                the temporary endpoint afterward; the next run receives a new URL.
-              </p>
-            </div>
-          </div>}
-      </AdminSectionCard>
+      <FirstEndpointQuickstart
+        endpointCreateUrl={endpointCreateUrl}
+        endpointUrl={endpointUrl}
+        explorerUrl={explorerUrl}
+        initialMode={initialQuickstartMode}
+        localDevelopment={localDevelopment}
+        onCopy={copy}
+      />
 
       <AdminSectionCard
         description={`${WEBHOOK_EVENT_TYPES.length} versioned event types are documented in this instance's generated OpenAPI contract.`}
@@ -454,6 +223,379 @@ export default function WebhookOverviewApp({
         </div>
       </AdminSectionCard>
     </div>
+  );
+}
+
+type FirstEndpointMode = "code" | "no_code";
+
+const LOCAL_LISTENER_ENDPOINT_URL = "http://127.0.0.1:8978/webhook";
+const PUBLIC_RECEIVER_ENDPOINT_EXAMPLE = "https://hooks.example.com/webhook";
+
+function deployedReceiverSource(
+  language: WebhookQuickstartLanguage,
+): string {
+  const source = WEBHOOK_QUICKSTARTS[language].source.replaceAll(
+    "this local inspector",
+    "this starter",
+  );
+  if (language === "javascript") {
+    return source.replace(
+      [
+        'app.listen(3000, "127.0.0.1", () => {',
+        '  console.log("Listening at http://127.0.0.1:3000/webhook");',
+        "});",
+        "",
+      ].join("\n"),
+      [
+        "const port = Number(process.env.PORT ?? 3000);",
+        "",
+        'app.listen(port, "0.0.0.0", () => {',
+        "  console.log(`Listening on port ${port}; expose /webhook through HTTPS.`);",
+        "});",
+        "",
+      ].join("\n"),
+    );
+  }
+  return source.replace(
+    '    app.run(host="127.0.0.1", port=3000)',
+    [
+      '    port = int(os.environ.get("PORT", "3000"))',
+      '    app.run(host="0.0.0.0", port=port)',
+    ].join("\n"),
+  );
+}
+
+function FirstEndpointQuickstart({
+  endpointCreateUrl,
+  endpointUrl,
+  explorerUrl,
+  initialMode,
+  localDevelopment,
+  onCopy,
+}: {
+  endpointCreateUrl: string;
+  endpointUrl: string;
+  explorerUrl: string;
+  initialMode: FirstEndpointMode;
+  localDevelopment: boolean;
+  onCopy: (value: string, label: string) => Promise<void>;
+}) {
+  const [mode, setMode] = useState<FirstEndpointMode>(initialMode);
+  const [language, setLanguage] =
+    useState<WebhookQuickstartLanguage>("javascript");
+  const quickstart = WEBHOOK_QUICKSTARTS[language];
+  const receiverSource = localDevelopment
+    ? quickstart.source
+    : deployedReceiverSource(language);
+
+  return (
+    <AdminSectionCard
+      description={mode === "no_code"
+        ? localDevelopment
+          ? "Inspect signed events immediately with the local CLI listener—no receiver code required."
+          : "Inspect a real signed delivery on this computer through a temporary public tunnel—no receiver code required."
+        : localDevelopment
+        ? "Scaffold a complete local receiver, create an endpoint, and send a real signed test."
+        : "Start from a complete receiver, deploy it at a public HTTPS address, and send a real signed test."}
+      title="Build and test your first endpoint"
+    >
+      <div className="mb-5 flex flex-wrap gap-2" role="tablist" aria-label="Webhook testing mode">
+        <Button
+          aria-selected={mode === "no_code"}
+          onClick={() => setMode("no_code")}
+          role="tab"
+          size="sm"
+          type="button"
+          variant={mode === "no_code" ? "default" : "outline"}
+        >
+          No-code testing
+        </Button>
+        <Button
+          aria-selected={mode === "code"}
+          onClick={() => setMode("code")}
+          role="tab"
+          size="sm"
+          type="button"
+          variant={mode === "code" ? "default" : "outline"}
+        >
+          Build with code
+        </Button>
+      </div>
+
+      {mode === "no_code"
+        ? <NoCodeQuickstart
+          endpointUrl={endpointUrl}
+          explorerUrl={explorerUrl}
+          localDevelopment={localDevelopment}
+          onCopy={onCopy}
+        />
+        : <div className="grid gap-5 lg:grid-cols-[minmax(0,0.85fr)_minmax(22rem,1.15fr)]">
+          <div className="grid content-start gap-3 text-sm leading-6">
+            <QuickstartStep
+              description={`Create the ${quickstart.label} receiver project in the repository root.`}
+              number={1}
+              title={`Scaffold the ${quickstart.label} receiver`}
+            >
+              <p>
+                From the microfeed repository root, run the command below. It
+                writes to the ignored <code>.microfeed/webhooks/</code>
+                {" "}workspace—not <code>packages/cli/.microfeed/</code>—and does
+                not install or start anything.
+              </p>
+              <QuickstartCommand onCopy={onCopy} value={quickstart.scaffoldCommand} />
+              {localDevelopment
+                ? <p>
+                  After it starts in step 3, this receiver will listen at
+                  {" "}<code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.
+                </p>
+                : <p>
+                  Before deploying, replace the generated server file with the
+                  public-host version shown here. It binds to
+                  {" "}<code>0.0.0.0</code> and honors the hosting platform's
+                  {" "}<code>PORT</code>. Never register <code>0.0.0.0</code>
+                  {" "}as the endpoint URL.
+                </p>}
+            </QuickstartStep>
+
+            <QuickstartStep
+              description={localDevelopment
+                ? "Register the local URL and reveal its signing secret."
+                : "Register the receiver's public HTTPS URL and reveal its signing secret."}
+              number={2}
+              title="Create the webhook endpoint"
+            >
+              <p>
+                {localDevelopment
+                  ? <>Open the prefilled endpoint form, enter a name, choose the events you want, and create the endpoint for <code>{WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.</>
+                  : <>Reserve or choose the public HTTPS address from your hosting platform, such as <code>{PUBLIC_RECEIVER_ENDPOINT_EXAMPLE}</code>. Open Endpoints, choose <strong>Add endpoint</strong>, and paste that exact public URL.</>}
+              </p>
+              <Button
+                render={<a href={localDevelopment ? endpointCreateUrl : endpointUrl} rel="noreferrer" target="_blank" />}
+                size="sm"
+              >
+                {localDevelopment ? "Create endpoint" : "Open Endpoints"}
+              </Button>
+              <p>
+                Open <strong>Signing secret</strong> and reveal the
+                {" "}<code>whsec_…</code> value. Store it as
+                {" "}<code>MICROFEED_WEBHOOK_SECRET</code>. It authenticates
+                microfeed and detects changed request bytes, so no additional
+                passcode is needed.
+              </p>
+            </QuickstartStep>
+
+            <QuickstartStep
+              description={localDevelopment
+                ? `Install ${quickstart.label} dependencies and start the loopback server.`
+                : `Install ${quickstart.label} dependencies and deploy the public receiver.`}
+              number={3}
+              title={localDevelopment
+                ? `Install and run the ${quickstart.label} receiver`
+                : `Configure and deploy the ${quickstart.label} receiver`}
+            >
+              <p>
+                Enter the generated directory and install its dependencies.
+              </p>
+              <QuickstartCommand onCopy={onCopy} value={quickstart.directoryCommand} />
+              {quickstart.installCommands.map((command) => (
+                <QuickstartCommand key={command} onCopy={onCopy} value={command} />
+              ))}
+              {localDevelopment
+                ? <>
+                  <p>Replace <code>whsec_...</code> with the secret revealed in step 2.</p>
+                  <QuickstartCommand onCopy={onCopy} value={quickstart.runCommand} />
+                  <p>Keep this terminal open. It should print <code>Listening at {WEBHOOK_QUICKSTART_ENDPOINT_URL}</code>.</p>
+                </>
+                : <>
+                  <p>
+                    Add <code>MICROFEED_WEBHOOK_SECRET</code> through the hosting
+                    platform's secret settings, use
+                    {" "}<code>{language === "javascript" ? "yarn start" : "python server.py"}</code>
+                    {" "}as the start command, and deploy. The platform should
+                    terminate HTTPS and route <code>/webhook</code> to this process.
+                  </p>
+                  <p>
+                    Confirm that the public URL from step 2 responds. Do not put
+                    the secret in source code, the endpoint URL, or a shell command.
+                  </p>
+                </>}
+            </QuickstartStep>
+
+            <TestEventStep explorerUrl={explorerUrl} />
+          </div>
+
+          <div className="min-w-0">
+            <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex gap-2" role="tablist" aria-label="Receiver language">
+                {(["javascript", "python"] as const).map((value) => (
+                  <Button
+                    aria-selected={language === value}
+                    key={value}
+                    onClick={() => setLanguage(value)}
+                    role="tab"
+                    size="sm"
+                    type="button"
+                    variant={language === value ? "default" : "outline"}
+                  >
+                    {WEBHOOK_QUICKSTARTS[value].label}
+                  </Button>
+                ))}
+              </div>
+              <Button
+                onClick={() => void onCopy(receiverSource, `${quickstart.label} receiver code`)}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                <CopyIcon aria-hidden="true" className="size-4" />
+                Copy {quickstart.filename}
+              </Button>
+            </div>
+            <AdminCodeEditor
+              ariaLabel={`${quickstart.label} webhook receiver code`}
+              code={receiverSource}
+              language={quickstart.highlightLanguage}
+              maxHeight="36rem"
+              minHeight="36rem"
+              readOnly
+            />
+            <div className="mt-3 rounded-xl border border-amber-500/35 bg-amber-500/8 p-4 text-sm leading-6">
+              <p className="font-medium">Starter receiver, not production architecture</p>
+              <p className="mt-1 text-muted-foreground">
+                Duplicate state resets on restart, no job is durably queued,
+                and production effects are intentionally absent. Add durable
+                acknowledgement, background work, idempotency, loop
+                prevention, approvals, audit logs, and cost alerts before
+                production use.
+              </p>
+            </div>
+          </div>
+        </div>}
+    </AdminSectionCard>
+  );
+}
+
+function NoCodeQuickstart({
+  endpointUrl,
+  explorerUrl,
+  localDevelopment,
+  onCopy,
+}: {
+  endpointUrl: string;
+  explorerUrl: string;
+  localDevelopment: boolean;
+  onCopy: (value: string, label: string) => Promise<void>;
+}) {
+  const listenCommand = localDevelopment
+    ? "yarn microfeed webhook listen"
+    : "yarn microfeed webhook listen --tunnel";
+
+  return (
+    <div className="grid max-w-4xl content-start gap-3 text-sm leading-6">
+      <QuickstartStep
+        description={localDevelopment
+          ? "Start the verified inspector on this computer."
+          : "Start the verified inspector and expose it through a temporary public URL."}
+        number={1}
+        title={localDevelopment
+          ? "Start the local webhook listener"
+          : "Start the temporary webhook listener"}
+      >
+        <p>
+          From the microfeed repository root, run the command below. It starts
+          a verified inspector and waits for the endpoint signing secret.
+          {!localDevelopment && <> It also starts a free Cloudflare Quick Tunnel. If <code>cloudflared</code> is unavailable, the CLI can download a pinned, verified copy after asking for approval.</>}
+        </p>
+        <QuickstartCommand onCopy={onCopy} value={listenCommand} />
+        {localDevelopment
+          ? <p>Leave the terminal waiting at the signing-secret prompt. The listener will use <code>{LOCAL_LISTENER_ENDPOINT_URL}</code>.</p>
+          : <p>Wait for <strong>Temporary public webhook endpoint</strong>. The CLI prints an exact URL like <code>https://…trycloudflare.com/webhook</code> before asking for the secret. Keep this terminal open.</p>}
+      </QuickstartStep>
+
+      <QuickstartStep
+        description={localDevelopment
+          ? "Copy the loopback URL into a new endpoint and reveal its signing secret."
+          : "Copy the exact Quick Tunnel URL into a new endpoint and reveal its signing secret."}
+        number={2}
+        title="Create the webhook endpoint"
+      >
+        {localDevelopment
+          ? <>
+            <p>Copy this URL, open Endpoints in another tab, choose <strong>Add endpoint</strong>, and paste it into <strong>Endpoint URL</strong>.</p>
+            <QuickstartCommand copyLabel="Endpoint URL" onCopy={onCopy} value={LOCAL_LISTENER_ENDPOINT_URL} />
+          </>
+          : <p>
+            Copy the complete <code>https://…trycloudflare.com/webhook</code>
+            {" "}URL printed by step 1. Open Endpoints in another tab, choose
+            {" "}<strong>Add endpoint</strong>, and paste that exact value into
+            {" "}<strong>Endpoint URL</strong>. The example text is not a real URL.
+          </p>}
+        <Button
+          render={<a href={endpointUrl} rel="noreferrer" target="_blank" />}
+          size="sm"
+        >
+          Open Endpoints
+        </Button>
+        <p>
+          After creation, copy the one-time <code>whsec_…</code> signing secret.
+          If you close it, use the endpoint's <strong>Signing secret</strong>
+          {" "}action to reveal it again.
+        </p>
+      </QuickstartStep>
+
+      <QuickstartStep
+        description="Authenticate the listener before it accepts or prints deliveries."
+        number={3}
+        title="Enter the signing secret"
+      >
+        <p>
+          Return to the listener terminal, paste the signing secret into its
+          prompt, and submit it. The CLI does not print the secret. Wait for
+          {" "}<strong>Listening for verified microfeed webhooks</strong>.
+        </p>
+      </QuickstartStep>
+
+      <TestEventStep explorerUrl={explorerUrl} />
+
+      {!localDevelopment && (
+        <div className="rounded-xl border border-amber-500/35 bg-amber-500/8 p-4">
+          <p className="font-medium">Temporary testing only</p>
+          <p className="mt-1 text-muted-foreground">
+            Quick Tunnels have no uptime guarantee and are not a deployed
+            receiver. Pressing Ctrl+C stops the listener and tunnel. Delete
+            the temporary endpoint afterward; the next run receives a new URL.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TestEventStep({explorerUrl}: {explorerUrl: string}) {
+  return (
+    <QuickstartStep
+      description="Send a signed webhook.test and confirm it reaches the receiver."
+      number={4}
+      title="Send and verify a test event"
+    >
+      <p>
+        Open Event Explorer. Select the endpoint from step 2 and
+        {" "}<code>webhook.test</code>, keep the generated example, then choose
+        {" "}<strong>Send test delivery</strong> and confirm the budgeted delivery.
+      </p>
+      <Button
+        render={<a href={explorerUrl} rel="noreferrer" target="_blank" />}
+        size="sm"
+        variant="outline"
+      >
+        Open Event Explorer
+      </Button>
+      <p>
+        The terminal should print the delivery ID, event type,
+        {" "}<code>test: true</code>, duplicate status, and formatted payload.
+        A <code>204</code> response marks the delivery as accepted.
+      </p>
+    </QuickstartStep>
   );
 }
 

--- a/tests/unit/components/admin-webhooks.test.ts
+++ b/tests/unit/components/admin-webhooks.test.ts
@@ -136,49 +136,22 @@ describe("Webhook Admin", () => {
     );
     expect(quickstartSection.match(/<details /gu)).toHaveLength(4);
     expect(quickstartSection).not.toContain("<details open");
-    expect(output).toContain(".microfeed/webhooks/");
-    expect(output).toContain("packages/cli/.microfeed/");
-    expect(output).toContain(
-      'href="/admin/webhooks/endpoints/?quickstart=1"',
-    );
-    expect(output).toContain("This is your");
-    expect(output).toContain("MICROFEED_WEBHOOK_SECRET");
-    expect(output).toContain("Scaffold the JavaScript receiver");
+    expect(output).toContain("yarn microfeed webhook listen --tunnel");
+    expect(output).toContain("Temporary public webhook endpoint");
+    expect(output).toContain("https://…trycloudflare.com/webhook");
+    expect(output).toContain('href="/admin/webhooks/endpoints/"');
+    expect(output).toContain("Start the temporary webhook listener");
     expect(output).toContain("Create the webhook endpoint");
-    expect(output).toContain("Install and run the JavaScript receiver");
+    expect(output).toContain("Enter the signing secret");
     expect(output).toContain("Send and verify a test event");
-    expect(output).toContain(WEBHOOK_QUICKSTARTS.javascript.scaffoldCommand);
-    expect(output).toContain(WEBHOOK_QUICKSTARTS.javascript.directoryCommand);
-    expect(output).toContain(WEBHOOK_QUICKSTARTS.javascript.runCommand);
-    expect(output).toContain("Copy server.cjs");
-    expect(output).toContain(
-      'aria-label="JavaScript webhook receiver code"',
-    );
-    expect(output).toContain("language-js");
-    expect(output).toContain('class="token keyword"');
-    expect(output).toContain("readonly=\"\"");
-    expect(output).toContain('app.listen(3000, &quot;127.0.0.1&quot;');
+    expect(output).toContain("Quick Tunnels have no uptime guarantee");
     expect(output).toContain(
       'href="/admin/webhooks/events/?event=webhook.test"',
     );
+    expect(output).not.toContain(".microfeed/webhooks/");
+    expect(output).not.toContain("Receiver language");
     expect(output).not.toContain("Open endpoint quickstart");
     expect(output).not.toContain("Endpoint quickstart");
-    expect(WEBHOOK_QUICKSTARTS.javascript.scaffoldCommand).toContain(
-      ".microfeed/webhooks/endpoint1 --language javascript",
-    );
-    expect(WEBHOOK_QUICKSTARTS.javascript.highlightLanguage).toBe("js");
-    expect(WEBHOOK_QUICKSTARTS.python.scaffoldCommand).toContain(
-      ".microfeed/webhooks/endpoint1 --language python",
-    );
-    expect(WEBHOOK_QUICKSTARTS.python.highlightLanguage).toBe("python");
-    expect(WEBHOOK_QUICKSTARTS.python.installCommands).toEqual([
-      "python3 -m venv .venv",
-      ". .venv/bin/activate",
-      "pip install -r requirements.txt",
-    ]);
-    expect(WEBHOOK_QUICKSTARTS.python.runCommand).toContain("python server.py");
-    expect(output).toContain("no additional");
-    expect(output).toContain("passcode is needed");
     expect(output).toContain("Content automation guide");
 
     const disabledOutput = renderToStaticMarkup(React.createElement(
@@ -229,6 +202,67 @@ describe("Webhook Admin", () => {
     expect(retainedOutput).toContain(
       "yarn manage deploy --enable-webhooks --instance personal",
     );
+  });
+
+  it("keeps the scaffolded receiver quickstart in local development", () => {
+    const output = renderToStaticMarkup(React.createElement(WebhookOverviewApp, {
+      localDevelopment: true,
+      overview: {
+        activeEndpoints: 0,
+        alerts: [],
+        dailyLimit: 1_000,
+        deliveriesToday: 0,
+        enabled: true,
+        infrastructureState: "enabled",
+        endpointLimit: 20,
+        endpoints: 0,
+        estimatedQueueOperationsToday: 0,
+        recentFailures: 0,
+      },
+    }));
+    const quickstartSection = output.slice(
+      output.indexOf("Build and test your first endpoint"),
+      output.indexOf("Use webhooks safely"),
+    );
+    expect(quickstartSection.match(/<details /gu)).toHaveLength(4);
+    expect(output).toContain("Webhook simulation is running locally");
+    expect(output).toContain(".microfeed/webhooks/");
+    expect(output).toContain("packages/cli/.microfeed/");
+    expect(output).toContain(
+      'href="/admin/webhooks/endpoints/?quickstart=1"',
+    );
+    expect(output).toContain("This is your");
+    expect(output).toContain("MICROFEED_WEBHOOK_SECRET");
+    expect(output).toContain("Scaffold the JavaScript receiver");
+    expect(output).toContain("Install and run the JavaScript receiver");
+    expect(output).toContain(WEBHOOK_QUICKSTARTS.javascript.scaffoldCommand);
+    expect(output).toContain(WEBHOOK_QUICKSTARTS.javascript.directoryCommand);
+    expect(output).toContain(WEBHOOK_QUICKSTARTS.javascript.runCommand);
+    expect(output).toContain("Copy server.cjs");
+    expect(output).toContain(
+      'aria-label="JavaScript webhook receiver code"',
+    );
+    expect(output).toContain("language-js");
+    expect(output).toContain('class="token keyword"');
+    expect(output).toContain("readonly=\"\"");
+    expect(output).toContain('app.listen(3000, &quot;127.0.0.1&quot;');
+    expect(output).not.toContain("yarn microfeed webhook listen --tunnel");
+    expect(WEBHOOK_QUICKSTARTS.javascript.scaffoldCommand).toContain(
+      ".microfeed/webhooks/endpoint1 --language javascript",
+    );
+    expect(WEBHOOK_QUICKSTARTS.javascript.highlightLanguage).toBe("js");
+    expect(WEBHOOK_QUICKSTARTS.python.scaffoldCommand).toContain(
+      ".microfeed/webhooks/endpoint1 --language python",
+    );
+    expect(WEBHOOK_QUICKSTARTS.python.highlightLanguage).toBe("python");
+    expect(WEBHOOK_QUICKSTARTS.python.installCommands).toEqual([
+      "python3 -m venv .venv",
+      ". .venv/bin/activate",
+      "pip install -r requirements.txt",
+    ]);
+    expect(WEBHOOK_QUICKSTARTS.python.runCommand).toContain("python server.py");
+    expect(output).toContain("no additional");
+    expect(output).toContain("passcode is needed");
   });
 
   it("renders signing-secret, endpoint-limit, pause recovery, filters, and redelivery controls", () => {

--- a/tests/unit/components/admin-webhooks.test.ts
+++ b/tests/unit/components/admin-webhooks.test.ts
@@ -95,7 +95,30 @@ describe("Webhook Admin", () => {
     expect(output).toContain("Print in yarn dev");
     expect(output).toContain("Subscription mismatch");
     expect(output).toContain("1,000-delivery daily budget");
+    expect(output).toContain('aria-label="Payload JSON"');
+    expect(output).toContain("language-json");
     expect(output).not.toContain("Endpoint quickstart");
+
+    const activeEndpoint = {
+      ...endpoint,
+      id: "whe_active_latest",
+      name: "Latest active endpoint",
+      status: "active" as const,
+    };
+    const defaultEndpointOutput = renderToStaticMarkup(React.createElement(
+      WebhookEventExplorerApp,
+      {
+        endpoints: [
+          {...endpoint, id: "whe_disabled_newest", status: "disabled" as const},
+          activeEndpoint,
+          {...activeEndpoint, id: "whe_active_older", name: "Older active endpoint"},
+        ],
+        localPrintAvailable: false,
+      },
+    ));
+    expect(defaultEndpointOutput).toContain(
+      '<option value="whe_active_latest" selected="">Latest active endpoint — active</option>',
+    );
   });
 
   it("shows cost, failure, event, and setup guidance on the overview", () => {
@@ -130,6 +153,8 @@ describe("Webhook Admin", () => {
     expect(output).toContain("Enable or stop webhooks");
     expect(output).toContain("Standard Webhooks");
     expect(output).toContain("Build and test your first endpoint");
+    expect(output).toContain("No-code testing");
+    expect(output).toContain("Build with code");
     const quickstartSection = output.slice(
       output.indexOf("Build and test your first endpoint"),
       output.indexOf("Use webhooks safely"),
@@ -153,6 +178,31 @@ describe("Webhook Admin", () => {
     expect(output).not.toContain("Open endpoint quickstart");
     expect(output).not.toContain("Endpoint quickstart");
     expect(output).toContain("Content automation guide");
+
+    const publicCodeOutput = renderToStaticMarkup(React.createElement(
+      WebhookOverviewApp,
+      {
+        initialQuickstartMode: "code",
+        overview: {
+          activeEndpoints: 1,
+          alerts: [],
+          dailyLimit: 1_000,
+          deliveriesToday: 0,
+          enabled: true,
+          infrastructureState: "enabled",
+          endpointLimit: 20,
+          endpoints: 1,
+          estimatedQueueOperationsToday: 0,
+          recentFailures: 0,
+        },
+      },
+    ));
+    expect(publicCodeOutput).toContain("https://hooks.example.com/webhook");
+    expect(publicCodeOutput).toContain("0.0.0.0");
+    expect(publicCodeOutput).toContain("process.env.PORT");
+    expect(publicCodeOutput).not.toContain(
+      'app.listen(3000, &quot;127.0.0.1&quot;',
+    );
 
     const disabledOutput = renderToStaticMarkup(React.createElement(
       WebhookOverviewApp,
@@ -206,6 +256,7 @@ describe("Webhook Admin", () => {
 
   it("keeps the scaffolded receiver quickstart in local development", () => {
     const output = renderToStaticMarkup(React.createElement(WebhookOverviewApp, {
+      initialQuickstartMode: "code",
       localDevelopment: true,
       overview: {
         activeEndpoints: 0,
@@ -231,7 +282,7 @@ describe("Webhook Admin", () => {
     expect(output).toContain(
       'href="/admin/webhooks/endpoints/?quickstart=1"',
     );
-    expect(output).toContain("This is your");
+    expect(output).toContain("Store it as");
     expect(output).toContain("MICROFEED_WEBHOOK_SECRET");
     expect(output).toContain("Scaffold the JavaScript receiver");
     expect(output).toContain("Install and run the JavaScript receiver");
@@ -263,6 +314,28 @@ describe("Webhook Admin", () => {
     expect(WEBHOOK_QUICKSTARTS.python.runCommand).toContain("python server.py");
     expect(output).toContain("no additional");
     expect(output).toContain("passcode is needed");
+
+    const noCodeOutput = renderToStaticMarkup(React.createElement(
+      WebhookOverviewApp,
+      {
+        localDevelopment: true,
+        overview: {
+          activeEndpoints: 0,
+          alerts: [],
+          dailyLimit: 1_000,
+          deliveriesToday: 0,
+          enabled: true,
+          infrastructureState: "enabled",
+          endpointLimit: 20,
+          endpoints: 0,
+          estimatedQueueOperationsToday: 0,
+          recentFailures: 0,
+        },
+      },
+    ));
+    expect(noCodeOutput).toContain("yarn microfeed webhook listen");
+    expect(noCodeOutput).toContain("http://127.0.0.1:8978/webhook");
+    expect(noCodeOutput).not.toContain("--tunnel");
   });
 
   it("renders signing-secret, endpoint-limit, pause recovery, filters, and redelivery controls", () => {
@@ -277,7 +350,11 @@ describe("Webhook Admin", () => {
     expect(endpoints).toContain("10 consecutive terminal failures");
     expect(endpoints).toContain("Send a successful test");
     expect(endpoints).toContain(">Resume<");
+    expect(endpoints).toContain("Auto-paused");
+    expect(endpoints).toContain('role="switch"');
     expect(endpoints).toContain("Signing secret");
+    expect(endpoints).not.toContain(">Disable</button>");
+    expect(endpoints).not.toContain(">Enable</button>");
     expect(endpoints).not.toContain(">Rotate secret</button>");
     expect(endpoints).not.toContain("Endpoint quickstart");
     const source = readFileSync(new URL(
@@ -288,6 +365,17 @@ describe("Webhook Admin", () => {
     expect(source).toContain("Copy signing secret");
     expect(source).toContain("Rotate signing secret");
     expect(source).toContain("previous secret remains valid for 24 hours");
+
+    const activeEndpoints = renderToStaticMarkup(React.createElement(
+      WebhookEndpointsApp,
+      {
+        enabled: true,
+        initialEndpoints: [{...endpoint, status: "active" as const}],
+      },
+    ));
+    expect(activeEndpoints).toContain("Active");
+    expect(activeEndpoints).toContain('data-checked=""');
+    expect(activeEndpoints).not.toContain(">Disable</button>");
 
     const emptyEndpoints = renderToStaticMarkup(React.createElement(WebhookEndpointsApp, {
       enabled: true,
@@ -337,5 +425,43 @@ describe("Webhook Admin", () => {
     expect(deliveries).toContain("All statuses");
     expect(deliveries).toContain("6 attempts");
     expect(deliveries).toContain("Payload, correlation chain");
+    expect(deliveries).toContain("text-red-700");
+
+    const successfulDelivery = {
+      attemptCount: 1,
+      completedAt: "2026-08-14T12:00:00.000Z",
+      createdAt: "2026-08-14T12:00:00.000Z",
+      endpointId: endpoint.id,
+      endpointName: endpoint.name,
+      endpointUrl: endpoint.url,
+      eventId: "evt_success",
+      eventType: "webhook.test" as const,
+      id: "whd_success",
+      isManual: false,
+      isTest: true,
+      responseStatus: 204,
+      status: "succeeded" as const,
+    };
+    const successfulDetails = renderToStaticMarkup(React.createElement(
+      WebhookDeliveriesApp,
+      {
+        endpoints: [endpoint],
+        initialDeliveries: [successfulDelivery],
+        initialSelected: {
+          ...successfulDelivery,
+          attempts: [{
+            attemptNumber: 1,
+            createdAt: "2026-08-14T12:00:00.000Z",
+            durationMs: 25,
+            outcome: "succeeded",
+            responseStatus: 204,
+          }],
+          payload: {test: true, type: "webhook.test"},
+        },
+      },
+    ));
+    expect(successfulDetails).toContain("text-emerald-700");
+    expect(successfulDetails).toContain(">succeeded</span>");
+    expect(successfulDetails).toContain(">204</span>");
   });
 });


### PR DESCRIPTION
## Summary

- offer adaptive No-code testing and Build with code paths on the webhook overview
- use the plain verified CLI listener locally and `yarn microfeed webhook listen --tunnel` for deployed sites
- make the tunnel URL handoff, signing-secret entry, and Event Explorer test sequence explicit
- color delivery, attempt, and HTTP response statuses semantically
- default Event Explorer to the newest active endpoint and syntax-highlight its exact JSON contract
- replace endpoint status badges and Enable/Disable buttons with an accessible status switch

## Related issue

N/A

## Testing

- [x] `yarn check`
- [x] `yarn vitest run tests/unit/components/admin-webhooks.test.ts`
- [x] `git diff --check`

## Screenshots

N/A. Both local and deployed rendering paths and the updated Admin states are covered by focused server-rendered component tests; no repository screenshot was added.

## Risks

Low. This changes Admin presentation and onboarding behavior. Webhook delivery semantics, endpoint APIs, budgets, signatures, and CLI behavior are unchanged.

## Checklist

- [x] This pull request contains one focused webhook Admin UX change.
- [x] Tests were added or updated when behavior changed.
- [x] No public command or API contract changed; existing CLI documentation already covers the listener and tunnel workflow.
- [x] No secrets, private configuration, production data, or generated files are included.