### PR TITLE
Add no-code webhook testing guide

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
           label: "Webhooks and integrations",
           items: [
             { label: "Webhooks overview", link: "/webhooks/" },
+            { label: "Test webhooks without code", link: "/webhooks/testing/" },
             { label: "Build webhook endpoints", link: "/webhooks/endpoints/" },
             { label: "Operate and troubleshoot webhooks", link: "/webhooks/operations/" },
           ],

--- a/docs/microfeed-cli.md
+++ b/docs/microfeed-cli.md
@@ -869,8 +869,9 @@ yarn microfeed webhook listen \
   --forward-to http://127.0.0.1:3000/hooks/microfeed
 ```
 
-See [Webhooks and integrations](/webhooks/) for enablement, endpoint creation,
-signed testing, and safe shutdown.
+See [Test webhooks without code](/webhooks/testing/) for the local and deployed
+signed-testing workflows. See [Webhooks and integrations](/webhooks/) for
+enablement, endpoint creation, and safe shutdown.
 
 ## `yarn microfeed webhook sample`
 

--- a/docs/webhooks/endpoints.md
+++ b/docs/webhooks/endpoints.md
@@ -144,13 +144,10 @@ terminal, print the same unsigned example with:
 yarn microfeed webhook sample item.published --json
 ```
 
-Use `yarn microfeed webhook listen` when you need a verified loopback inspector
-or forwarder without a receiver project. Add `--tunnel` to print a temporary
-HTTPS endpoint that can receive a deployed instance's signed test on this
-computer. The CLI can download a pinned, SHA-256-verified `cloudflared` helper
-into its own cache after approval, and it stops the child tunnel on exit. Event
-Explorer sends are real signed, budgeted deliveries and may retry; previews and
-unsigned samples do not make an HTTP request.
+Before creating a receiver project, follow [Test webhooks without code](../testing/)
+to inspect a signed delivery with the loopback listener or a temporary public
+tunnel. Event Explorer sends are real signed, budgeted deliveries and may
+retry; previews and unsigned samples do not make an HTTP request.
 
 Before production, test:
 

--- a/docs/webhooks/index.md
+++ b/docs/webhooks/index.md
@@ -218,24 +218,11 @@ production effects. It is a local inspector, not a production queue: replace
 its in-memory duplicate tracking and console output with durable acceptance
 before deploying real actions.
 
-Use `yarn microfeed webhook listen` when you want a verified inspector or
-forwarder without creating a receiver project. For a deployed instance, add
-`--tunnel`: the CLI prints a temporary public HTTPS endpoint, offers to
-download and verify an app-scoped `cloudflared` helper when needed, and stops
-the Quick Tunnel together with the listener. Register the printed URL, paste
-the signing secret into the visible prompt, and send the Event
-Explorer test. Use `yarn microfeed webhook sample <event> --json` to read an
-unsigned exact example from the instance's OpenAPI contract. Event Explorer
-sends are real signed deliveries that use the normal Queue, retry policy,
-delivery history, and daily budget.
-
-```console
-yarn microfeed webhook listen --tunnel
-```
-
-Quick Tunnels are temporary development tools, not production endpoints. The
-random URL changes on every run and is publicly reachable while the command is
-active; Standard Webhooks signature verification remains required.
+To inspect signed deliveries without creating a receiver project, follow [Test
+webhooks without code](./testing/). It covers the loopback-only `webhook listen`
+workflow for a local site and the temporary `--tunnel` workflow for a deployed
+site. Use `yarn microfeed webhook sample <event> --json` to read an unsigned
+exact example from the instance's OpenAPI contract.
 
 ## Authentication and limits
 
@@ -255,6 +242,7 @@ can increase Queue and Worker usage.
 ## Choose your next step
 
 - [Connect microfeed to n8n or Zapier](../automation/#automation-platforms-n8n-and-zapier).
+- [Test webhooks without writing endpoint code](./testing/).
 - [Build a webhook endpoint](./endpoints/).
 - [Operate and troubleshoot webhooks](./operations/).
 - [Explore content automation examples](../automation/#automation-examples).

--- a/docs/webhooks/operations.md
+++ b/docs/webhooks/operations.md
@@ -16,52 +16,6 @@ verification gateway. See the [automation-platform
 comparison](../automation/#automation-platforms-n8n-and-zapier) for where
 acknowledgment, signature verification, and downstream retries belong.
 
-## Test a production deployment with a temporary endpoint
-
-You can receive a real signed event from a deployed production site on your
-computer without first deploying a receiver. From a microfeed repository clone,
-start the verified listener with a temporary Cloudflare Quick Tunnel:
-
-```console
-yarn microfeed webhook listen --tunnel
-```
-
-Plain `webhook listen` accepts only local traffic. With `--tunnel`, the CLI uses
-an existing `cloudflared` executable or offers to download a pinned official
-version into microfeed's app cache. The download requires confirmation and is
-verified by SHA-256; it does not install anything system-wide or require
-administrator access.
-
-The CLI prints a random public URL such as
-`https://example.trycloudflare.com/webhook` before asking for a signing secret.
-Keep that terminal open, then:
-
-1. Open the production site's **Admin → Webhooks → Endpoints** page and choose
-   **Add endpoint**.
-2. Paste the exact temporary HTTPS URL, choose the events you want to inspect,
-   and create the endpoint.
-3. Reveal the `whsec_…` signing secret and paste it into the CLI's visible
-   prompt. The secret is used locally to reject unsigned or modified requests;
-   it is never sent to `cloudflared`.
-4. Open **Webhooks → Event explorer**, select the new endpoint and
-   `webhook.test`, then confirm **Send test**.
-5. Verify that the signed payload appears in the terminal and that the
-   production delivery is marked `succeeded` in **Webhooks → Deliveries**.
-
-An Event Explorer send is a real, budgeted delivery and may retry. The Quick
-Tunnel URL is publicly reachable only while the command runs, changes on the
-next run, and has no uptime guarantee. Press Ctrl+C when testing is complete;
-this stops both the listener and its child tunnel. Then delete the temporary
-endpoint, or replace its URL with a durable production receiver, so later
-events do not fail and retry against an expired address.
-
-Use this workflow for production-deployment verification only. It is not a
-production webhook host, durable relay, or substitute for a receiver that
-queues work before acknowledging it. See [Build webhook endpoints](../endpoints/)
-for the production architecture and the [`webhook listen` reference](/microfeed-cli/#yarn-microfeed-webhook-listen)
-for tunnel options such as `--install-cloudflared` and
-`--cloudflared-path`.
-
 ## Delivery states
 
 | Status | Meaning | Operator action |

--- a/docs/webhooks/testing.md
+++ b/docs/webhooks/testing.md
@@ -1,0 +1,104 @@
+---
+title: Test webhooks without code
+description: Use the microfeed CLI to receive and verify signed webhook events locally or through a temporary public endpoint without writing a receiver.
+---
+
+Use the microfeed CLI as a development receiver when you want to inspect real,
+signed webhook events without writing or deploying endpoint code. The listener
+verifies each Standard Webhooks signature against the exact request bytes and
+prints the event in your terminal.
+
+You still create an endpoint in **Admin → Webhooks → Endpoints** so microfeed
+knows which events to send and generates a unique signing secret. The listener
+does not create or edit that endpoint for you.
+
+## Choose a listener mode
+
+- **Local development:** Run `yarn microfeed webhook listen` and register
+  `http://127.0.0.1:8978/webhook`. The endpoint is reachable only from this
+  computer.
+- **Deployed preview or production:** Run `yarn microfeed webhook listen
+  --tunnel` and register the random HTTPS URL printed by the CLI. The endpoint
+  is public only while the command runs.
+
+Run either command from the root of a microfeed repository clone. Event
+Explorer sends are real signed deliveries that use the normal Queue, retry
+policy, delivery history, and daily budget. Previewing an event does not send a
+delivery.
+
+## Test a local development site
+
+Plain `webhook listen` starts a loopback-only receiver. It does not expose your
+computer to the internet or require `cloudflared`.
+
+1. From the microfeed repository root, start the listener:
+
+   ```console
+   yarn microfeed webhook listen
+   ```
+
+2. Open the local site's **Admin → Webhooks → Endpoints** page, choose **Add
+   endpoint**, and enter `http://127.0.0.1:8978/webhook`.
+3. Choose the events you want to inspect, create the endpoint, and reveal its
+   `whsec_…` signing secret.
+4. Paste the secret into the CLI's visible prompt. The CLI then confirms that
+   it is listening on `127.0.0.1:8978`.
+5. Open **Webhooks → Event explorer**, select the endpoint and an event, inspect
+   its Payload, Schema, and Headers, then confirm **Send test**.
+6. Verify that the signed payload appears in the terminal and that the delivery
+   is marked `succeeded` under **Webhooks → Deliveries**.
+
+Press Ctrl+C when testing is complete. Disable or delete the local endpoint if
+you do not want later events to retry while the listener is stopped.
+
+## Test a production deployment with a temporary endpoint
+
+You can receive a real signed event from a deployed production site on your
+computer without first deploying a receiver. From a microfeed repository clone,
+start the verified listener with a temporary Cloudflare Quick Tunnel:
+
+```console
+yarn microfeed webhook listen --tunnel
+```
+
+Plain `webhook listen` accepts only local traffic. With `--tunnel`, the CLI uses
+an existing `cloudflared` executable or offers to download a pinned official
+version into microfeed's app cache. The download requires confirmation and is
+verified by SHA-256; it does not install anything system-wide or require
+administrator access.
+
+The CLI prints a random public URL such as
+`https://example.trycloudflare.com/webhook` before asking for a signing secret.
+Keep that terminal open, then:
+
+1. Open the production site's **Admin → Webhooks → Endpoints** page and choose
+   **Add endpoint**.
+2. Paste the exact temporary HTTPS URL, choose the events you want to inspect,
+   and create the endpoint.
+3. Reveal the `whsec_…` signing secret and paste it into the CLI's visible
+   prompt. The secret is used locally to reject unsigned or modified requests;
+   it is never sent to `cloudflared`.
+4. Open **Webhooks → Event explorer**, select the new endpoint and
+   `webhook.test`, then confirm **Send test**.
+5. Verify that the signed payload appears in the terminal and that the
+   production delivery is marked `succeeded` in **Webhooks → Deliveries**.
+
+An Event Explorer send is a real, budgeted delivery and may retry. The Quick
+Tunnel URL is publicly reachable only while the command runs, changes on the
+next run, and has no uptime guarantee. Press Ctrl+C when testing is complete;
+this stops both the listener and its child tunnel. Then delete the temporary
+endpoint, or replace its URL with a durable production receiver, so later
+events do not fail and retry against an expired address.
+
+Use this workflow for production-deployment verification only. It is not a
+production webhook host, durable relay, or substitute for a receiver that
+queues work before acknowledging it. See [Build webhook endpoints](../endpoints/)
+for the production architecture.
+
+## Use listener options
+
+The [`webhook listen` CLI reference](/microfeed-cli/#yarn-microfeed-webhook-listen)
+documents every option, including `--secret-file`, `--forward-to`, `--json`,
+`--install-cloudflared`, and `--cloudflared-path`. Use those options when you
+need non-interactive secret input, machine-readable output, forwarding to a
+local receiver, or explicit control over the tunnel helper.


### PR DESCRIPTION
## Summary

- Add a standalone **Test webhooks without code** guide for the local listener and temporary tunnel workflows.
- Move the production Quick Tunnel walkthrough out of operations and consolidate duplicated guidance into links.
- Place the guide before **Build webhook endpoints** in navigation and update related CLI and webhook cross-links.

This gives users a clear way to inspect verified, signed webhook deliveries before writing or deploying receiver code.

## Related issue

N/A

## Testing

- [x] `yarn check`
- [x] `yarn docs:check`
- [x] `git diff --check`
- [x] Previewed desktop and mobile layouts in light and dark themes; verified sidebar order, routes, and cross-links.

## Screenshots

N/A — documentation-only content and navigation changes were verified in the local preview.

## Risks

None. This changes documentation only; CLI behavior and public APIs are unchanged.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.