### PR TITLE
Prune superseded bundled theme versions

### DIFF
--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -332,9 +332,16 @@ after the Worker switch
 captures any item write completed by the previous Worker version. An incomplete
 pass stops deployment instead of serving partially normalized search data.
 When the site's current public appearance uses a format-v1 theme, deployment
-also installs the bundled default format-v2 theme as an inactive version. It
-never activates that version or changes the site's current appearance; preview
-and activation remain explicit actions in **Settings → Themes**.
+installs the bundled default format-v2 theme as an inactive version. Once a site
+has a bundled-theme lineage, later deployments keep its inactive bundled
+candidate current as well. Deployment never activates or replaces the current
+appearance; preview and activation remain explicit actions in **Settings →
+Themes**. After the current bundled version is available, deployment
+soft-deletes older inactive versions of that same bundled package when they are
+not the rollback target or referenced by a draft, another version, or theme
+assets. Active, previous, referenced, current, newer, user-installed, and
+invalid-version records are preserved. The soft-deleted identities remain
+reserved while their installed theme slots become available again.
 The complete repository test suite remains part of `yarn check` and continuous
 integration. Cloudflare mode then tags the Worker version with the current Git
 commit, deploys it, and verifies the Worker. The protected dashboard uses that

--- a/manage-cli/help.ts
+++ b/manage-cli/help.ts
@@ -117,7 +117,7 @@ export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
       "Deploy requires saved local instance configuration. Use connect for an existing Cloudflare microfeed or init for a new installation.",
       "Runs type checks, focused deployment smoke tests, and a build before deploying, then verifies the public site and protected admin route. The complete repository test suite remains part of yarn check and continuous integration.",
       "Normalizes stored item plain text before deployment and reconciles it after the Worker switch; search remains unavailable if either validation pass is incomplete.",
-      "When the current public appearance uses a v1 theme, installs the bundled default v2 theme as an inactive version. Deployment never activates or replaces the current theme.",
+      "When the current public appearance uses a v1 theme, installs the bundled default v2 theme as an inactive version. Later deployments keep an existing bundled-theme lineage current without activating it, and safely soft-delete older inactive releases unless they are a rollback target or remain referenced.",
       "Records the current Git commit on the deployed Worker version so the protected dashboard can identify its source release.",
       "A content-only installation deploys normally. Automatic pending setup prompts once when R2 becomes available; a decline is remembered, while non-interactive runs print the deterministic enable command.",
       "--enable-r2 requires Cloudflare R2 entitlement, creates or explicitly reuses the saved bucket, deploys MEDIA_BUCKET, and verifies the exact bucket and Worker binding before completing.",

--- a/manage-cli/lib/bundled-theme-pruning.ts
+++ b/manage-cli/lib/bundled-theme-pruning.ts
@@ -1,0 +1,152 @@
+import {lt, valid} from "semver";
+
+import {themeBundleV1Schema} from "@/shared/themes/ThemeContract";
+
+type QueryParameter = string | number | null;
+
+export interface BundledThemePruningStore {
+  deleteAssets: (keys: string[]) => Promise<void>;
+  query: (
+    sql: string,
+    parameters?: QueryParameter[],
+  ) => Promise<Array<Record<string, unknown>>>;
+}
+
+interface BundledThemeCandidate {
+  assetOwnerThemeId: string | null;
+  id: string;
+  version: string;
+}
+
+function candidateFromRow(
+  row: Record<string, unknown>,
+): BundledThemeCandidate | null {
+  if (typeof row.id !== "string" || typeof row.version !== "string") {
+    return null;
+  }
+  return {
+    assetOwnerThemeId: typeof row.asset_owner_theme_id === "string"
+      ? row.asset_owner_theme_id
+      : null,
+    id: row.id,
+    version: row.version,
+  };
+}
+
+const MARK_SUPERSEDED_BUNDLED_THEME_DELETED = `UPDATE themes
+  SET deleted_at = CURRENT_TIMESTAMP
+  WHERE id = ?
+    AND package_id = ?
+    AND version = ?
+    AND source_kind = 'bundled'
+    AND deleted_at IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM theme_state
+      WHERE id = 'current'
+        AND (active_theme_id = ? OR previous_theme_id = ?)
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM theme_drafts
+      WHERE origin_theme_id = ? OR asset_owner_theme_id = ?
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM themes AS dependent
+      WHERE dependent.deleted_at IS NULL
+        AND dependent.id != ?
+        AND (
+          dependent.origin_theme_id = ? OR
+          dependent.asset_owner_theme_id = ?
+        )
+    )
+  RETURNING id`;
+
+async function cleanupAssetOwner(
+  store: BundledThemePruningStore,
+  ownerId: string,
+): Promise<void> {
+  const [references] = await store.query(
+    `SELECT (
+      SELECT count(*) FROM themes
+      WHERE deleted_at IS NULL AND asset_owner_theme_id = ?
+    ) + (
+      SELECT count(*) FROM theme_drafts WHERE asset_owner_theme_id = ?
+    ) AS count`,
+    [ownerId, ownerId],
+  );
+  if (Number(references?.count ?? 0) > 0) return;
+
+  const [owner] = await store.query(
+    "SELECT bundle_json FROM themes WHERE id = ? LIMIT 1",
+    [ownerId],
+  );
+  if (typeof owner?.bundle_json !== "string") return;
+  const bundle = themeBundleV1Schema.parse(JSON.parse(owner.bundle_json));
+  if (bundle.assets.length === 0) return;
+
+  try {
+    await store.deleteAssets(bundle.assets.map((asset) => asset.key));
+    await store.query(
+      `UPDATE themes SET assets_deleted_at = CURRENT_TIMESTAMP,
+       asset_cleanup_error = NULL WHERE id = ?`,
+      [ownerId],
+    );
+  } catch (error) {
+    await store.query(
+      "UPDATE themes SET asset_cleanup_error = ? WHERE id = ?",
+      [error instanceof Error ? error.message : String(error), ownerId],
+    );
+    throw error;
+  }
+}
+
+/**
+ * Soft-deletes superseded bundled versions that are not active, the rollback
+ * target, or the origin/asset owner of another installed version or draft.
+ * Invalid and newer version strings fail closed and remain installed.
+ */
+export async function pruneSupersededBundledThemeVersions(
+  store: BundledThemePruningStore,
+  packageId: string,
+  currentVersion: string,
+): Promise<string[]> {
+  if (valid(currentVersion) !== currentVersion) {
+    throw new Error(
+      `The current bundled theme version ${currentVersion} is not exact SemVer.`,
+    );
+  }
+  const rows = await store.query(
+    `SELECT id, version, asset_owner_theme_id FROM themes
+     WHERE package_id = ? AND source_kind = 'bundled' AND deleted_at IS NULL`,
+    [packageId],
+  );
+  const candidates = rows
+    .map(candidateFromRow)
+    .filter((candidate): candidate is BundledThemeCandidate =>
+      candidate !== null && valid(candidate.version) === candidate.version &&
+      lt(candidate.version, currentVersion)
+    );
+  const pruned: string[] = [];
+  for (const candidate of candidates) {
+    const deleted = await store.query(
+      MARK_SUPERSEDED_BUNDLED_THEME_DELETED,
+      [
+        candidate.id,
+        packageId,
+        candidate.version,
+        candidate.id,
+        candidate.id,
+        candidate.id,
+        candidate.id,
+        candidate.id,
+        candidate.id,
+        candidate.id,
+      ],
+    );
+    if (deleted.length === 0) continue;
+    pruned.push(candidate.id);
+    if (candidate.assetOwnerThemeId) {
+      await cleanupAssetOwner(store, candidate.assetOwnerThemeId);
+    }
+  }
+  return pruned;
+}

--- a/manage-cli/theme.ts
+++ b/manage-cli/theme.ts
@@ -61,6 +61,7 @@ import DEFAULT_THEME_MANIFEST from "../themes/default/microfeed-theme.json";
 import type {CommandRunner, MicrofeedConfig} from "./types";
 import type {Flags} from "./commands";
 import {CloudflareClient} from "./lib/cloudflare";
+import {pruneSupersededBundledThemeVersions} from "./lib/bundled-theme-pruning";
 import {
   cloudflareAccountId,
   defaultLocalInstance,
@@ -951,6 +952,53 @@ async function installLocal(
   }
 }
 
+async function pruneInstalledBundledThemeVersions(
+  target: Target,
+  installed: StoredThemeVersion,
+): Promise<void> {
+  if (target.local) {
+    const local = await localResources(target);
+    try {
+      await pruneSupersededBundledThemeVersions({
+        deleteAssets: async (keys) => {
+          if (keys.length > 0) await local.bucket.delete(keys);
+        },
+        query: async (sql, parameters = []) => {
+          const result = await local.database.prepare(sql)
+            .bind(...parameters)
+            .all<Record<string, unknown>>();
+          return result.results;
+        },
+      }, installed.packageId, installed.version);
+    } finally {
+      await local.close();
+    }
+    return;
+  }
+
+  await pruneSupersededBundledThemeVersions({
+    deleteAssets: async (keys) => {
+      if (keys.length === 0) return;
+      if (!isR2Ready(target.config)) {
+        throw new Error(
+          "R2 media storage is unavailable for bundled theme asset cleanup.",
+        );
+      }
+      const accountId = cloudflareAccountId(target.config);
+      await Promise.all(keys.map((key) => target.client.deleteR2Object(
+        accountId,
+        target.config.r2.name,
+        key,
+      )));
+    },
+    query: (sql, parameters = []) => target.client.queryD1WithParameters(
+      target.config,
+      sql,
+      parameters,
+    ),
+  }, installed.packageId, installed.version);
+}
+
 async function installResolved(target: Target, resolved: ResolvedThemeSource) {
   if (resolved.source.kind === "bundled") {
     if (!isReservedThemePackageId(resolved.loaded.manifest.packageId)) {
@@ -961,7 +1009,13 @@ async function installResolved(target: Target, resolved: ResolvedThemeSource) {
   } else {
     assertUserThemePackageId(resolved.loaded.manifest.packageId);
   }
-  return target.local ? installLocal(target, resolved) : installRemote(target, resolved);
+  const installed = target.local
+    ? await installLocal(target, resolved)
+    : await installRemote(target, resolved);
+  if (resolved.source.kind === "bundled") {
+    await pruneInstalledBundledThemeVersions(target, installed);
+  }
+  return installed;
 }
 
 async function initializationThemeState(target: Target): Promise<ThemeState> {
@@ -974,6 +1028,28 @@ async function initializationThemeState(target: Target): Promise<ThemeState> {
     "SELECT * FROM theme_state WHERE id = 'current' LIMIT 1",
   );
   return themeStateFromRow(row ?? null);
+}
+
+async function hasInstalledBundledThemePackage(
+  target: Target,
+  packageId: string,
+): Promise<boolean> {
+  const sql = `SELECT 1 AS installed FROM themes
+    WHERE package_id = ? AND source_kind = 'bundled' AND deleted_at IS NULL
+    LIMIT 1`;
+  if (target.local) {
+    const local = await localResources(target);
+    try {
+      return Boolean(await local.database.prepare(sql).bind(packageId).first());
+    } finally {
+      await local.close();
+    }
+  }
+  return (await target.client.queryD1WithParameters(
+    target.config,
+    sql,
+    [packageId],
+  )).length > 0;
 }
 
 async function activateInitializationTheme(
@@ -1080,9 +1156,10 @@ export async function installDefaultThemeForInitialization(
 }
 
 /**
- * Makes the current bundled v2 theme available to an upgraded site without
- * changing its public appearance. The effective-theme lookup also recognizes
- * pre-versioning custom themes as v1 appearances.
+ * Makes the current bundled v2 theme available to an upgraded site or a site
+ * that already has a bundled-theme lineage, without changing its public
+ * appearance. The effective-theme lookup also recognizes pre-versioning
+ * custom themes as v1 appearances.
  */
 export async function installDefaultThemeForV1Appearance(
   config: MicrofeedConfig,
@@ -1095,7 +1172,13 @@ export async function installDefaultThemeForV1Appearance(
     local,
   };
   const active = await effectiveTheme(target);
-  if (active.manifest.formatVersion !== 1) return null;
+  if (
+    active.manifest.formatVersion !== 1 &&
+    !await hasInstalledBundledThemePackage(
+      target,
+      DEFAULT_THEME_MANIFEST.packageId,
+    )
+  ) return null;
   if (DEFAULT_THEME_MANIFEST.formatVersion !== 2) {
     throw new Error(
       "The bundled default must use theme format v2 before it can be installed for a v1 site.",

--- a/tests/unit/manage-cli/bundled-theme-pruning.test.ts
+++ b/tests/unit/manage-cli/bundled-theme-pruning.test.ts
@@ -1,0 +1,213 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import {Miniflare} from "miniflare";
+
+import {pruneSupersededBundledThemeVersions} from "../../../manage-cli/lib/bundled-theme-pruning";
+
+const miniflares: Miniflare[] = [];
+
+const emptyBundle = JSON.stringify({
+  assets: [],
+  rssStylesheet: "rss",
+  webBodyEnd: "end",
+  webBodyStart: "start",
+  webFeed: "feed",
+  webHeader: "header",
+  webItem: "item",
+});
+
+async function database(): Promise<D1Database> {
+  const miniflare = new Miniflare({
+    d1Databases: {DATABASE: "bundled-theme-pruning"},
+    modules: true,
+    script: "export default {fetch(){return new Response('ok')}}",
+  });
+  miniflares.push(miniflare);
+  const database = await miniflare.getD1Database("DATABASE");
+  await database.exec([
+    "CREATE TABLE themes (id TEXT PRIMARY KEY, package_id TEXT NOT NULL, version TEXT NOT NULL, source_kind TEXT NOT NULL, bundle_json TEXT NOT NULL, origin_theme_id TEXT, asset_owner_theme_id TEXT, deleted_at TIMESTAMP, assets_deleted_at TIMESTAMP, asset_cleanup_error TEXT);",
+    "CREATE TABLE theme_drafts (id TEXT PRIMARY KEY, origin_theme_id TEXT, asset_owner_theme_id TEXT);",
+    "CREATE TABLE theme_state (id TEXT PRIMARY KEY, active_theme_id TEXT, previous_theme_id TEXT);",
+    "INSERT INTO theme_state (id, active_theme_id, previous_theme_id) VALUES ('current', NULL, NULL);",
+  ].join("\n"));
+  return database;
+}
+
+async function insertTheme(
+  database: D1Database,
+  input: {
+    assetOwnerThemeId?: string | null;
+    bundle?: string;
+    id: string;
+    originThemeId?: string | null;
+    packageId?: string;
+    sourceKind?: string;
+    version: string;
+  },
+): Promise<void> {
+  await database.prepare(
+    `INSERT INTO themes (
+      id, package_id, version, source_kind, bundle_json,
+      origin_theme_id, asset_owner_theme_id
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    input.id,
+    input.packageId ?? "microfeed.default",
+    input.version,
+    input.sourceKind ?? "bundled",
+    input.bundle ?? emptyBundle,
+    input.originThemeId ?? null,
+    input.assetOwnerThemeId ?? null,
+  ).run();
+}
+
+function pruningStore(database: D1Database, deleteAssets = vi.fn()) {
+  return {
+    deleteAssets,
+    query: async (
+      sql: string,
+      parameters: Array<string | number | null> = [],
+    ) => {
+      const result = await database.prepare(sql).bind(...parameters)
+        .all<Record<string, unknown>>();
+      return result.results;
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(miniflares.splice(0).map((miniflare) =>
+    miniflare.dispose()
+  ));
+});
+
+describe("superseded bundled theme pruning", () => {
+  it("keeps active, rollback, referenced, current, newer, and untrusted versions", async () => {
+    const db = await database();
+    await Promise.all([
+      insertTheme(db, {id: "safe-old", version: "1.0.0"}),
+      insertTheme(db, {id: "active-old", version: "1.0.1"}),
+      insertTheme(db, {id: "previous-old", version: "1.0.2"}),
+      insertTheme(db, {id: "draft-origin-old", version: "1.0.3"}),
+      insertTheme(db, {id: "draft-owner-old", version: "1.0.4"}),
+      insertTheme(db, {id: "dependent-origin-old", version: "1.0.5"}),
+      insertTheme(db, {id: "dependent-owner-old", version: "1.0.6"}),
+      insertTheme(db, {id: "invalid-version", version: "legacy"}),
+      insertTheme(db, {id: "current", version: "1.1.10"}),
+      insertTheme(db, {id: "newer", version: "1.1.11"}),
+      insertTheme(db, {
+        id: "user-theme",
+        sourceKind: "github",
+        version: "0.9.0",
+      }),
+      insertTheme(db, {
+        id: "origin-dependent",
+        originThemeId: "dependent-origin-old",
+        packageId: "org.example.origin",
+        sourceKind: "github",
+        version: "1.0.0",
+      }),
+      insertTheme(db, {
+        assetOwnerThemeId: "dependent-owner-old",
+        id: "asset-dependent",
+        packageId: "org.example.asset",
+        sourceKind: "github",
+        version: "1.0.0",
+      }),
+    ]);
+    await db.prepare(
+      `UPDATE theme_state SET active_theme_id = ?, previous_theme_id = ?
+       WHERE id = 'current'`,
+    ).bind("active-old", "previous-old").run();
+    await db.batch([
+      db.prepare(
+        "INSERT INTO theme_drafts (id, origin_theme_id) VALUES (?, ?)",
+      ).bind("origin-draft", "draft-origin-old"),
+      db.prepare(
+        "INSERT INTO theme_drafts (id, asset_owner_theme_id) VALUES (?, ?)",
+      ).bind("asset-draft", "draft-owner-old"),
+    ]);
+
+    const first = await pruneSupersededBundledThemeVersions(
+      pruningStore(db),
+      "microfeed.default",
+      "1.1.10",
+    );
+    expect(first).toEqual(["safe-old"]);
+
+    await db.prepare(
+      `UPDATE theme_state SET active_theme_id = NULL, previous_theme_id = NULL
+       WHERE id = 'current'`,
+    ).run();
+    await db.prepare("DELETE FROM theme_drafts").run();
+    await db.prepare(
+      `UPDATE themes SET deleted_at = CURRENT_TIMESTAMP
+       WHERE id IN ('origin-dependent', 'asset-dependent')`,
+    ).run();
+    const second = await pruneSupersededBundledThemeVersions(
+      pruningStore(db),
+      "microfeed.default",
+      "1.1.10",
+    );
+    expect(second).toEqual([
+      "active-old",
+      "previous-old",
+      "draft-origin-old",
+      "draft-owner-old",
+      "dependent-origin-old",
+      "dependent-owner-old",
+    ]);
+
+    const remaining = await db.prepare(
+      "SELECT id FROM themes WHERE deleted_at IS NULL ORDER BY id",
+    ).all<{id: string}>();
+    expect(remaining.results.map(({id}) => id)).toEqual([
+      "current",
+      "invalid-version",
+      "newer",
+      "user-theme",
+    ]);
+  });
+
+  it("deletes unreferenced assets after preserving the version tombstone", async () => {
+    const db = await database();
+    const ownerId = "asset-owner";
+    const bundle = JSON.stringify({
+      ...JSON.parse(emptyBundle),
+      assets: [{
+        contentType: "text/css",
+        key: "themes/asset-owner/theme.css",
+        path: "theme.css",
+        sha256: "a".repeat(64),
+        size: 12,
+      }],
+    });
+    await insertTheme(db, {
+      assetOwnerThemeId: ownerId,
+      bundle,
+      id: ownerId,
+      version: "1.0.0",
+    });
+    await insertTheme(db, {id: "current", version: "1.1.10"});
+    const deleteAssets = vi.fn(async () => undefined);
+
+    await expect(pruneSupersededBundledThemeVersions(
+      pruningStore(db, deleteAssets),
+      "microfeed.default",
+      "1.1.10",
+    )).resolves.toEqual([ownerId]);
+    expect(deleteAssets).toHaveBeenCalledWith([
+      "themes/asset-owner/theme.css",
+    ]);
+    const owner = await db.prepare(
+      `SELECT deleted_at, assets_deleted_at, asset_cleanup_error
+       FROM themes WHERE id = ?`,
+    ).bind(ownerId).first<{
+      asset_cleanup_error: string | null;
+      assets_deleted_at: string | null;
+      deleted_at: string | null;
+    }>();
+    expect(owner?.deleted_at).not.toBeNull();
+    expect(owner?.assets_deleted_at).not.toBeNull();
+    expect(owner?.asset_cleanup_error).toBeNull();
+  });
+});

--- a/tests/unit/manage-cli/theme-init.test.ts
+++ b/tests/unit/manage-cli/theme-init.test.ts
@@ -187,6 +187,13 @@ describe("theme repository initialization", () => {
       if (request.sql.includes("SELECT * FROM themes WHERE id = ?")) {
         return d1Response(stored ? [stored] : []);
       }
+      if (request.sql.includes("SELECT id, version, asset_owner_theme_id FROM themes")) {
+        return d1Response(stored ? [{
+          asset_owner_theme_id: stored.asset_owner_theme_id,
+          id: stored.id,
+          version: stored.version,
+        }] : []);
+      }
       if (request.sql.includes("UPDATE theme_state SET active_theme_id")) {
         return d1Response([{active_theme_id: request.params?.[0]}]);
       }
@@ -286,6 +293,13 @@ describe("theme repository initialization", () => {
         if (request.sql.includes("SELECT * FROM themes WHERE id = ?")) {
           return d1Response(stored ? [stored] : []);
         }
+        if (request.sql.includes("SELECT id, version, asset_owner_theme_id FROM themes")) {
+          return d1Response(stored ? [{
+            asset_owner_theme_id: stored.asset_owner_theme_id,
+            id: stored.id,
+            version: stored.version,
+          }] : []);
+        }
         throw new Error(`Unexpected D1 query: ${request.sql}`);
       }));
 
@@ -374,6 +388,9 @@ describe("theme repository initialization", () => {
         if (request.sql.includes("FROM settings")) {
           return d1Response([]);
         }
+        if (request.sql.includes("SELECT 1 AS installed FROM themes")) {
+          return d1Response([]);
+        }
         throw new Error(`Unexpected D1 query: ${request.sql}`);
       }));
 
@@ -386,6 +403,121 @@ describe("theme repository initialization", () => {
         .toBe(false);
     },
   );
+
+  it("replaces an existing inactive bundled candidate without changing an active v2 theme", async () => {
+    const {theme} = await freshModules();
+    const runner = commandRunner();
+    const v2Manifest = {
+      ...manifest,
+      files: {
+        ...manifest.files,
+        webPage: "source/page.mustache",
+        webSearch: "source/search.mustache",
+      },
+      formatVersion: 2 as const,
+    };
+    const v2Bundle = {
+      ...bundle,
+      webPage: "page {{page.title}}",
+      webSearch: "search {{search.query}}",
+    };
+    let stored: Record<string, unknown> | null = null;
+    const pruned: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (
+      _input: URL | RequestInfo,
+      init?: RequestInit,
+    ) => {
+      const request = JSON.parse(String(init?.body)) as {
+        params?: unknown[];
+        sql: string;
+      };
+      if (request.sql.includes("sqlite_master")) {
+        return d1Response([{name: "themes"}, {name: "theme_state"}]);
+      }
+      if (
+        request.sql.includes("FROM theme_state") &&
+        request.sql.includes("LEFT JOIN themes")
+      ) {
+        return d1Response([{
+          asset_owner_theme_id: null,
+          bundle_json: JSON.stringify(v2Bundle),
+          checksum_sha256: "a".repeat(64),
+          created_at: "2026-08-10T00:00:00.000Z",
+          deleted_at: null,
+          id: "active-v2-theme",
+          manifest_json: JSON.stringify(v2Manifest),
+          name: v2Manifest.name,
+          origin_theme_id: null,
+          package_id: v2Manifest.packageId,
+          requested_active_theme_id: "active-v2-theme",
+          source_commit: null,
+          source_kind: "github",
+          source_path: null,
+          source_ref: "main",
+          source_url: "https://github.com/example/active",
+          version: v2Manifest.version,
+        }]);
+      }
+      if (request.sql.includes("FROM settings")) return d1Response([]);
+      if (request.sql.includes("SELECT 1 AS installed FROM themes")) {
+        return d1Response([{installed: 1}]);
+      }
+      if (request.sql.includes("WHERE package_id = ? AND version = ?")) {
+        return d1Response([]);
+      }
+      if (request.sql.includes("INSERT INTO themes")) {
+        const values = request.params!;
+        stored = {
+          asset_owner_theme_id: values[13],
+          bundle_json: values[5],
+          checksum_sha256: values[11],
+          created_at: "2026-08-18T00:00:00.000Z",
+          deleted_at: null,
+          id: values[0],
+          manifest_json: values[4],
+          name: values[3],
+          origin_theme_id: values[12],
+          package_id: values[1],
+          source_commit: values[10],
+          source_kind: values[6],
+          source_path: values[9],
+          source_ref: values[8],
+          source_url: values[7],
+          version: values[2],
+        };
+        return d1Response([{id: values[0]}]);
+      }
+      if (request.sql.includes("SELECT * FROM themes WHERE id = ?")) {
+        return d1Response(stored ? [stored] : []);
+      }
+      if (request.sql.includes("SELECT id, version, asset_owner_theme_id FROM themes")) {
+        return d1Response([{
+          asset_owner_theme_id: null,
+          id: "old-bundled",
+          version: "1.1.8",
+        }, ...(stored ? [{
+          asset_owner_theme_id: stored.asset_owner_theme_id,
+          id: stored.id,
+          version: stored.version,
+        }] : [])]);
+      }
+      if (request.sql.startsWith("UPDATE themes\n  SET deleted_at")) {
+        pruned.push(String(request.params?.[0]));
+        return d1Response([{id: request.params?.[0]}]);
+      }
+      throw new Error(`Unexpected D1 query: ${request.sql}`);
+    }));
+
+    await expect(theme.installDefaultThemeForV1Appearance(
+      savedConfig(),
+      runner,
+      false,
+    )).resolves.toMatchObject({
+      packageId: "microfeed.default",
+      version: "1.1.10",
+    });
+    expect(pruned).toEqual(["old-bundled"]);
+  });
 
   it("creates a new Git-ready package from the active immutable version", async () => {
     const {directory, theme} = await freshModules();


### PR DESCRIPTION
## Summary

- keep the latest bundled-theme candidate current without activating it
- soft-delete superseded inactive bundled versions while preserving active, rollback, draft, origin, and asset references
- retain immutable tombstones, clean unreferenced assets, and free installed-theme slots
- document deployment reconciliation behavior

## Validation

- `yarn check`
- focused management CLI pruning and initialization tests
- latest-main Worker theme tests
- `git diff --check`