### PR TITLE
Make visual editor media responsive by default

### DIFF
--- a/src/client/RichEditorMedia.ts
+++ b/src/client/RichEditorMedia.ts
@@ -39,6 +39,8 @@ const OBSOLETE_NATIVE_VIDEO_CLASSES = new Set([
   "ql-native-video",
   "ql-video",
 ]);
+const DEFAULT_MEDIA_MAX_WIDTH = "600px";
+const DEFAULT_MEDIA_WIDTH = "100%";
 const DEFAULT_VIDEO_ASPECT_RATIO = "16 / 9";
 const FALLBACK_DIMENSION_PATTERN =
   /^(?:auto|min-content|max-content|fit-content|0|(?:\d+(?:\.\d+)?|\.\d+)(?:%|px|em|rem|vw|vh|vmin|vmax|ch|ex|cm|mm|in|pt|pc))$/iu;
@@ -186,6 +188,19 @@ export function applyRichEditorMediaSettings(
   if (!element.style.cssText) {
     element.removeAttribute("style");
   }
+}
+
+export function applyRichEditorMediaEmbedDefaults(
+  element: HTMLElement,
+  mediaType: RichEditorMediaType,
+) {
+  applyRichEditorMediaSettings(element, mediaType, {
+    alt: "",
+    height: mediaType === "video" ? "auto" : "",
+    style: `max-width: ${DEFAULT_MEDIA_MAX_WIDTH};`,
+    title: "",
+    width: DEFAULT_MEDIA_WIDTH,
+  });
 }
 
 export function findRichEditorMediaElement(

--- a/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaDialog/index.tsx
+++ b/src/components/admin/shared/AdminRichEditor/component/RichEditorMediaDialog/index.tsx
@@ -14,7 +14,10 @@ import {
 import Requests from "@/client/requests";
 import {showToast} from "@/client/ToastUtils";
 import {Button} from "@/components/ui/button";
-import {richEditorMediaEmbedFormat} from "@/client/RichEditorMedia";
+import {
+  applyRichEditorMediaEmbedDefaults,
+  richEditorMediaEmbedFormat,
+} from "@/client/RichEditorMedia";
 
 const UPLOAD_STATUS__START = 1;
 
@@ -151,8 +154,14 @@ export default class RichEditorMediaDialog extends React.Component<any, any> {
         index,
         richEditorMediaEmbedFormat(mediaType),
         url,
-        Quill.sources.USER,
+        Quill.sources.SILENT,
       );
+      const [mediaBlot] = quill.getLeaf(index);
+      const mediaElement = mediaBlot?.domNode;
+      if (mediaElement instanceof HTMLElement) {
+        applyRichEditorMediaEmbedDefaults(mediaElement, mediaType);
+        quill.update(Quill.sources.SILENT);
+      }
       quill.insertText(index + 1, "\n", Quill.sources.USER);
       quill.setSelection(index + 2, 0, Quill.sources.SILENT);
       this.setState({url: null});

--- a/tests/unit/client/RichEditorMedia.test.ts
+++ b/tests/unit/client/RichEditorMedia.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 
 import {
+  applyRichEditorMediaEmbedDefaults,
   applyRichEditorMediaSettings,
   isValidMediaDimension,
   richEditorMediaEmbedFormat,
@@ -116,6 +117,32 @@ describe("rich editor media helpers", () => {
   it("starts pointer dragging only after intentional movement", () => {
     expect(shouldStartRichEditorMediaDrag(10, 10, 13, 14)).toBe(false);
     expect(shouldStartRichEditorMediaDrag(10, 10, 16, 10)).toBe(true);
+  });
+
+  it("applies responsive defaults to new image embeds", () => {
+    const {attributes, declarations, element} = fakeMediaElement("IMG");
+
+    applyRichEditorMediaEmbedDefaults(element, "image");
+
+    expect(attributes.get("width")).toBe("100%");
+    expect(attributes.has("height")).toBe(false);
+    expect(declarations.get("max-width")).toBe("600px");
+    expect(declarations.get("--resize-width")).toBe("100%");
+    expect(element.dataset.relativeSize).toBe("true");
+  });
+
+  it("applies responsive defaults to new video embeds", () => {
+    const {attributes, declarations, element} = fakeMediaElement("VIDEO");
+
+    applyRichEditorMediaEmbedDefaults(element, "video");
+
+    expect(attributes.get("width")).toBe("100%");
+    expect(attributes.has("height")).toBe(false);
+    expect(declarations.get("max-width")).toBe("600px");
+    expect(declarations.get("width")).toBe("100%");
+    expect(declarations.get("height")).toBe("auto");
+    expect(declarations.get("--resize-width")).toBe("100%");
+    expect(element.dataset.relativeSize).toBe("true");
   });
 
   it("accepts practical CSS media dimensions and rejects invalid values", () => {


### PR DESCRIPTION
## Summary

- Default newly inserted visual-editor images and videos to `width="100%"`.
- Add `max-width: 600px;` to their additional inline styles so media can shrink on narrow devices without growing beyond the intended desktop size.
- Reuse the editor's media-settings pipeline so the dialog, resize metadata, and serialized HTML stay in sync while existing embeds remain unchanged.

## Related issue

None.

## Testing

- [x] `yarn check`
- [x] `yarn vitest run tests/unit/client/RichEditorMedia.test.ts`
- [x] `git diff --check`

## Screenshots

N/A. This changes the generated defaults for newly inserted media rather than the editor chrome.

## Risks

Low. The defaults apply only when inserting new image or video embeds; existing authored media is not migrated or resized.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation is unchanged because no command or documented workflow changed.
- [x] No secrets, private configuration, production data, or generated files are included.
