### PR TITLE
Stabilize theme search fixture IDs

### DIFF
--- a/tests/worker/themes.test.ts
+++ b/tests/worker/themes.test.ts
@@ -276,17 +276,17 @@ describe("versioned theme storage", () => {
 
   it("lists searchable, sorted metadata without serializing theme bundles", async () => {
     const store = new ThemeStore(env.FEED_DB);
-    const first = packageData(`worker.alpha.${crypto.randomUUID()}`);
+    const first = packageData("worker.alpha.search-fixture");
     first.manifest.name = "Alpha Editorial";
     first.manifest.author = "Ada";
-    const second = packageData(`worker.beta.${crypto.randomUUID()}`);
+    const second = packageData("worker.beta.search-fixture");
     second.manifest.name = "Beta Journal";
     second.manifest.author = "Bea";
     const installed = await Promise.all([
       store.installVersion({...first, source: {kind: "github", url: "https://github.com/example/alpha"}}),
       store.installVersion({...second, source: {kind: "local-directory", path: "/beta"}}),
     ]);
-    const derivedPackage = packageData(`worker.derived.${crypto.randomUUID()}`);
+    const derivedPackage = packageData("worker.derived.search-fixture");
     derivedPackage.manifest.name = "Derived Alpha";
     await store.installVersion({
       ...derivedPackage,


### PR DESCRIPTION
## Summary

- Replace random UUIDs in the theme search test package IDs with deterministic fixtures.
- Prevent an accidental `ada` substring from producing an extra search match and intermittently failing CI.
- Leave production behavior unchanged.

## Related issue

N/A.

## Testing

- [x] `TZ=UTC yarn vitest run --config vitest.worker.config.ts tests/worker/themes.test.ts`
- [x] `yarn check`
- [x] `git diff --check`

## Screenshots

N/A — test-only change.

## Risks

None. The deterministic package IDs remain unique within the isolated test.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.