### PR TITLE
Detach Queue consumers when disabling webhooks

### DIFF
--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -2815,6 +2815,63 @@ async function cancelPendingWebhookDeliveries(
   await context.cloudflare.queryD1(config, WEBHOOK_CANCEL_PENDING_SQL);
 }
 
+function verifiedWebhookQueueConsumers(
+  consumers: QueueConsumer[],
+  targetWorkerName: string,
+): QueueConsumer[] {
+  const expected = consumers.filter(({scriptName, type}) =>
+    type === "worker" && scriptName === targetWorkerName
+  );
+  const unexpected = consumers.filter((consumer) =>
+    !expected.includes(consumer)
+  );
+  if (unexpected.length > 0 || expected.length > 1) {
+    const summary = consumers.map(({id, scriptName, type}) =>
+      `${type}:${scriptName ?? "unknown"} (${id})`
+    ).join(", ");
+    throw new Error(
+      `Webhook Queue has an unexpected consumer configuration: ${summary}. ` +
+        `microfeed will detach only the single Worker consumer named ` +
+        `\`${targetWorkerName}\`. No Queue consumers were detached.`,
+    );
+  }
+  return expected;
+}
+
+async function detachWebhookQueueConsumer(
+  context: CommandContext,
+  config: MicrofeedConfig,
+): Promise<number> {
+  const accountId = cloudflareAccountId(config);
+  const queue = await verifiedWebhookQueue(context, config);
+  const consumers = await context.cloudflare.queueConsumers(
+    accountId,
+    queue.id,
+  );
+  const expectedConsumers = verifiedWebhookQueueConsumers(
+    consumers,
+    workerName(config),
+  );
+  for (const consumer of expectedConsumers) {
+    await context.cloudflare.deleteQueueConsumer(
+      accountId,
+      queue.id,
+      consumer.id,
+    );
+  }
+  const remainingConsumers = await context.cloudflare.queueConsumers(
+    accountId,
+    queue.id,
+  );
+  if (remainingConsumers.length > 0) {
+    throw new Error(
+      `Cloudflare still reports a consumer for webhook Queue ${queue.name}. ` +
+        "The Queue was retained and no other webhook resource was changed.",
+    );
+  }
+  return expectedConsumers.length;
+}
+
 async function disabledWebhookDeploymentIsVerified(
   context: CommandContext,
   config: MicrofeedConfig,
@@ -2833,6 +2890,21 @@ async function disabledWebhookDeploymentIsVerified(
   );
   return queue.deliveryPaused && metrics?.backlogCount === 0 && !bound &&
     consumers.length === 0 && schedules.length === 0;
+}
+
+async function webhookDisableDeploymentIsDetached(
+  context: CommandContext,
+  config: MicrofeedConfig,
+): Promise<boolean> {
+  const accountId = cloudflareAccountId(config);
+  const [bindings, schedules] = await Promise.all([
+    context.cloudflare.workerBindings(accountId, workerName(config)),
+    context.cloudflare.workerSchedules(accountId, workerName(config)),
+  ]);
+  const bound = bindings.some(({name, type}) =>
+    name === "WEBHOOK_QUEUE" && type === "queue"
+  );
+  return !bound && schedules.length === 0;
 }
 
 async function enabledWebhookDeploymentIsVerified(
@@ -2974,6 +3046,7 @@ export async function deployCommand(
     config.webhooks?.transition === "disabling";
   let finishWebhookEnable = enableWebhooks ||
     config.webhooks?.transition === "enabling";
+  let resumeDetachedWebhookDisable = false;
 
   if (enableWebhooks && config.webhooks?.transition === "disabling") {
     throw new Error(
@@ -3033,9 +3106,23 @@ export async function deployCommand(
       );
       return;
     } else {
+      const resumingDisable = config.webhooks?.transition === "disabling";
       const queue = await verifiedWebhookQueue(context, config);
-      await context.cloudflare.pauseQueue(accountId, queue.name);
-      await context.cloudflare.applyMigrations(config);
+      if (!queue.deliveryPaused) {
+        await context.cloudflare.pauseQueue(accountId, queue.name);
+      }
+      if (
+        resumingDisable && !enableR2 &&
+        await webhookDisableDeploymentIsDetached(context, config)
+      ) {
+        resumeDetachedWebhookDisable = true;
+        prompts.log.info(
+          "Webhook Queue binding and Cron are already removed; continuing " +
+            "the interrupted disable without redeploying the Worker.",
+        );
+      } else {
+        await context.cloudflare.applyMigrations(config);
+      }
       await cancelPendingWebhookDeliveries(context, config);
       config.webhooks!.state = "disabled";
       config.webhooks!.transition = "disabling";
@@ -3043,40 +3130,51 @@ export async function deployCommand(
       await generateWranglerConfig(config);
     }
   }
-  const pages = await context.cloudflare.pagesProjects(accountId);
-  const targetWorkerName = workerName(config);
-  if (pages.includes(targetWorkerName)) {
-    throw new Error(pagesCollisionMessage(targetWorkerName));
-  }
-  const enabledR2Now = await prepareR2ForDeployment(
-    context,
-    config,
-    enableR2,
-  );
-  const r2EnablePending = enabledR2Now ||
-    config.completedSteps.includes("r2-enable-pending");
-  try {
-    await deployConfiguredProject(context, config, false);
-  } catch (error) {
-    const detail = errorMessage(error);
-    if (
-      isR2Ready(config) &&
-      /(?:\br2\b|media_bucket|10042|notentitled)/iu.test(detail)
-    ) {
-      throw new Error(
-        `${detail}\n\nThe saved R2 bucket and MEDIA_BUCKET binding were not ` +
-          "removed. Restore this account's R2 billing and permissions, then " +
-          `rerun \`yarn manage deploy --instance ${config.instanceName}\`.`,
-      );
+  if (!resumeDetachedWebhookDisable) {
+    const pages = await context.cloudflare.pagesProjects(accountId);
+    const targetWorkerName = workerName(config);
+    if (pages.includes(targetWorkerName)) {
+      throw new Error(pagesCollisionMessage(targetWorkerName));
     }
-    throw error;
-  }
-  if (r2EnablePending) {
-    await verifyR2Deployment(context, config);
-    await tryRecordDeferredR2RestoreBaseline(context, config);
+    const enabledR2Now = await prepareR2ForDeployment(
+      context,
+      config,
+      enableR2,
+    );
+    const r2EnablePending = enabledR2Now ||
+      config.completedSteps.includes("r2-enable-pending");
+    try {
+      await deployConfiguredProject(context, config, false);
+    } catch (error) {
+      const detail = errorMessage(error);
+      if (
+        isR2Ready(config) &&
+        /(?:\br2\b|media_bucket|10042|notentitled)/iu.test(detail)
+      ) {
+        throw new Error(
+          `${detail}\n\nThe saved R2 bucket and MEDIA_BUCKET binding were not ` +
+            "removed. Restore this account's R2 billing and permissions, then " +
+            `rerun \`yarn manage deploy --instance ${config.instanceName}\`.`,
+        );
+      }
+      throw error;
+    }
+    if (r2EnablePending) {
+      await verifyR2Deployment(context, config);
+      await tryRecordDeferredR2RestoreBaseline(context, config);
+    }
   }
   if (finishWebhookDisable && config.webhooks) {
     await cancelPendingWebhookDeliveries(context, config);
+    const detachedConsumers = await detachWebhookQueueConsumer(
+      context,
+      config,
+    );
+    prompts.log.success(
+      detachedConsumers > 0
+        ? "Webhook Queue consumer: detached"
+        : "Webhook Queue consumer: already absent",
+    );
     if (!config.completedSteps.includes(WEBHOOK_DISABLE_PURGED_STEP)) {
       await context.cloudflare.purgeQueue(accountId, config.webhooks.queueName);
       markStep(config, WEBHOOK_DISABLE_PURGED_STEP);
@@ -3903,29 +4001,6 @@ const DESTROY_CRON_STEP = "destroy-webhook-crons-removed";
 const DESTROY_CONSUMER_STEP = "destroy-webhook-consumer-detached";
 const DESTROY_QUEUE_STEP = "destroy-webhook-queue-deleted";
 
-function verifiedDestroyQueueConsumers(
-  consumers: QueueConsumer[],
-  targetWorkerName: string,
-): QueueConsumer[] {
-  const expected = consumers.filter(({scriptName, type}) =>
-    type === "worker" && scriptName === targetWorkerName
-  );
-  const unexpected = consumers.filter((consumer) =>
-    !expected.includes(consumer)
-  );
-  if (unexpected.length > 0 || expected.length > 1) {
-    const summary = consumers.map(({id, scriptName, type}) =>
-      `${type}:${scriptName ?? "unknown"} (${id})`
-    ).join(", ");
-    throw new Error(
-      `Webhook Queue has an unexpected consumer configuration: ${summary}. ` +
-        `microfeed will detach only the single Worker consumer named ` +
-        `\`${targetWorkerName}\`. No resources were deleted.`,
-    );
-  }
-  return expected;
-}
-
 function normalizedHostnames(hostnames: string[]): string[] {
   return hostnames.map((hostname) => hostname.toLowerCase().replace(/\.$/u, ""))
     .sort((left, right) => left.localeCompare(right));
@@ -3997,7 +4072,7 @@ async function inspectDestroyTarget(
     );
   }
   if (!config.completedSteps.includes(DESTROY_CONSUMER_STEP)) {
-    verifiedDestroyQueueConsumers(queueConsumers, targetWorkerName);
+    verifiedWebhookQueueConsumers(queueConsumers, targetWorkerName);
   }
 
   if (config.completedSteps.includes(DESTROY_WORKER_STEP) && workerExists) {
@@ -4415,7 +4490,7 @@ export async function destroyCommand(
         accountId,
         queue.id,
       );
-      const expectedConsumers = verifiedDestroyQueueConsumers(
+      const expectedConsumers = verifiedWebhookQueueConsumers(
         consumers,
         targetWorkerName,
       );

--- a/tests/unit/manage-cli/webhook-lifecycle.test.ts
+++ b/tests/unit/manage-cli/webhook-lifecycle.test.ts
@@ -55,6 +55,8 @@ function remoteConfig(): MicrofeedConfig {
 interface RemoteState {
   backlog: number;
   consumer: boolean;
+  consumerDeleteCount: number;
+  consumerScriptName: string;
   crons: string[];
   paused: boolean;
   producer: boolean;
@@ -70,6 +72,8 @@ async function lifecycleHarness(
   const state: RemoteState = {
     backlog: 0,
     consumer: false,
+    consumerDeleteCount: 0,
+    consumerScriptName: "feed",
     crons: [],
     paused: false,
     producer: false,
@@ -146,7 +150,7 @@ async function lifecycleHarness(
       const saved = await readConfig();
       const enabled = saved?.webhooks?.state === "enabled";
       state.producer = enabled;
-      state.consumer = enabled;
+      if (enabled) state.consumer = true;
       state.crons = enabled ? ["0 * * * *"] : [];
       const secretIndex = args.indexOf("--secrets-file");
       if (secretIndex >= 0) {
@@ -160,7 +164,10 @@ async function lifecycleHarness(
 
   const apiResult = (result: unknown) =>
     Response.json({errors: [], result, success: true});
-  const fetchMock = vi.fn(async (input: URL | RequestInfo) => {
+  const fetchMock = vi.fn(async (
+    input: URL | RequestInfo,
+    init?: RequestInit,
+  ) => {
     const url = new URL(input instanceof Request ? input.url : input.toString());
     const pathname = url.pathname;
     if (url.hostname === "feed.example.workers.dev") {
@@ -182,9 +189,21 @@ async function lifecycleHarness(
         oldest_message_timestamp_ms: 0,
       });
     }
+    if (
+      pathname.endsWith(`/queues/${state.queueId}/consumers/consumer-id`) &&
+      init?.method === "DELETE"
+    ) {
+      state.consumer = false;
+      state.consumerDeleteCount += 1;
+      return apiResult({});
+    }
     if (pathname.endsWith(`/queues/${state.queueId}/consumers`)) {
       return apiResult(state.consumer
-        ? [{consumer_id: "consumer-id", script_name: "feed", type: "worker"}]
+        ? [{
+            consumer_id: "consumer-id",
+            script_name: state.consumerScriptName,
+            type: "worker",
+          }]
         : []);
     }
     if (pathname.endsWith("/workers/scripts/feed/settings")) {
@@ -307,6 +326,7 @@ describe("reversible webhook infrastructure", () => {
     expect(harness.state).toMatchObject({
       backlog: 0,
       consumer: false,
+      consumerDeleteCount: 1,
       crons: [],
       paused: true,
       producer: false,
@@ -378,5 +398,79 @@ describe("reversible webhook infrastructure", () => {
     }, harness.runner)).rejects.toThrow("replacement Queue was not changed");
     expect(harness.runner.mock.calls.some(([, args]) => args[0] === "deploy"))
       .toBe(false);
+  });
+
+  it("resumes consumer detachment without redeploying an already detached Worker", async () => {
+    const {commands, config} = await freshModules();
+    await config.writeConfig({
+      ...remoteConfig(),
+      completedSteps: [
+        ...remoteConfig().completedSteps,
+        "webhook-queue-ready",
+        "webhook-secret-created",
+        "webhook-disable-queue-purged",
+      ],
+      webhooks: {
+        queueId: "queue-id",
+        queueName: "feed-webhooks",
+        state: "disabled",
+        transition: "disabling",
+      },
+    });
+    const harness = await lifecycleHarness(() => config.readConfig(false, "feed"));
+    harness.state.consumer = true;
+    harness.state.paused = true;
+    harness.state.queuePresent = true;
+    vi.stubGlobal("fetch", harness.fetchMock);
+
+    await commands.deployCommand({
+      "disable-webhooks": true,
+      instance: "feed",
+    }, harness.runner);
+
+    expect(harness.state.consumer).toBe(false);
+    expect(harness.state.consumerDeleteCount).toBe(1);
+    expect(harness.state.purgeCount).toBe(0);
+    expect(harness.deployedConfigs).toEqual([]);
+    await expect(config.readConfig(false, "feed")).resolves.toMatchObject({
+      webhooks: {
+        queueId: "queue-id",
+        queueName: "feed-webhooks",
+        state: "disabled",
+      },
+    });
+    expect((await config.readConfig(false, "feed"))?.webhooks?.transition)
+      .toBeUndefined();
+  });
+
+  it("refuses to detach an unexpected Queue consumer", async () => {
+    const {commands, config} = await freshModules();
+    await config.writeConfig({
+      ...remoteConfig(),
+      completedSteps: [
+        ...remoteConfig().completedSteps,
+        "webhook-queue-ready",
+        "webhook-secret-created",
+      ],
+      webhooks: {
+        queueId: "queue-id",
+        queueName: "feed-webhooks",
+        state: "enabled",
+      },
+    });
+    const harness = await lifecycleHarness(() => config.readConfig(false, "feed"));
+    harness.state.consumer = true;
+    harness.state.consumerScriptName = "unrelated-worker";
+    harness.state.crons = ["0 * * * *"];
+    harness.state.producer = true;
+    harness.state.queuePresent = true;
+    vi.stubGlobal("fetch", harness.fetchMock);
+
+    await expect(commands.deployCommand({
+      "disable-webhooks": true,
+      instance: "feed",
+    }, harness.runner)).rejects.toThrow("unexpected consumer configuration");
+    expect(harness.state.consumer).toBe(true);
+    expect(harness.state.consumerDeleteCount).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- Explicitly detach the single verified Worker consumer when disabling webhook infrastructure.
- Fail closed without detaching anything when a Queue contains an unexpected or additional consumer.
- Resume an interrupted disable without rebuilding, redeploying, or purging again when the producer binding and Cron are already absent.
- Correct the lifecycle test harness so a Worker deployment no longer pretends to remove a Queue consumer automatically.

This fixes production disables that left the Queue paused and the Worker detached from its producer and Cron, but could not complete because Cloudflare retained the Queue consumer as a separate resource.

## Related issue

N/A.

## Testing

- [x] `yarn vitest run tests/unit/manage-cli/webhook-lifecycle.test.ts tests/unit/manage-cli/destroy-command.test.ts tests/unit/manage-cli/cloudflare.test.ts` — 44 tests passed.
- [x] `git diff --check`
- [x] `yarn check` — 684 unit tests and 135 Worker tests passed, along with OpenAPI validation, CLI packaging, application builds, and documentation checks.
- [x] Live recovery on `wh-test4` detached the retained consumer without redeploying; `yarn manage status` verified the Queue is retained, paused, empty, and detached with no Cron.

## Screenshots

N/A — management CLI lifecycle fix with no UI changes.

## Risks

Low. The disable path uses the existing Cloudflare consumer-delete client already exercised by guarded instance destruction. It validates the exact Queue identity and permits detaching only one Worker consumer whose script name matches the saved microfeed Worker. The Queue, endpoint data, delivery history, and encryption secret remain retained. No migration is required.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation remains accurate; this fixes the implementation to match the existing disable contract.
- [x] No secrets, private configuration, production data, or generated files are included.