### PR TITLE
Add draft-only WebMCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ same published content.
 | Publish many content types | Share articles, podcasts, videos, images, documents, and curated external links from one feed. |
 | Website, RSS, and JSON Feed | Reach browsers, podcast and feed readers, developer tools, and AI agents without publishing the same item repeatedly. |
 | Friendly admin dashboard | Create and edit posts, upload media, control visibility, manage settings, and preview changes in the browser. |
+| Experimental WebMCP site tools | Let a compatible browser agent automatically discover read and draft-only editing tools after it opens the signed-in dashboard. WebMCP does not expose a remote MCP server or add runtime work to public pages. |
 | Headless CMS and content automation | Read and update content through the API, receive signed change notifications through webhooks, and give local AI agents a friendlier workflow through `@microfeed/cli`. |
 | Versioned themes | Edit safely in Admin or install community themes from GitHub, preview inactive versions, and activate or roll back explicitly. |
 | Your data on your Cloudflare account | Keep content metadata in D1 and optional media and theme assets in R2 under infrastructure you control. |

--- a/README.md
+++ b/README.md
@@ -180,7 +180,12 @@ Choose the publishing workflow that fits the task:
   use external URLs in content-only mode; [customize themes and shared website
   code](https://docs.microfeed.org/dashboard/themes/); and choose [Public,
   Headless, or Offline site access](https://docs.microfeed.org/dashboard/customize/).
-* **For AI agents:** use the official
+* **For browser AI agents:** a dashboard protected by built-in login or
+  Cloudflare Access automatically exposes experimental, draft-only
+  [WebMCP](https://docs.microfeed.org/automation/ai-agents/#use-webmcp-for-visible-drafts)
+  tools when the browser provides the native API. Unsupported browsers and
+  public pages do not load the implementation.
+* **For local AI agents:** use the official
   [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli) to manage the
   same content through browser-authorized access after you enable the API. The
   agent may start login, but you sign in and approve permissions in the

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -31,6 +31,12 @@ If you want a coding agent to publish content, start with the official
 directly against the REST API when you are integrating another application or
 service.
 
+For interactive draft editing, a compatible browser agent can instead discover
+microfeed's experimental [WebMCP site tools](../automation/ai-agents/#use-webmcp-for-visible-drafts)
+after it opens the signed-in, protected dashboard. WebMCP is separate from this
+remote API: API documentation can tell an agent that the capability exists, but
+the tools themselves are available only from the active dashboard page.
+
 ## What the API can do
 
 The authenticated API covers these capability groups:

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -144,7 +144,7 @@ export default defineConfig({
           description:
             "microfeed is an open-source CMS that publishes one collection as a website, RSS feed, and JSON Feed from the owner's Cloudflare account.",
           details:
-            "Use the Installation guides for deployment workflows. Use the yarn manage reference for site-management commands and the @microfeed/cli reference for content commands and safety rules.",
+            "Use the Installation guides for deployment workflows. Use the yarn manage reference for site-management commands, the WebMCP guide for browser-based draft editing, and the @microfeed/cli reference for broader content commands and safety rules.",
           promote: ["index", "start-here/**", "manage-cli", "microfeed-cli", "theme-kit-cli"],
           demote: ["contribute/**"],
           customSets: [
@@ -161,9 +161,9 @@ export default defineConfig({
               paths: ["api/index", "api/authentication", "api/build-and-test"],
             },
             {
-              label: "Manage content with @microfeed/cli and AI agents",
+              label: "Manage content with WebMCP, @microfeed/cli, and AI agents",
               description:
-                "The guided CLI workflow, AI-agent conventions, and complete content-management command reference.",
+                "Use draft-only WebMCP site tools in a signed-in dashboard, or follow the guided CLI workflow and complete content-management command reference.",
               paths: ["automation/cli", "automation/ai-agents", "microfeed-cli"],
             },
             {

--- a/docs/automation/ai-agents.md
+++ b/docs/automation/ai-agents.md
@@ -1,13 +1,57 @@
 ---
 title: Manage content with AI agents
-description: Give a local coding agent a content task while browser authorization, credentials, and destructive approval remain under your control.
+description: Use experimental browser-native WebMCP for visible drafts, or give a local coding agent a broader content task through the credential-safe CLI.
 ---
 
-Use `@microfeed/cli` when a person asks a local coding agent to work on drafts,
-upload media, or publish content. The CLI wraps the API in task-oriented
+microfeed supports two interactive agent workflows. Experimental WebMCP lets a
+browser-based agent read content and help with the draft currently open in a
+protected dashboard. `@microfeed/cli` gives a local coding agent the broader
+API-backed workflow for drafts, media, publishing, and other content tasks.
+
+## Use WebMCP for visible drafts
+
+[WebMCP](https://webmachinelearning.github.io/webmcp/) is an experimental web
+platform proposal. A page can expose structured JavaScript tools to an agent in
+the same browser through `document.modelContext`. It is not a remote MCP server
+and does not replace microfeed's API, OAuth, CLI, OpenAPI document, or
+`llms.txt` files.
+
+microfeed activates its WebMCP tools automatically only when both conditions
+are true:
+
+- the current browser provides the native `document.modelContext` API; and
+- the dashboard is protected by built-in login or Cloudflare Access.
+
+There is no microfeed setting to enable. Public themed pages do not load or run
+WebMCP code. An unsupported browser performs one feature check and downloads no
+WebMCP implementation or validation chunk. A supported protected dashboard
+loads the small tool registry only in that browser session; the server does no
+polling or background work.
+
+The dashboard exposes tools to list and read Items and Pages, open a new Item
+or Page editor, and save the visible new or unpublished editor as a draft. A
+save merges only supplied editorial fields with the editor's current state and
+always persists an unpublished result. The tool disappears when the visible
+content is published, unlisted, deleted, or the default 404 Page. The server
+rechecks stored and resulting status before accepting every WebMCP write.
+
+WebMCP cannot publish, delete, upload media, manage Site Files or themes, read
+API keys, change account settings, or configure webhooks. Use the dashboard or
+the authenticated CLI/API workflow for those operations. Webhook events caused
+by an accepted draft save use `context.origin: "webmcp"`, so an automation can
+distinguish them from dashboard and API writes.
+
+Because the browser API remains experimental, tool discovery currently
+requires a Chrome WebMCP development or origin-trial environment. Browsers
+without the native API degrade silently.
+
+## Use the CLI for broader content tasks
+
+Use `@microfeed/cli` when a person asks a local coding agent to work across
+content, upload media, or publish. The CLI wraps the API in task-oriented
 commands and keeps its browser-granted credentials opaque.
 
-This is an interactive workflow: the person supplies the task and remains
+The CLI is an interactive workflow: the person supplies the task and remains
 available for browser consent and destructive confirmation. A persistent
 service that reacts asynchronously should instead follow [Build webhook
 endpoints](/webhooks/endpoints/) and the `build-microfeed-automation` skill.

--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -1,23 +1,26 @@
 ---
 title: Content automation overview
-description: Choose the microfeed API, webhooks, or agent-friendly CLI for local agents, remote services, n8n, Zapier, and other content workflows.
+description: Choose WebMCP, the microfeed API, webhooks, or the agent-friendly CLI for browser agents, local agents, remote services, n8n, Zapier, and other workflows.
 ---
 
-microfeed provides three building blocks for content automation. Use one or
+microfeed provides four building blocks for content automation. Use one or
 combine them according to where the automation runs and whether it needs to
 react to changes.
 
-## Compare the API, webhooks, and CLI
+## Compare WebMCP, the API, webhooks, and CLI
 
 | Tool | Direction | Use it for | Authentication |
 | --- | --- | --- | --- |
 | **API** | Your integration → microfeed | Pull current content and create, update, or delete content. | A named, least-privilege `mf_…` API key. |
 | **Webhooks** | microfeed → your receiver | Receive a push notification whenever subscribed content changes. | A per-endpoint `whsec_…` signing secret verifies the request; it does not grant API access. |
 | **`@microfeed/cli`** | Local terminal or agent → microfeed API | Manage content through task-oriented commands without handling a raw API key. It is a more agent-friendly wrapper around the API. | Browser authorization stored and refreshed by the CLI. |
+| **WebMCP** | Protected dashboard ↔ browser agent | Read Items and Pages, open an editor, and save only the visible new or unpublished draft. | The existing built-in login or Cloudflare Access session; the native browser mediates tool use. |
 
 The API does not notify you when something changes. A webhook announces a
 change but cannot read or modify content. The CLI does not receive webhooks; it
 makes API operations easier and safer for a person or local coding agent.
+WebMCP is a small experimental, in-page tool surface for the active protected
+dashboard; it is not a remote MCP server or a background integration.
 
 ```text
 API client or CLI ───────── read and write ────────→ microfeed
@@ -90,6 +93,19 @@ the person gives the agent the task directly.
 Start with [Manage content with `@microfeed/cli`](./cli/) and [Manage content
 with AI agents](./ai-agents/). The `manage-microfeed-content` skill provides the
 matching workflow for coding agents.
+
+### Browser AI agents: use WebMCP for drafts
+
+When a browser provides the native experimental `document.modelContext` API,
+a protected microfeed dashboard automatically exposes concise tools for
+reading Items and Pages and saving the visible draft. Public pages and
+unsupported browsers do not load the WebMCP implementation. Publishing,
+deletion, media, configuration, and account operations remain outside this
+surface.
+
+See [Manage content with AI agents](./ai-agents/#use-webmcp-for-visible-drafts)
+for the exact boundary and performance behavior. Use the CLI for a local agent
+that needs to work beyond the active browser editor.
 
 ### Remote AI agents and long-running services: use webhooks and the API
 

--- a/migrations/0022_webmcp_webhook_origin.sql
+++ b/migrations/0022_webmcp_webhook_origin.sql
@@ -1,0 +1,141 @@
+PRAGMA defer_foreign_keys = true;
+
+DROP TRIGGER IF EXISTS webhook_event_reserve_budget;
+DROP INDEX IF EXISTS webhook_events_created;
+DROP INDEX IF EXISTS webhook_events_subject;
+DROP INDEX IF EXISTS webhook_deliveries_created;
+DROP INDEX IF EXISTS webhook_deliveries_endpoint;
+DROP INDEX IF EXISTS webhook_deliveries_reconcile;
+DROP INDEX IF EXISTS webhook_delivery_attempts_delivery;
+
+ALTER TABLE webhook_delivery_attempts
+RENAME TO webhook_delivery_attempts_legacy;
+ALTER TABLE webhook_deliveries RENAME TO webhook_deliveries_legacy;
+ALTER TABLE webhook_events RENAME TO webhook_events_legacy;
+
+CREATE TABLE webhook_events (
+  id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  api_version TEXT NOT NULL DEFAULT '1',
+  subject_type TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  origin TEXT NOT NULL
+    CHECK (origin IN ('dashboard', 'api', 'system', 'webmcp')),
+  request_id TEXT NOT NULL,
+  correlation_id TEXT NOT NULL,
+  causation_id TEXT,
+  delivery_count INTEGER NOT NULL DEFAULT 0,
+  budget_day TEXT NOT NULL,
+  suppression_reason TEXT,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO webhook_events (
+  id, event_type, api_version, subject_type, subject_id, payload_json,
+  origin, request_id, correlation_id, causation_id, delivery_count,
+  budget_day, suppression_reason, created_at
+)
+SELECT
+  id, event_type, api_version, subject_type, subject_id, payload_json,
+  origin, request_id, correlation_id, causation_id, delivery_count,
+  budget_day, suppression_reason, created_at
+FROM webhook_events_legacy;
+
+CREATE TABLE webhook_deliveries (
+  id TEXT PRIMARY KEY,
+  event_id TEXT NOT NULL,
+  endpoint_id TEXT NOT NULL,
+  endpoint_url TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN (
+    'pending', 'retrying', 'succeeded', 'failed',
+    'suppressed_budget', 'suppressed_endpoint_paused',
+    'canceled_endpoint_paused', 'canceled_endpoint_disabled',
+    'canceled_webhooks_disabled'
+  )),
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  is_test BOOLEAN NOT NULL DEFAULT 0,
+  is_manual BOOLEAN NOT NULL DEFAULT 0,
+  queued_at TIMESTAMP,
+  next_attempt_at TIMESTAMP,
+  lease_until TIMESTAMP,
+  response_status INTEGER,
+  response_body TEXT,
+  error TEXT,
+  completed_at TIMESTAMP,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (event_id) REFERENCES webhook_events(id),
+  FOREIGN KEY (endpoint_id) REFERENCES webhook_endpoints(id)
+);
+
+INSERT INTO webhook_deliveries (
+  id, event_id, endpoint_id, endpoint_url, status, attempt_count, is_test,
+  is_manual, queued_at, next_attempt_at, lease_until, response_status,
+  response_body, error, completed_at, created_at, updated_at
+)
+SELECT
+  id, event_id, endpoint_id, endpoint_url, status, attempt_count, is_test,
+  is_manual, queued_at, next_attempt_at, lease_until, response_status,
+  response_body, error, completed_at, created_at, updated_at
+FROM webhook_deliveries_legacy;
+
+CREATE TABLE webhook_delivery_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  delivery_id TEXT NOT NULL,
+  attempt_number INTEGER NOT NULL,
+  outcome TEXT NOT NULL,
+  response_status INTEGER,
+  response_body TEXT,
+  error TEXT,
+  duration_ms INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (delivery_id) REFERENCES webhook_deliveries(id)
+);
+
+INSERT INTO webhook_delivery_attempts (
+  id, delivery_id, attempt_number, outcome, response_status, response_body,
+  error, duration_ms, created_at
+)
+SELECT
+  id, delivery_id, attempt_number, outcome, response_status, response_body,
+  error, duration_ms, created_at
+FROM webhook_delivery_attempts_legacy;
+
+DROP TABLE webhook_delivery_attempts_legacy;
+DROP TABLE webhook_deliveries_legacy;
+DROP TABLE webhook_events_legacy;
+
+CREATE INDEX webhook_events_created
+ON webhook_events (created_at DESC, id DESC);
+CREATE INDEX webhook_events_subject
+ON webhook_events (subject_type, subject_id, created_at DESC);
+CREATE INDEX webhook_deliveries_created
+ON webhook_deliveries (created_at DESC, id DESC);
+CREATE INDEX webhook_deliveries_endpoint
+ON webhook_deliveries (endpoint_id, created_at DESC);
+CREATE INDEX webhook_deliveries_reconcile
+ON webhook_deliveries (status, queued_at, next_attempt_at, lease_until);
+CREATE INDEX webhook_delivery_attempts_delivery
+ON webhook_delivery_attempts (delivery_id, attempt_number);
+
+CREATE TRIGGER webhook_event_reserve_budget
+BEFORE INSERT ON webhook_events
+WHEN NEW.delivery_count > 0
+BEGIN
+  INSERT INTO webhook_daily_usage (usage_day, deliveries, updated_at)
+  VALUES (NEW.budget_day, 0, CURRENT_TIMESTAMP)
+  ON CONFLICT (usage_day) DO NOTHING;
+
+  UPDATE webhook_daily_usage
+  SET deliveries = deliveries + NEW.delivery_count,
+      updated_at = CURRENT_TIMESTAMP
+  WHERE usage_day = NEW.budget_day
+    AND deliveries + NEW.delivery_count <= COALESCE(
+      (SELECT daily_delivery_limit FROM webhook_settings WHERE id = 1),
+      1000
+    );
+
+  SELECT (CASE WHEN changes() = 0
+    THEN RAISE(ABORT, 'webhook_daily_budget') END);
+END;

--- a/src/client/requests.ts
+++ b/src/client/requests.ts
@@ -1,10 +1,13 @@
-import axios from 'axios';
+import axios, {type AxiosRequestConfig} from 'axios';
 import {ADMIN_URLS} from "@/shared/StringUtils";
 import type {ImageMetadataTarget} from "@/types";
 
-const axiosPost = (url: any, bodyDict: any) => {
-  return axios.post(url, bodyDict, {
-  });
+const axiosPost = (
+  url: any,
+  bodyDict: any,
+  config: AxiosRequestConfig = {},
+) => {
+  return axios.post(url, bodyDict, config);
 };
 
 const deleteImage = (

--- a/src/client/webmcp/admin-tools.ts
+++ b/src/client/webmcp/admin-tools.ts
@@ -3,6 +3,7 @@ import {ADMIN_URLS} from "@/shared/StringUtils";
 import {
   registerWebMcpTools,
   type WebMcpTool,
+  webMcpExecutionSignal,
 } from "./model-context";
 import {
   emptyInputSchema,
@@ -57,7 +58,8 @@ export function dashboardTools(): WebMcpTool[] {
       annotations: readAnnotations,
       description:
         "List compact microfeed Item summaries, optionally filtered by status and continued from a cursor.",
-      async execute(input, {signal}) {
+      async execute(input, options) {
+        const signal = webMcpExecutionSignal(options);
         const parsed = parseInput(listItemsInputSchema, input);
         const url = new URL(ADMIN_URLS.ajaxItems(), window.location.origin);
         if (parsed.status) url.searchParams.set("status", parsed.status);
@@ -81,7 +83,8 @@ export function dashboardTools(): WebMcpTool[] {
     {
       annotations: readAnnotations,
       description: "Get editable fields and status for one microfeed Item.",
-      async execute(input, {signal}) {
+      async execute(input, options) {
+        const signal = webMcpExecutionSignal(options);
         const {item_id: itemId} = parseInput(getItemInputSchema, input);
         const item = await getJson(
           `${ADMIN_URLS.ajaxItems()}${encodeURIComponent(itemId)}/`,
@@ -99,7 +102,8 @@ export function dashboardTools(): WebMcpTool[] {
     {
       annotations: readAnnotations,
       description: "List compact microfeed Page summaries and editor URLs.",
-      async execute(input, {signal}) {
+      async execute(input, options) {
+        const signal = webMcpExecutionSignal(options);
         parseInput(emptyInputSchema, input);
         const result = await getJson(ADMIN_URLS.ajaxPages(), signal);
         return {
@@ -120,7 +124,8 @@ export function dashboardTools(): WebMcpTool[] {
     {
       annotations: readAnnotations,
       description: "Get editable fields and status for one microfeed Page.",
-      async execute(input, {signal}) {
+      async execute(input, options) {
+        const signal = webMcpExecutionSignal(options);
         const {page_id: pageId} = parseInput(getPageInputSchema, input);
         const page = await getJson(ADMIN_URLS.ajaxPage(pageId), signal);
         return {

--- a/src/client/webmcp/admin-tools.ts
+++ b/src/client/webmcp/admin-tools.ts
@@ -1,0 +1,166 @@
+import {ITEM_STATUSES_DICT} from "@/shared/Constants";
+import {ADMIN_URLS} from "@/shared/StringUtils";
+import {
+  registerWebMcpTools,
+  type WebMcpTool,
+} from "./model-context";
+import {
+  emptyInputSchema,
+  getItemInputSchema,
+  getPageInputSchema,
+  inputJsonSchema,
+  listItemsInputSchema,
+  parseInput,
+  startDraftInputSchema,
+} from "./schemas";
+
+let dashboardController: AbortController | undefined;
+
+const readAnnotations = {
+  readOnlyHint: true,
+  untrustedContentHint: true,
+} as const;
+const navigationAnnotations = {
+  readOnlyHint: false,
+  untrustedContentHint: false,
+} as const;
+
+async function responseJson(response: Response): Promise<any> {
+  const data = await response.json().catch(() => ({})) as Record<string, any>;
+  if (!response.ok) {
+    throw new Error(data.error ?? `microfeed request failed (${response.status}).`);
+  }
+  return data;
+}
+
+async function getJson(url: string, signal: AbortSignal): Promise<any> {
+  return responseJson(await fetch(url, {
+    credentials: "same-origin",
+    headers: {accept: "application/json"},
+    signal,
+  }));
+}
+
+function absoluteUrl(path: string): string {
+  return new URL(path, window.location.origin).toString();
+}
+
+function itemStatusName(value: unknown): string {
+  return ITEM_STATUSES_DICT[
+    Number(value) as keyof typeof ITEM_STATUSES_DICT
+  ]?.name ?? "unknown";
+}
+
+export function dashboardTools(): WebMcpTool[] {
+  return [
+    {
+      annotations: readAnnotations,
+      description:
+        "List compact microfeed Item summaries, optionally filtered by status and continued from a cursor.",
+      async execute(input, {signal}) {
+        const parsed = parseInput(listItemsInputSchema, input);
+        const url = new URL(ADMIN_URLS.ajaxItems(), window.location.origin);
+        if (parsed.status) url.searchParams.set("status", parsed.status);
+        if (parsed.limit) url.searchParams.set("limit", String(parsed.limit));
+        if (parsed.cursor) url.searchParams.set("next_cursor", parsed.cursor);
+        const result = await getJson(url.toString(), signal);
+        return {
+          items: result.items.map((item: Record<string, unknown>) => ({
+            id: item.id,
+            status: itemStatusName(item.status),
+            title: item.title,
+            updated_at_ms: item.updatedAtMs,
+            editor_url: absoluteUrl(ADMIN_URLS.editItem(item.id)),
+          })),
+          ...(result.nextCursor ? {next_cursor: result.nextCursor} : {}),
+        };
+      },
+      inputSchema: inputJsonSchema(listItemsInputSchema),
+      name: "microfeed_list_items",
+    },
+    {
+      annotations: readAnnotations,
+      description: "Get editable fields and status for one microfeed Item.",
+      async execute(input, {signal}) {
+        const {item_id: itemId} = parseInput(getItemInputSchema, input);
+        const item = await getJson(
+          `${ADMIN_URLS.ajaxItems()}${encodeURIComponent(itemId)}/`,
+          signal,
+        );
+        return {
+          ...item,
+          status: itemStatusName(item.status),
+          editor_url: absoluteUrl(ADMIN_URLS.editItem(itemId)),
+        };
+      },
+      inputSchema: inputJsonSchema(getItemInputSchema),
+      name: "microfeed_get_item",
+    },
+    {
+      annotations: readAnnotations,
+      description: "List compact microfeed Page summaries and editor URLs.",
+      async execute(input, {signal}) {
+        parseInput(emptyInputSchema, input);
+        const result = await getJson(ADMIN_URLS.ajaxPages(), signal);
+        return {
+          items: result.items.map((page: Record<string, unknown>) => ({
+            id: page.id,
+            navigation_label: page.navigation_label,
+            show_in_navigation: page.show_in_navigation,
+            slug: page.slug,
+            status: page.status,
+            title: page.title,
+            editor_url: absoluteUrl(ADMIN_URLS.editPage(String(page.id))),
+          })),
+        };
+      },
+      inputSchema: inputJsonSchema(emptyInputSchema),
+      name: "microfeed_list_pages",
+    },
+    {
+      annotations: readAnnotations,
+      description: "Get editable fields and status for one microfeed Page.",
+      async execute(input, {signal}) {
+        const {page_id: pageId} = parseInput(getPageInputSchema, input);
+        const page = await getJson(ADMIN_URLS.ajaxPage(pageId), signal);
+        return {
+          ...page,
+          editor_url: absoluteUrl(ADMIN_URLS.editPage(pageId)),
+        };
+      },
+      inputSchema: inputJsonSchema(getPageInputSchema),
+      name: "microfeed_get_page",
+    },
+    {
+      annotations: navigationAnnotations,
+      description:
+        "Open the new microfeed Item or Page editor without creating content.",
+      execute(input) {
+        const {kind} = parseInput(startDraftInputSchema, input);
+        const path = kind === "item" ? ADMIN_URLS.newItem() : ADMIN_URLS.newPage();
+        const editorUrl = absoluteUrl(path);
+        setTimeout(() => window.location.assign(editorUrl), 0);
+        return {editor_url: editorUrl, kind};
+      },
+      inputSchema: inputJsonSchema(startDraftInputSchema),
+      name: "microfeed_start_draft",
+    },
+  ];
+}
+
+export async function reconcileAdminWebMcpTools(): Promise<void> {
+  dashboardController?.abort();
+  const controller = new AbortController();
+  dashboardController = controller;
+  try {
+    await registerWebMcpTools(dashboardTools(), controller.signal);
+  } catch (error) {
+    if (dashboardController === controller) clearAdminWebMcpTools();
+    throw error;
+  }
+}
+
+export function clearAdminWebMcpTools(): void {
+  dashboardController?.abort();
+  dashboardController = undefined;
+}

--- a/src/client/webmcp/editor-tools.ts
+++ b/src/client/webmcp/editor-tools.ts
@@ -1,0 +1,61 @@
+import {
+  registerWebMcpTools,
+  type WebMcpTool,
+} from "./model-context";
+import {
+  inputJsonSchema,
+  parseInput,
+  saveItemDraftInputSchema,
+  savePageDraftInputSchema,
+  type SaveItemDraftInput,
+  type SavePageDraftInput,
+} from "./schemas";
+
+const writeAnnotations = {
+  readOnlyHint: false,
+  untrustedContentHint: true,
+} as const;
+
+export function itemDraftTool(
+  save: (input: SaveItemDraftInput, signal: AbortSignal) => Promise<unknown>,
+): WebMcpTool {
+  return {
+    annotations: writeAnnotations,
+    description:
+      "Merge title or body HTML into the visible new or unpublished microfeed Item and save it as an unpublished draft.",
+    execute(input, {signal}) {
+      return save(parseInput(saveItemDraftInputSchema, input), signal);
+    },
+    inputSchema: inputJsonSchema(saveItemDraftInputSchema),
+    name: "microfeed_save_item_draft",
+  };
+}
+
+export function pageDraftTool(
+  save: (input: SavePageDraftInput, signal: AbortSignal) => Promise<unknown>,
+): WebMcpTool {
+  return {
+    annotations: writeAnnotations,
+    description:
+      "Merge supplied fields into the visible new or unpublished microfeed Page and save it as an unpublished draft.",
+    execute(input, {signal}) {
+      return save(parseInput(savePageDraftInputSchema, input), signal);
+    },
+    inputSchema: inputJsonSchema(savePageDraftInputSchema),
+    name: "microfeed_save_page_draft",
+  };
+}
+
+export function registerItemDraftTool(
+  signal: AbortSignal,
+  save: (input: SaveItemDraftInput, signal: AbortSignal) => Promise<unknown>,
+): Promise<void> {
+  return registerWebMcpTools([itemDraftTool(save)], signal);
+}
+
+export function registerPageDraftTool(
+  signal: AbortSignal,
+  save: (input: SavePageDraftInput, signal: AbortSignal) => Promise<unknown>,
+): Promise<void> {
+  return registerWebMcpTools([pageDraftTool(save)], signal);
+}

--- a/src/client/webmcp/editor-tools.ts
+++ b/src/client/webmcp/editor-tools.ts
@@ -1,6 +1,7 @@
 import {
   registerWebMcpTools,
   type WebMcpTool,
+  webMcpExecutionSignal,
 } from "./model-context";
 import {
   inputJsonSchema,
@@ -23,8 +24,11 @@ export function itemDraftTool(
     annotations: writeAnnotations,
     description:
       "Merge title or body HTML into the visible new or unpublished microfeed Item and save it as an unpublished draft.",
-    execute(input, {signal}) {
-      return save(parseInput(saveItemDraftInputSchema, input), signal);
+    execute(input, options) {
+      return save(
+        parseInput(saveItemDraftInputSchema, input),
+        webMcpExecutionSignal(options),
+      );
     },
     inputSchema: inputJsonSchema(saveItemDraftInputSchema),
     name: "microfeed_save_item_draft",
@@ -38,8 +42,11 @@ export function pageDraftTool(
     annotations: writeAnnotations,
     description:
       "Merge supplied fields into the visible new or unpublished microfeed Page and save it as an unpublished draft.",
-    execute(input, {signal}) {
-      return save(parseInput(savePageDraftInputSchema, input), signal);
+    execute(input, options) {
+      return save(
+        parseInput(savePageDraftInputSchema, input),
+        webMcpExecutionSignal(options),
+      );
     },
     inputSchema: inputJsonSchema(savePageDraftInputSchema),
     name: "microfeed_save_page_draft",

--- a/src/client/webmcp/feature-detection.ts
+++ b/src/client/webmcp/feature-detection.ts
@@ -1,0 +1,14 @@
+export function nativeWebMcpAvailable(
+  currentDocument: Document = document,
+): boolean {
+  if (currentDocument.querySelector<HTMLMetaElement>(
+    'meta[name="microfeed-webmcp-enabled"]',
+  )?.content !== "true") {
+    return false;
+  }
+  const value = Reflect.get(currentDocument, "modelContext") as unknown;
+  return Boolean(
+    value && typeof value === "object" &&
+      typeof Reflect.get(value, "registerTool") === "function",
+  );
+}

--- a/src/client/webmcp/model-context.ts
+++ b/src/client/webmcp/model-context.ts
@@ -1,7 +1,7 @@
 import {nativeWebMcpAvailable} from "./feature-detection";
 
 export interface WebMcpExecutionOptions {
-  signal: AbortSignal;
+  signal?: AbortSignal;
 }
 
 export interface WebMcpTool {
@@ -12,7 +12,7 @@ export interface WebMcpTool {
   description: string;
   execute: (
     input: unknown,
-    options: WebMcpExecutionOptions,
+    options?: WebMcpExecutionOptions,
   ) => unknown | Promise<unknown>;
   inputSchema: Record<string, unknown>;
   name: string;
@@ -41,6 +41,12 @@ export function nativeModelContext(
   return nativeWebMcpAvailable(currentDocument)
     ? modelContextFromDocument(currentDocument)
     : undefined;
+}
+
+export function webMcpExecutionSignal(
+  options?: WebMcpExecutionOptions,
+): AbortSignal {
+  return options?.signal ?? new AbortController().signal;
 }
 
 export async function registerWebMcpTools(

--- a/src/client/webmcp/model-context.ts
+++ b/src/client/webmcp/model-context.ts
@@ -1,0 +1,55 @@
+import {nativeWebMcpAvailable} from "./feature-detection";
+
+export interface WebMcpExecutionOptions {
+  signal: AbortSignal;
+}
+
+export interface WebMcpTool {
+  annotations?: {
+    readOnlyHint?: boolean;
+    untrustedContentHint?: boolean;
+  };
+  description: string;
+  execute: (
+    input: unknown,
+    options: WebMcpExecutionOptions,
+  ) => unknown | Promise<unknown>;
+  inputSchema: Record<string, unknown>;
+  name: string;
+}
+
+export interface WebMcpModelContext {
+  registerTool: (
+    tool: WebMcpTool,
+    options?: {signal?: AbortSignal},
+  ) => Promise<void>;
+}
+
+function modelContextFromDocument(
+  currentDocument: Document,
+): WebMcpModelContext | undefined {
+  const value = Reflect.get(currentDocument, "modelContext") as unknown;
+  if (!value || typeof value !== "object") return undefined;
+  return typeof Reflect.get(value, "registerTool") === "function"
+    ? value as WebMcpModelContext
+    : undefined;
+}
+
+export function nativeModelContext(
+  currentDocument: Document = document,
+): WebMcpModelContext | undefined {
+  return nativeWebMcpAvailable(currentDocument)
+    ? modelContextFromDocument(currentDocument)
+    : undefined;
+}
+
+export async function registerWebMcpTools(
+  tools: WebMcpTool[],
+  signal: AbortSignal,
+): Promise<void> {
+  const modelContext = nativeModelContext();
+  if (!modelContext || signal.aborted) return;
+  await Promise.all(tools.map((tool) =>
+    modelContext.registerTool(tool, {signal})
+  ));
+}

--- a/src/client/webmcp/page-editor-state.ts
+++ b/src/client/webmcp/page-editor-state.ts
@@ -1,0 +1,23 @@
+import type {SavePageDraftInput} from "./schemas";
+import type {PageRecord} from "@/shared/Pages";
+
+export type PageEditorDraft = Pick<PageRecord,
+  "content_html" | "meta_description" | "navigation_label" |
+  "show_in_navigation" | "slug" | "status" | "title"
+>;
+
+export function pageWebMcpDraftEligible(options: {
+  draftStatus: PageRecord["status"];
+  isNotFoundPage: boolean;
+  savedStatus?: PageRecord["status"];
+}): boolean {
+  return !options.isNotFoundPage && options.draftStatus === "unpublished" &&
+    (options.savedStatus === undefined || options.savedStatus === "unpublished");
+}
+
+export function mergePageWebMcpDraft(
+  current: PageEditorDraft,
+  input: SavePageDraftInput,
+): PageEditorDraft {
+  return {...current, ...input, status: "unpublished"};
+}

--- a/src/client/webmcp/schemas.ts
+++ b/src/client/webmcp/schemas.ts
@@ -1,0 +1,273 @@
+const MAX_ITEMS_PER_PAGE = 300;
+const PAGE_META_DESCRIPTION_MAX_LENGTH = 155;
+const PAGE_SLUG_MAX_LENGTH = 100;
+
+interface InputContract<T> {
+  jsonSchema: Record<string, unknown>;
+  parse: (input: unknown) => T;
+}
+
+interface ListItemsInput {
+  cursor?: string;
+  limit?: number;
+  status?: "published" | "unlisted" | "unpublished";
+}
+
+export interface SaveItemDraftInput {
+  content_html?: string;
+  title?: string;
+}
+
+export interface SavePageDraftInput {
+  content_html?: string;
+  meta_description?: string;
+  navigation_label?: string;
+  show_in_navigation?: boolean;
+  slug?: string;
+  title?: string;
+}
+
+function objectInput(input: unknown): Record<string, unknown> {
+  const value = input ?? {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Tool input must be an object.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function rejectUnknownKeys(
+  input: Record<string, unknown>,
+  allowed: readonly string[],
+): void {
+  const allowedKeys = new Set(allowed);
+  const unknown = Object.keys(input).find((key) => !allowedKeys.has(key));
+  if (unknown) throw new TypeError(`Unrecognized key: "${unknown}"`);
+}
+
+function optionalString(
+  input: Record<string, unknown>,
+  key: string,
+  options: {max?: number; nonempty?: boolean} = {},
+): string | undefined {
+  const value = input[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new TypeError(`${key} must be a string.`);
+  }
+  if (options.nonempty && !value.trim()) {
+    throw new TypeError(`${key} must not be empty.`);
+  }
+  if (options.max !== undefined && value.length > options.max) {
+    throw new TypeError(`${key} must be at most ${options.max} characters.`);
+  }
+  return value;
+}
+
+function objectSchema(
+  properties: Record<string, unknown>,
+  options: {minProperties?: number; required?: string[]} = {},
+): Record<string, unknown> {
+  return {
+    additionalProperties: false,
+    ...(options.minProperties === undefined
+      ? {}
+      : {minProperties: options.minProperties}),
+    properties,
+    ...(options.required ? {required: options.required} : {}),
+    type: "object",
+  };
+}
+
+export const listItemsInputSchema: InputContract<ListItemsInput> = {
+  jsonSchema: objectSchema({
+    cursor: {
+      description: "Opaque next cursor returned by the previous call.",
+      minLength: 1,
+      type: "string",
+    },
+    limit: {
+      description: `Maximum summaries to return, from 1 to ${MAX_ITEMS_PER_PAGE}.`,
+      maximum: MAX_ITEMS_PER_PAGE,
+      minimum: 1,
+      type: "integer",
+    },
+    status: {
+      enum: ["published", "unlisted", "unpublished"],
+      type: "string",
+    },
+  }),
+  parse(input) {
+    const value = objectInput(input);
+    rejectUnknownKeys(value, ["cursor", "limit", "status"]);
+    const cursor = optionalString(value, "cursor", {nonempty: true});
+    const limit = value.limit;
+    if (
+      limit !== undefined &&
+      (typeof limit !== "number" || !Number.isInteger(limit) ||
+        limit < 1 || limit > MAX_ITEMS_PER_PAGE)
+    ) {
+      throw new TypeError(
+        `limit must be an integer from 1 to ${MAX_ITEMS_PER_PAGE}.`,
+      );
+    }
+    const status = value.status;
+    if (
+      status !== undefined && status !== "published" &&
+      status !== "unlisted" && status !== "unpublished"
+    ) {
+      throw new TypeError("status must be published, unlisted, or unpublished.");
+    }
+    return {
+      ...(cursor ? {cursor} : {}),
+      ...(limit === undefined ? {} : {limit: limit as number}),
+      ...(status === undefined
+        ? {}
+        : {status: status as ListItemsInput["status"]}),
+    };
+  },
+};
+
+function idInput(
+  key: "item_id" | "page_id",
+): InputContract<Record<string, string>> {
+  return {
+    jsonSchema: objectSchema({
+      [key]: {maxLength: 200, minLength: 1, type: "string"},
+    }, {required: [key]}),
+    parse(input) {
+      const value = objectInput(input);
+      rejectUnknownKeys(value, [key]);
+      const id = optionalString(value, key, {max: 200, nonempty: true});
+      if (!id) throw new TypeError(`${key} is required.`);
+      return {[key]: id};
+    },
+  };
+}
+
+export const getItemInputSchema = idInput("item_id") as InputContract<{
+  item_id: string;
+}>;
+export const getPageInputSchema = idInput("page_id") as InputContract<{
+  page_id: string;
+}>;
+
+export const emptyInputSchema: InputContract<Record<string, never>> = {
+  jsonSchema: objectSchema({}),
+  parse(input) {
+    const value = objectInput(input);
+    rejectUnknownKeys(value, []);
+    return {};
+  },
+};
+
+export const startDraftInputSchema: InputContract<{kind: "item" | "page"}> = {
+  jsonSchema: objectSchema({
+    kind: {enum: ["item", "page"], type: "string"},
+  }, {required: ["kind"]}),
+  parse(input) {
+    const value = objectInput(input);
+    rejectUnknownKeys(value, ["kind"]);
+    if (value.kind !== "item" && value.kind !== "page") {
+      throw new TypeError("kind must be item or page.");
+    }
+    return {kind: value.kind};
+  },
+};
+
+export const saveItemDraftInputSchema: InputContract<SaveItemDraftInput> = {
+  jsonSchema: objectSchema({
+    content_html: {
+      description: "Rich-text HTML for the item body.",
+      type: "string",
+    },
+    title: {type: "string"},
+  }, {minProperties: 1}),
+  parse(input) {
+    const value = objectInput(input);
+    rejectUnknownKeys(value, ["content_html", "title"]);
+    const contentHtml = optionalString(value, "content_html");
+    const title = optionalString(value, "title");
+    if (contentHtml === undefined && title === undefined) {
+      throw new TypeError("Supply at least one item field to save.");
+    }
+    return {
+      ...(contentHtml === undefined ? {} : {content_html: contentHtml}),
+      ...(title === undefined ? {} : {title}),
+    };
+  },
+};
+
+export const savePageDraftInputSchema: InputContract<SavePageDraftInput> = {
+  jsonSchema: objectSchema({
+    content_html: {
+      description: "Rich-text HTML for the Page body.",
+      type: "string",
+    },
+    meta_description: {
+      maxLength: PAGE_META_DESCRIPTION_MAX_LENGTH,
+      type: "string",
+    },
+    navigation_label: {maxLength: 100, type: "string"},
+    show_in_navigation: {type: "boolean"},
+    slug: {maxLength: PAGE_SLUG_MAX_LENGTH, type: "string"},
+    title: {maxLength: 200, type: "string"},
+  }, {minProperties: 1}),
+  parse(input) {
+    const value = objectInput(input);
+    rejectUnknownKeys(value, [
+      "content_html",
+      "meta_description",
+      "navigation_label",
+      "show_in_navigation",
+      "slug",
+      "title",
+    ]);
+    const result: SavePageDraftInput = {
+      ...(value.content_html === undefined
+        ? {}
+        : {content_html: optionalString(value, "content_html")}),
+      ...(value.meta_description === undefined
+        ? {}
+        : {
+            meta_description: optionalString(value, "meta_description", {
+              max: PAGE_META_DESCRIPTION_MAX_LENGTH,
+            }),
+          }),
+      ...(value.navigation_label === undefined
+        ? {}
+        : {
+            navigation_label: optionalString(value, "navigation_label", {
+              max: 100,
+            }),
+          }),
+      ...(value.slug === undefined
+        ? {}
+        : {
+            slug: optionalString(value, "slug", {max: PAGE_SLUG_MAX_LENGTH}),
+          }),
+      ...(value.title === undefined
+        ? {}
+        : {title: optionalString(value, "title", {max: 200})}),
+    };
+    if (value.show_in_navigation !== undefined) {
+      if (typeof value.show_in_navigation !== "boolean") {
+        throw new TypeError("show_in_navigation must be a boolean.");
+      }
+      result.show_in_navigation = value.show_in_navigation;
+    }
+    if (Object.keys(result).length === 0) {
+      throw new TypeError("Supply at least one Page field to save.");
+    }
+    return result;
+  },
+};
+
+export function inputJsonSchema<T>(
+  schema: InputContract<T>,
+): Record<string, unknown> {
+  return schema.jsonSchema;
+}
+
+export function parseInput<T>(schema: InputContract<T>, input: unknown): T {
+  return schema.parse(input);
+}

--- a/src/components/admin/items/EditItemApp/index.tsx
+++ b/src/components/admin/items/EditItemApp/index.tsx
@@ -51,6 +51,9 @@ import {
 } from "@/components/ui/alert-dialog";
 import {queueReplacedImageUrl} from "@/client/ImageUploadUtils";
 import AdminSaveAction from "@/components/admin/shared/AdminSaveAction";
+import {nativeWebMcpAvailable} from "@/client/webmcp/feature-detection";
+import {WEBMCP_INTERACTION_HEADERS} from "@/shared/WebMcp";
+import type {SaveItemDraftInput} from "@/client/webmcp/schemas";
 
 const SUBMIT_STATUS__START = 1;
 
@@ -75,6 +78,7 @@ interface Props {
 interface ItemSnapshot {
   deleteImageUrls: string[];
   item: Record<string, unknown>;
+  webMcpSignal?: AbortSignal;
 }
 
 export default class EditItemApp extends React.Component<Props, any> {
@@ -82,6 +86,9 @@ export default class EditItemApp extends React.Component<Props, any> {
   private cleanupNavigationGuard?: () => void;
   private mounted = false;
   private publishRequested = false;
+  private webMcpController?: AbortController;
+  private webMcpLoadVersion = 0;
+  private webMcpSaveSignal?: AbortSignal;
 
   constructor(props: Props) {
     super(props);
@@ -120,6 +127,9 @@ export default class EditItemApp extends React.Component<Props, any> {
       getSnapshot: () => ({
         deleteImageUrls: [...this.state.replacedImageUrls],
         item: {id: this.state.itemId, ...this.state.item},
+        ...(this.webMcpSaveSignal
+          ? {webMcpSignal: this.webMcpSaveSignal}
+          : {}),
       }),
       onError: (error) => this.showSaveError(error),
       onStateChange: (autosaveState) => {
@@ -154,10 +164,19 @@ export default class EditItemApp extends React.Component<Props, any> {
         this.onUpdateItemMeta(attrDict);
       }
     }
+    this.reconcileWebMcpTool();
+  }
+
+  componentDidUpdate(_previousProps: Props, previousState: any) {
+    if (previousState.item.status !== this.state.item.status) {
+      this.reconcileWebMcpTool();
+    }
   }
 
   componentWillUnmount() {
     this.mounted = false;
+    this.webMcpLoadVersion += 1;
+    this.webMcpController?.abort();
     this.autosave.dispose();
     this.cleanupNavigationGuard?.();
   }
@@ -221,7 +240,21 @@ export default class EditItemApp extends React.Component<Props, any> {
   }
 
   async saveSnapshot(snapshot: ItemSnapshot) {
-    await Requests.axiosPost(ADMIN_URLS.ajaxFeed(), snapshot);
+    const {webMcpSignal, ...body} = snapshot;
+    if (webMcpSignal) {
+      try {
+        await Requests.axiosPost(ADMIN_URLS.ajaxFeed(), body, {
+          headers: WEBMCP_INTERACTION_HEADERS,
+          signal: webMcpSignal,
+        });
+      } finally {
+        if (this.webMcpSaveSignal === webMcpSignal) {
+          this.webMcpSaveSignal = undefined;
+        }
+      }
+    } else {
+      await Requests.axiosPost(ADMIN_URLS.ajaxFeed(), body);
+    }
     if (!this.mounted) return;
 
     const created = this.state.action === 'create';
@@ -262,6 +295,74 @@ export default class EditItemApp extends React.Component<Props, any> {
     } else {
       showToast('Couldn’t save. Your changes are still on this page.', 'error');
     }
+  }
+
+  private reconcileWebMcpTool() {
+    this.webMcpLoadVersion += 1;
+    const loadVersion = this.webMcpLoadVersion;
+    this.webMcpController?.abort();
+    this.webMcpController = undefined;
+    if (
+      !this.mounted || this.state.item.status !== STATUSES.UNPUBLISHED ||
+      !nativeWebMcpAvailable()
+    ) {
+      return;
+    }
+    void import("@/client/webmcp/editor-tools").then(
+      ({registerItemDraftTool}) => {
+        if (!this.mounted || loadVersion !== this.webMcpLoadVersion) return;
+        const controller = new AbortController();
+        this.webMcpController = controller;
+        return registerItemDraftTool(
+          controller.signal,
+          (input, signal) => this.saveWebMcpDraft(input, signal),
+        );
+      },
+    ).catch((error) => {
+      if (!this.webMcpController?.signal.aborted) {
+        this.webMcpController?.abort();
+        console.warn(error);
+      }
+    });
+  }
+
+  private async saveWebMcpDraft(
+    input: SaveItemDraftInput,
+    signal: AbortSignal,
+  ) {
+    if (signal.aborted) throw signal.reason;
+    if (this.state.item.status !== STATUSES.UNPUBLISHED) {
+      throw new Error("WebMCP can save only the visible unpublished Item.");
+    }
+    this.webMcpSaveSignal = signal;
+    await new Promise<void>((resolve) => {
+      this.setState((previousState: any) => ({
+        item: {
+          ...previousState.item,
+          ...(input.title !== undefined ? {title: input.title} : {}),
+          ...(input.content_html !== undefined
+            ? {description: input.content_html}
+            : {}),
+          status: STATUSES.UNPUBLISHED,
+        },
+      }), () => {
+        this.autosave.markChanged({immediate: true});
+        resolve();
+      });
+    });
+    if (!await this.autosave.flush()) {
+      throw new Error("The Item draft could not be saved.");
+    }
+    return {
+      content_html: String(this.state.item.description ?? ""),
+      editor_url: new URL(
+        ADMIN_URLS.editItem(this.state.itemId),
+        window.location.origin,
+      ).toString(),
+      id: this.state.itemId,
+      status: "unpublished",
+      title: String(this.state.item.title ?? ""),
+    };
   }
 
   render() {

--- a/src/components/admin/pages/PageEditorApp.tsx
+++ b/src/components/admin/pages/PageEditorApp.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from "react";
+import {useCallback, useEffect, useRef, useState} from "react";
 import {
   ExternalLinkIcon,
   SaveIcon,
@@ -7,6 +7,13 @@ import {
 
 import {preventCloseWhenChanged} from "@/client/BrowserUtils";
 import {showToast} from "@/client/ToastUtils";
+import {nativeWebMcpAvailable} from "@/client/webmcp/feature-detection";
+import type {SavePageDraftInput} from "@/client/webmcp/schemas";
+import {
+  mergePageWebMcpDraft,
+  pageWebMcpDraftEligible,
+  type PageEditorDraft,
+} from "@/client/webmcp/page-editor-state";
 import AdminHelpLabel from "@/components/admin/shared/AdminHelpLabel";
 import AdminRichEditor from "@/components/admin/shared/AdminRichEditor";
 import {Button} from "@/components/ui/button";
@@ -29,11 +36,9 @@ import {
   pageNavigationEnabledForStatus,
   type PageRecord,
 } from "@/shared/Pages";
+import {WEBMCP_INTERACTION_HEADERS} from "@/shared/WebMcp";
 
-type Draft = Pick<PageRecord,
-  "content_html" | "meta_description" | "navigation_label" |
-  "show_in_navigation" | "slug" | "status" | "title"
->;
+type Draft = PageEditorDraft;
 
 const EMPTY_PAGE: Draft = {
   content_html: "",
@@ -183,6 +188,8 @@ export default function PageEditorApp({
   const [helpTopic, setHelpTopic] = useState<HelpTopic | null>(null);
   const [savedPage, setSavedPage] = useState<PageRecord | undefined>(page);
   const changedRef = useRef(false);
+  const busyRef = useRef(false);
+  const draftRef = useRef(draft);
   const isNotFoundPage = Boolean(page?.is_not_found_page);
   useEffect(() => preventCloseWhenChanged(() => changedRef.current), []);
   useEffect(() => {
@@ -192,66 +199,152 @@ export default function PageEditorApp({
     window.sessionStorage.removeItem(PAGE_CREATED_TOAST_KEY);
     showToast("Page created.", "success");
   }, [page]);
-  const markChanged = (value: boolean) => {
+  const markChanged = useCallback((value: boolean) => {
     changedRef.current = value;
     setChanged(value);
-  };
+  }, []);
   const update = (value: Partial<Draft>) => {
-    setDraft((current) => ({...current, ...value}));
+    setDraft((current) => {
+      const next = {...current, ...value};
+      draftRef.current = next;
+      return next;
+    });
     markChanged(true);
   };
 
-  const save = async () => {
-    if (!draft.title.trim()) {
-      showToast("Give the Page a title.", "error");
-      return;
+  const persistDraft = useCallback(async (
+    nextDraft: Draft,
+    options: {signal?: AbortSignal; webMcp?: boolean} = {},
+  ): Promise<PageRecord> => {
+    if (busyRef.current) {
+      throw new Error("A Page save is already in progress.");
     }
-    if (!isNotFoundPage && !draft.slug.trim()) {
-      showToast("Enter a URL path, such as about.", "error");
-      return;
+    if (!nextDraft.title.trim()) {
+      throw new Error("Give the Page a title.");
+    }
+    if (!isNotFoundPage && !nextDraft.slug.trim()) {
+      throw new Error("Enter a URL path, such as about.");
     }
     if (
-      !isNotFoundPage && draft.show_in_navigation &&
-      !draft.navigation_label.trim()
+      !isNotFoundPage && nextDraft.show_in_navigation &&
+      !nextDraft.navigation_label.trim()
     ) {
-      showToast(
+      throw new Error(
         "Enter a navigation label, or turn off Show in navigation.",
-        "error",
       );
-      return;
     }
     if (
       !isNotFoundPage && !themeSupportsPages &&
-      draft.status !== "unpublished"
+      nextDraft.status !== "unpublished"
     ) {
-      showToast("Activate a format v2 theme before publishing this Page.", "error");
-      return;
+      throw new Error(
+        "Activate a format v2 theme before publishing this Page.",
+      );
     }
+    busyRef.current = true;
     setBusy(true);
     try {
       const saved = await responseJson(await fetch(
         page ? ADMIN_URLS.ajaxPage(page.id) : ADMIN_URLS.ajaxPages(),
         {
-          body: JSON.stringify(draft),
-          headers: {"content-type": "application/json"},
+          body: JSON.stringify(nextDraft),
+          headers: {
+            "content-type": "application/json",
+            ...(options.webMcp ? WEBMCP_INTERACTION_HEADERS : {}),
+          },
           method: page ? "PUT" : "POST",
+          signal: options.signal,
         },
       )) as PageRecord;
       markChanged(false);
+      draftRef.current = saved;
+      setDraft(saved);
+      setSavedPage(saved);
+      return saved;
+    } finally {
+      busyRef.current = false;
+      setBusy(false);
+    }
+  }, [isNotFoundPage, markChanged, page, themeSupportsPages]);
+
+  const save = async () => {
+    try {
+      const saved = await persistDraft(draft);
       if (!page) {
         window.sessionStorage.setItem(PAGE_CREATED_TOAST_KEY, saved.id);
         window.location.assign(ADMIN_URLS.editPage(saved.id));
       } else {
         showToast("Page saved.", "success");
-        setDraft(saved);
-        setSavedPage(saved);
       }
     } catch (error) {
       showToast(error instanceof Error ? error.message : "Page operation failed.", "error");
-    } finally {
-      setBusy(false);
     }
   };
+
+  useEffect(() => {
+    const eligible = pageWebMcpDraftEligible({
+      draftStatus: draft.status,
+      isNotFoundPage,
+      savedStatus: page ? savedPage?.status : undefined,
+    });
+    if (!eligible || !nativeWebMcpAvailable()) return;
+    const controller = new AbortController();
+    void import("@/client/webmcp/editor-tools").then(
+      ({registerPageDraftTool}) => registerPageDraftTool(
+        controller.signal,
+        async (input: SavePageDraftInput, signal) => {
+          const current = draftRef.current;
+          if (
+            current.status !== "unpublished" ||
+            (page && savedPage?.status !== "unpublished")
+          ) {
+            throw new Error(
+              "WebMCP can save only the visible unpublished Page.",
+            );
+          }
+          const next = mergePageWebMcpDraft(current, input);
+          draftRef.current = next;
+          setDraft(next);
+          markChanged(true);
+          const saved = await persistDraft(next, {signal, webMcp: true});
+          const editorUrl = new URL(
+            ADMIN_URLS.editPage(saved.id),
+            window.location.origin,
+          ).toString();
+          if (!page) {
+            window.sessionStorage.setItem(PAGE_CREATED_TOAST_KEY, saved.id);
+            setTimeout(() => window.location.assign(editorUrl), 0);
+          } else {
+            showToast("Page saved.", "success");
+          }
+          return {
+            content_html: saved.content_html,
+            editor_url: editorUrl,
+            id: saved.id,
+            meta_description: saved.meta_description ?? "",
+            navigation_label: saved.navigation_label,
+            show_in_navigation: saved.show_in_navigation,
+            slug: saved.slug,
+            status: "unpublished",
+            title: saved.title,
+          };
+        },
+      ),
+    ).catch((error) => {
+      if (!controller.signal.aborted) {
+        controller.abort();
+        console.warn(error);
+      }
+    });
+    return () => controller.abort();
+  }, [
+    draft.status,
+    isNotFoundPage,
+    markChanged,
+    page,
+    persistDraft,
+    savedPage?.status,
+  ]);
 
   const remove = async () => {
     if (!page || !window.confirm(`Delete “${page.title}”? Its old paths will remain reserved.`)) return;

--- a/src/layouts/AdminShell.astro
+++ b/src/layouts/AdminShell.astro
@@ -194,6 +194,10 @@ const webhookSidebar: AdminWebhookSidebarData | undefined = webhookNavigation
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="microfeed-admin-path" content={adminPath} />
+    <meta
+      name="microfeed-webmcp-enabled"
+      content={protectedDashboard ? "true" : "false"}
+    />
     <title>{documentTitle ?? `${pageTitle} | microfeed.org`}</title>
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon/favicon-32x32.png" />
@@ -265,6 +269,23 @@ const webhookSidebar: AdminWebhookSidebarData | undefined = webhookNavigation
         browserAdminPath,
         isAdminPathname,
       } from "@/shared/AdminPath";
+      import {nativeWebMcpAvailable} from
+        "@/client/webmcp/feature-detection";
+
+      type WebMcpAdminModule = typeof import("@/client/webmcp/admin-tools");
+
+      let webMcpAdminModule: Promise<WebMcpAdminModule> | undefined;
+
+      const reconcileWebMcp = async () => {
+        if (!nativeWebMcpAvailable()) {
+          if (webMcpAdminModule) {
+            (await webMcpAdminModule).clearAdminWebMcpTools();
+          }
+          return;
+        }
+        webMcpAdminModule ??= import("@/client/webmcp/admin-tools");
+        await (await webMcpAdminModule).reconcileAdminWebMcpTools();
+      };
 
       const staysInProtectedAdmin = (destination: URL) => {
         const configuredAdminPath = browserAdminPath();
@@ -289,6 +310,12 @@ const webhookSidebar: AdminWebhookSidebarData | undefined = webhookNavigation
             event.preventDefault();
           }
         };
+      });
+      document.addEventListener("astro:page-load", () => {
+        void reconcileWebMcp().catch((error) => console.warn(
+          "microfeed could not register WebMCP tools.",
+          error,
+        ));
       });
     </script>
   </body>

--- a/src/pages/[adminPath]/ajax/feed.ts
+++ b/src/pages/[adminPath]/ajax/feed.ts
@@ -15,6 +15,10 @@ import {
   webhookItemObject,
 } from "@/server/webhooks/emission";
 import {commitMutationWithWebhookEvents} from "@/server/webhooks/events";
+import {
+  isUnpublishedStatus,
+  isWebMcpInteraction,
+} from "@/shared/WebMcp";
 
 export async function updateAdminFeed(
   request: Request,
@@ -22,16 +26,44 @@ export async function updateAdminFeed(
   schedule: (promise: Promise<unknown>) => void,
   publicCachePurger?: PublicCachePurger,
 ): Promise<Response> {
-  const updatedFeed = await request.json() as FeedContent;
+  const updatedFeed = await request.json().catch(() => null) as
+    | FeedContent
+    | null;
+  if (!updatedFeed || typeof updatedFeed !== "object") {
+    return jsonResponse({error: "Send a valid feed update."}, {status: 400});
+  }
+  const webMcpInteraction = isWebMcpInteraction(request);
+  const updatedItemId = updatedFeed.item?.id;
+  if (
+    webMcpInteraction &&
+    (typeof updatedItemId !== "string" || !updatedItemId.trim())
+  ) {
+    return jsonResponse({error: "Choose an Item draft to save."}, {status: 400});
+  }
+  if (webMcpInteraction && (
+    !updatedFeed.item || updatedFeed.channel || updatedFeed.settings ||
+    !isUnpublishedStatus(updatedFeed.item.status)
+  )) {
+    return jsonResponse({
+      error: "WebMCP can save only an unpublished Item draft.",
+    }, {status: 409});
+  }
   const deleteImageUrls = Array.isArray(updatedFeed.deleteImageUrls)
     ? updatedFeed.deleteImageUrls
     : [];
   const database = new FeedDb(runtimeEnv, request, publicCachePurger);
-  const updatedItemId = updatedFeed.item?.id;
   const [beforeItem, beforeChannelContent] = await Promise.all([
     updatedItemId ? database.getItemById(updatedItemId) : null,
     updatedFeed.channel ? database.getContent(null) : null,
   ]);
+  if (
+    webMcpInteraction && beforeItem &&
+    !isUnpublishedStatus(beforeItem.status)
+  ) {
+    return jsonResponse({
+      error: "WebMCP cannot change an Item that is no longer unpublished.",
+    }, {status: 409});
+  }
   await database.putContent(updatedFeed, async (statements) => {
     const events = [];
     if (updatedItemId && updatedFeed.item) {
@@ -78,7 +110,7 @@ export async function updateAdminFeed(
       request,
       statements,
       events,
-      {origin: "dashboard"},
+      {origin: webMcpInteraction ? "webmcp" : "dashboard"},
     );
   });
   scheduleBestEffortMediaDeletion(

--- a/src/pages/[adminPath]/ajax/items/[itemId].ts
+++ b/src/pages/[adminPath]/ajax/items/[itemId].ts
@@ -1,0 +1,1 @@
+export {getAdminItem as GET} from "@/server/admin/item-handlers";

--- a/src/server/admin/item-handlers.ts
+++ b/src/server/admin/item-handlers.ts
@@ -1,9 +1,10 @@
-import {env} from "cloudflare:workers";
+import {cache, env} from "cloudflare:workers";
 import type {APIRoute} from "astro";
 
 import {normalizeAdminItemListLimit} from "@/shared/AdminCollections";
 import {jsonResponse} from "@/server/http";
 import {listAdminItems} from "@/server/items/admin-list";
+import FeedDb from "@/server/feed/FeedDb";
 
 export const listAdminItemSummaries: APIRoute = async ({request}) => {
   const url = new URL(request.url);
@@ -13,4 +14,21 @@ export const listAdminItemSummaries: APIRoute = async ({request}) => {
     }),
     {headers: {"cache-control": "private, no-store"}},
   );
+};
+
+export const getAdminItem: APIRoute = async ({params, request}) => {
+  const item = params.itemId
+    ? await new FeedDb(env, request, cache).getItemById(params.itemId)
+    : null;
+  return item
+    ? jsonResponse({
+        content_html: String(item.description ?? ""),
+        id: String(item.id ?? params.itemId),
+        status: item.status,
+        title: String(item.title ?? ""),
+      }, {headers: {"cache-control": "private, no-store"}})
+    : jsonResponse(
+        {error: "Item not found."},
+        {headers: {"cache-control": "private, no-store"}, status: 404},
+      );
 };

--- a/src/server/admin/page-handlers.ts
+++ b/src/server/admin/page-handlers.ts
@@ -25,6 +25,10 @@ import {
   contentMutationWebhookCommit,
   singleWebhookEventCommit,
 } from "@/server/webhooks/emission";
+import {
+  isUnpublishedStatus,
+  isWebMcpInteraction,
+} from "@/shared/WebMcp";
 
 const pageNavigationOrderSchema = z.object({
   page_ids: z.array(z.string().min(1)).max(100),
@@ -74,11 +78,21 @@ export const createAdminPage: APIRoute = async ({request}) => {
       {status: 400},
     );
   }
+  const webMcpInteraction = isWebMcpInteraction(request);
+  if (
+    webMcpInteraction && !isUnpublishedStatus(parsed.data.status)
+  ) {
+    return jsonResponse({
+      error: "WebMCP can create only an unpublished Page draft.",
+    }, {status: 409});
+  }
   try {
     const page = await createPage(database(request), request, parsed.data, {
       adminPath: env.MICROFEED_ADMIN_PATH,
       commit: contentMutationWebhookCommit(env, request, {
-        context: {origin: "dashboard"},
+        context: {
+          origin: webMcpInteraction ? "webmcp" : "dashboard",
+        },
         id: (result) => result.id,
         kind: "page",
         mutation: "created",
@@ -142,12 +156,28 @@ export const updateAdminPage: APIRoute = async ({params, request}) => {
         : "Choose a Page to update.",
     }, {status: 400});
   }
+  const webMcpInteraction = isWebMcpInteraction(request);
+  if (
+    webMcpInteraction && !isUnpublishedStatus(parsed.data.status)
+  ) {
+    return jsonResponse({
+      error: "WebMCP can save only an unpublished Page draft.",
+    }, {status: 409});
+  }
   try {
     const before = await getPageById(
       env.FEED_DB,
       request,
       params.pageId,
     );
+    if (
+      webMcpInteraction && before &&
+      !isUnpublishedStatus(before.status)
+    ) {
+      return jsonResponse({
+        error: "WebMCP cannot change a Page that is no longer unpublished.",
+      }, {status: 409});
+    }
     const page = await updatePage(
       database(request),
       request,
@@ -157,7 +187,9 @@ export const updateAdminPage: APIRoute = async ({params, request}) => {
         adminPath: env.MICROFEED_ADMIN_PATH,
         commit: contentMutationWebhookCommit(env, request, {
           before: before as unknown as Record<string, unknown> | null,
-          context: {origin: "dashboard"},
+          context: {
+            origin: webMcpInteraction ? "webmcp" : "dashboard",
+          },
           id: params.pageId,
           kind: "page",
           mutation: "updated",

--- a/src/server/openapi/document.ts
+++ b/src/server/openapi/document.ts
@@ -17,6 +17,11 @@ export const API_LLMS_TEXT = `# microfeed API\n\n` +
   `Full API guide: ${API_BASE_PATH}llms-full.txt\n\n` +
   `Authenticate with an API key or scoped OAuth access token: ` +
   `Authorization: Bearer YOUR_CREDENTIAL\n\n` +
+  `For interactive work in a signed-in dashboard, compatible browser agents ` +
+  `can separately discover experimental, draft-only WebMCP site tools. ` +
+  `WebMCP requires the protected dashboard to be open; this API reference ` +
+  `does not expose a remote MCP server. Guide: ` +
+  `https://docs.microfeed.org/automation/ai-agents/#use-webmcp-for-visible-drafts\n\n` +
   API_OPERATION_SUMMARY + "\n";
 
 export const API_LLMS_FULL_TEXT = `# microfeed API\n\n` +
@@ -36,6 +41,12 @@ export const API_LLMS_FULL_TEXT = `# microfeed API\n\n` +
   `use JSON file or standard-input payloads, never request or print a key or ` +
   `token, pause for user-controlled browser consent, and confirm an exact ` +
   `item ID before deletion.\n\n` +
+  `For interactive work in a signed-in dashboard, compatible browser agents ` +
+  `can separately discover experimental, draft-only WebMCP site tools. ` +
+  `Those tools are available only after the agent opens the protected ` +
+  `dashboard; this API reference advertises the capability but is not a ` +
+  `remote MCP endpoint. See ` +
+  `https://docs.microfeed.org/automation/ai-agents/#use-webmcp-for-visible-drafts.\n\n` +
   `The API base path is ${API_BASE_PATH}. Operation paths in the contract ` +
   `are relative ` +
   `to that base path.\n\n` +

--- a/src/server/webhooks/events.ts
+++ b/src/server/webhooks/events.ts
@@ -6,7 +6,7 @@ import {
 } from "@/shared/Webhooks";
 import {WebhookRequestError, WebhookUnavailableError} from "./validation";
 
-export type WebhookOrigin = "api" | "dashboard" | "system";
+export type WebhookOrigin = "api" | "dashboard" | "system" | "webmcp";
 
 export interface WebhookEventContext {
   causationId?: string;

--- a/src/shared/ApiSchemas.ts
+++ b/src/shared/ApiSchemas.ts
@@ -509,7 +509,7 @@ export const apiWebhookTestSubjectSchema = apiWebhookSubjectSchema.extend({
 export const apiWebhookContextSchema = z.object({
   causation_id: apiAutomationContextIdSchema.nullable(),
   correlation_id: apiAutomationContextIdSchema,
-  origin: z.enum(["dashboard", "api", "system"]),
+  origin: z.enum(["dashboard", "api", "system", "webmcp"]),
   request_id: z.string(),
 }).meta({id: "WebhookContext"});
 

--- a/src/shared/OpenApiDocument.ts
+++ b/src/shared/OpenApiDocument.ts
@@ -87,7 +87,10 @@ export const OPENAPI_DOCUMENT = createDocument({
     version: MICROFEED_VERSION,
     description:
       "Create, read, update, and delete content in this microfeed instance. " +
-      "Send an API key using Bearer authentication.",
+      "Send an API key using Bearer authentication. A protected dashboard " +
+      "can separately expose experimental, draft-only WebMCP site tools to " +
+      "compatible browser agents after the signed-in dashboard is opened; " +
+      "WebMCP is not a remote API or MCP server.",
     license: {
       name: "GNU Affero General Public License v3.0",
       identifier: "AGPL-3.0-only",

--- a/src/shared/SiteFileTemplates.ts
+++ b/src/shared/SiteFileTemplates.ts
@@ -16,6 +16,8 @@ const DEFAULT_LLMS_TEMPLATE = `# {{{title}}}
 
 This site is powered by [microfeed](https://github.com/microfeed/microfeed), an agentic CMS on Cloudflare.
 
+For administrators, the protected dashboard can expose experimental, draft-only [WebMCP site tools](https://docs.microfeed.org/automation/ai-agents/#use-webmcp-for-visible-drafts) to a compatible browser agent. The agent discovers them only after it opens the signed-in dashboard; this public file is not a remote MCP endpoint.
+
 {{#_site.api_llms_full_url}}
 This site's API is enabled. Learn how to use it at <{{{_site.api_llms_full_url}}}>.
 {{/_site.api_llms_full_url}}

--- a/src/shared/WebMcp.ts
+++ b/src/shared/WebMcp.ts
@@ -1,0 +1,16 @@
+export const WEBMCP_INTERACTION_SOURCE_HEADER =
+  "Microfeed-Interaction-Source";
+export const WEBMCP_INTERACTION_SOURCE = "webmcp";
+
+export const WEBMCP_INTERACTION_HEADERS = {
+  [WEBMCP_INTERACTION_SOURCE_HEADER]: WEBMCP_INTERACTION_SOURCE,
+} as const;
+
+export function isWebMcpInteraction(request: Request): boolean {
+  return request.headers.get(WEBMCP_INTERACTION_SOURCE_HEADER)
+    ?.toLocaleLowerCase("en-US") === WEBMCP_INTERACTION_SOURCE;
+}
+
+export function isUnpublishedStatus(value: unknown): boolean {
+  return value === "unpublished" || value === 2;
+}

--- a/tests/unit/components/admin-autosave-editors.test.ts
+++ b/tests/unit/components/admin-autosave-editors.test.ts
@@ -170,7 +170,6 @@ describe("admin editor autosave", () => {
     let settled = false;
     const execution = tool.execute(
       {content_html: "<p>Agent body</p>", title: "Agent title"},
-      {signal: new AbortController().signal},
     ).then((value: unknown) => {
       settled = true;
       return value;
@@ -187,7 +186,10 @@ describe("admin editor autosave", () => {
           title: "Agent title",
         }),
       }),
-      expect.objectContaining({headers: WEBMCP_INTERACTION_HEADERS}),
+      expect.objectContaining({
+        headers: WEBMCP_INTERACTION_HEADERS,
+        signal: expect.any(AbortSignal),
+      }),
     );
     pending.resolve({});
     await expect(execution).resolves.toMatchObject({

--- a/tests/unit/components/admin-autosave-editors.test.ts
+++ b/tests/unit/components/admin-autosave-editors.test.ts
@@ -11,6 +11,7 @@ import AdminDatetimePicker from "@/components/admin/shared/AdminDatetimePicker";
 import AdminRadioGroup from "@/components/admin/shared/AdminRadioGroup";
 import {Button} from "@/components/ui/button";
 import {STATUSES} from "@/shared/Constants";
+import {WEBMCP_INTERACTION_HEADERS} from "@/shared/WebMcp";
 
 vi.mock("@/client/ToastUtils", () => ({showToast: vi.fn()}));
 vi.mock("astro:transitions/client", () => ({navigate: vi.fn()}));
@@ -115,7 +116,12 @@ beforeEach(() => {
       windowListeners.set(name, listener);
     }),
     history: {replaceState: vi.fn(), state: null},
-    location: {hostname: "feed.example.com", search: ""},
+    location: {
+      assign: vi.fn(),
+      hostname: "feed.example.com",
+      origin: "https://feed.example.com",
+      search: "",
+    },
     removeEventListener: vi.fn((name: string) => {
       windowListeners.delete(name);
     }),
@@ -142,6 +148,78 @@ afterEach(() => {
 });
 
 describe("admin editor autosave", () => {
+  it("registers an Item save tool only for drafts and awaits persistence", async () => {
+    const registerTool = vi.fn(async (
+      _tool: any,
+      _options: {signal: AbortSignal},
+    ) => undefined);
+    vi.mocked(document.querySelector).mockImplementation((selector: string) =>
+      selector.includes("microfeed-webmcp-enabled")
+        ? {content: "true"} as HTMLMetaElement
+        : {content: "admin"} as HTMLMetaElement
+    );
+    Reflect.set(document, "modelContext", {registerTool});
+    const app = mount(new EditItemApp(props()));
+    await vi.waitFor(() => expect(registerTool).toHaveBeenCalledOnce());
+    const [tool, registration] = registerTool.mock.calls[0]!;
+    expect(tool.name).toBe("microfeed_save_item_draft");
+
+    app.onUpdateItemMeta({link: "https://example.com/human-change"});
+    const pending = deferred<any>();
+    vi.mocked(Requests.axiosPost).mockReturnValueOnce(pending.promise);
+    let settled = false;
+    const execution = tool.execute(
+      {content_html: "<p>Agent body</p>", title: "Agent title"},
+      {signal: new AbortController().signal},
+    ).then((value: unknown) => {
+      settled = true;
+      return value;
+    });
+    await vi.waitFor(() => expect(Requests.axiosPost).toHaveBeenCalledOnce());
+    expect(settled).toBe(false);
+    expect(vi.mocked(Requests.axiosPost)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        item: expect.objectContaining({
+          description: "<p>Agent body</p>",
+          link: "https://example.com/human-change",
+          status: STATUSES.UNPUBLISHED,
+          title: "Agent title",
+        }),
+      }),
+      expect.objectContaining({headers: WEBMCP_INTERACTION_HEADERS}),
+    );
+    pending.resolve({});
+    await expect(execution).resolves.toMatchObject({
+      content_html: "<p>Agent body</p>",
+      status: "unpublished",
+      title: "Agent title",
+    });
+
+    const previousState = {
+      ...app.state,
+      item: {...app.state.item, status: STATUSES.UNPUBLISHED},
+    };
+    (app.state as any).item = {
+      ...app.state.item,
+      status: STATUSES.PUBLISHED,
+    };
+    app.componentDidUpdate(app.props, previousState);
+    expect(registration.signal.aborted).toBe(true);
+
+    registerTool.mockClear();
+    mount(new EditItemApp({
+      ...props({
+        id: "published-webmcp",
+        status: STATUSES.PUBLISHED,
+        title: "Published",
+      }),
+      itemId: "published-webmcp",
+    }));
+    await Promise.resolve();
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+
   it("reports autosave state and exposes a retry action after failure", () => {
     const clean = renderToStaticMarkup(
       React.createElement(AdminSaveAction, {

--- a/tests/unit/components/admin-pages.test.ts
+++ b/tests/unit/components/admin-pages.test.ts
@@ -3,6 +3,10 @@ import {describe, expect, it} from "vitest";
 
 import {reorderNavigationPageList} from "@/components/admin/pages/PagesApp";
 import {
+  mergePageWebMcpDraft,
+  pageWebMcpDraftEligible,
+} from "@/client/webmcp/page-editor-state";
+import {
   pageNavigationEnabledForStatus,
   type PageRecord,
 } from "@/shared/Pages";
@@ -13,6 +17,37 @@ const routeSource = (path: string) => readFile(
 );
 
 describe("admin Page editor routes", () => {
+  it("merges WebMCP Page input only into eligible visible drafts", () => {
+    const current = {
+      content_html: "<p>Human body</p>",
+      meta_description: "Human description",
+      navigation_label: "About",
+      show_in_navigation: true,
+      slug: "about",
+      status: "unpublished" as const,
+      title: "Human title",
+    };
+    expect(mergePageWebMcpDraft(current, {title: "Agent title"})).toEqual({
+      ...current,
+      status: "unpublished",
+      title: "Agent title",
+    });
+    expect(pageWebMcpDraftEligible({
+      draftStatus: "unpublished",
+      isNotFoundPage: false,
+      savedStatus: "unpublished",
+    })).toBe(true);
+    expect(pageWebMcpDraftEligible({
+      draftStatus: "unpublished",
+      isNotFoundPage: false,
+      savedStatus: "published",
+    })).toBe(false);
+    expect(pageWebMcpDraftEligible({
+      draftStatus: "unpublished",
+      isNotFoundPage: true,
+    })).toBe(false);
+  });
+
   it("keeps the Quill-based editor out of server rendering", async () => {
     const [newRoute, existingRoute] = await Promise.all([
       routeSource("new"),

--- a/tests/unit/webmcp-migration.test.ts
+++ b/tests/unit/webmcp-migration.test.ts
@@ -1,0 +1,65 @@
+import {readFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+import path from "node:path";
+import {DatabaseSync} from "node:sqlite";
+
+import {describe, expect, it} from "vitest";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+async function migration(name: string): Promise<string> {
+  return readFile(path.join(repositoryRoot, "migrations", name), "utf8");
+}
+
+describe("WebMCP webhook-origin migration", () => {
+  it("preserves event history and dependent deliveries", async () => {
+    const database = new DatabaseSync(":memory:");
+    database.exec(await migration("0017_webhooks.sql"));
+    database.exec(await migration("0019_webhook_delivery_budget.sql"));
+    database.exec(await migration("0020_webhook_infrastructure_disable.sql"));
+    database.exec("PRAGMA foreign_keys = ON");
+    database.exec(`
+      INSERT INTO webhook_endpoints (
+        id, name, url, secret_ciphertext
+      ) VALUES ('endpoint', 'Endpoint', 'https://example.com/hook', 'secret');
+      INSERT INTO webhook_events (
+        id, event_type, subject_type, subject_id, payload_json, origin,
+        request_id, correlation_id, delivery_count, budget_day
+      ) VALUES (
+        'event', 'item.updated', 'item', 'item', '{}', 'dashboard',
+        'request', 'correlation', 0, '2026-08-26'
+      );
+      INSERT INTO webhook_deliveries (
+        id, event_id, endpoint_id, endpoint_url
+      ) VALUES (
+        'delivery', 'event', 'endpoint', 'https://example.com/hook'
+      );
+      INSERT INTO webhook_delivery_attempts (
+        delivery_id, attempt_number, outcome, duration_ms
+      ) VALUES ('delivery', 1, 'retry', 10);
+    `);
+
+    database.exec(
+      `BEGIN IMMEDIATE;\n${await migration("0022_webmcp_webhook_origin.sql")}\nCOMMIT;`,
+    );
+    expect(database.prepare(
+      "SELECT id, origin FROM webhook_events",
+    ).get()).toEqual({id: "event", origin: "dashboard"});
+    expect(database.prepare(
+      "SELECT id, event_id FROM webhook_deliveries",
+    ).get()).toEqual({event_id: "event", id: "delivery"});
+    expect(database.prepare(
+      "SELECT delivery_id, attempt_number FROM webhook_delivery_attempts",
+    ).get()).toEqual({attempt_number: 1, delivery_id: "delivery"});
+    expect(database.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+
+    expect(() => database.prepare(`
+      INSERT INTO webhook_events (
+        id, event_type, subject_type, subject_id, payload_json, origin,
+        request_id, correlation_id, delivery_count, budget_day
+      ) VALUES (?, 'item.created', 'item', 'draft', '{}', ?, 'request', ?, 0, ?)
+    `).run("webmcp-event", "webmcp", "webmcp-event", "2026-08-26"))
+      .not.toThrow();
+    database.close();
+  });
+});

--- a/tests/unit/webmcp.test.ts
+++ b/tests/unit/webmcp.test.ts
@@ -145,6 +145,27 @@ describe("WebMCP tool contracts", () => {
     expect(pageSave).not.toHaveBeenCalled();
   });
 
+  it("normalizes missing execution signals from preview clients", async () => {
+    const itemSave = vi.fn(async (
+      _input: unknown,
+      _signal: AbortSignal,
+    ) => ({}));
+    const pageSave = vi.fn(async (
+      _input: unknown,
+      _signal: AbortSignal,
+    ) => ({}));
+
+    await itemDraftTool(itemSave).execute({title: "Draft"});
+    await pageDraftTool(pageSave).execute({title: "Page"}, {});
+
+    const itemSignal = itemSave.mock.calls[0]?.[1];
+    const pageSignal = pageSave.mock.calls[0]?.[1];
+    expect(itemSignal).toBeInstanceOf(AbortSignal);
+    expect(itemSignal?.aborted).toBe(false);
+    expect(pageSignal).toBeInstanceOf(AbortSignal);
+    expect(pageSignal?.aborted).toBe(false);
+  });
+
   it("uses authenticated same-origin fetches for read tools", async () => {
     vi.stubGlobal("document", fakeDocument({adminPath: "admin"}));
     const fetch = vi.fn(async () => new Response(JSON.stringify({
@@ -154,7 +175,6 @@ describe("WebMCP tool contracts", () => {
     vi.stubGlobal("fetch", fetch);
     const result = await dashboardTools()[0]!.execute(
       {limit: 1, status: "unpublished"},
-      {signal: new AbortController().signal},
     ) as Record<string, any>;
 
     expect(fetch).toHaveBeenCalledWith(

--- a/tests/unit/webmcp.test.ts
+++ b/tests/unit/webmcp.test.ts
@@ -1,0 +1,169 @@
+import {readFile} from "node:fs/promises";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+import {dashboardTools, clearAdminWebMcpTools, reconcileAdminWebMcpTools} from
+  "@/client/webmcp/admin-tools";
+import {itemDraftTool, pageDraftTool} from "@/client/webmcp/editor-tools";
+import {nativeWebMcpAvailable} from "@/client/webmcp/feature-detection";
+import {registerWebMcpTools} from "@/client/webmcp/model-context";
+
+function fakeDocument(options: {
+  adminPath?: string;
+  enabled?: boolean;
+  modelContext?: unknown;
+} = {}): Document {
+  return {
+    ...(options.modelContext ? {modelContext: options.modelContext} : {}),
+    querySelector: vi.fn((selector: string) => {
+      if (selector.includes("microfeed-webmcp-enabled")) {
+        return {content: options.enabled ? "true" : "false"};
+      }
+      if (selector.includes("microfeed-admin-path")) {
+        return {content: options.adminPath ?? "admin"};
+      }
+      return null;
+    }),
+  } as unknown as Document;
+}
+
+beforeEach(() => {
+  vi.stubGlobal("window", {
+    location: {
+      assign: vi.fn(),
+      origin: "https://feed.example.com",
+    },
+  });
+});
+
+afterEach(() => {
+  clearAdminWebMcpTools();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("WebMCP feature detection and registration", () => {
+  it("requires both protected-dashboard markup and the native Document API", () => {
+    const registerTool = vi.fn();
+    expect(nativeWebMcpAvailable(fakeDocument({
+      enabled: true,
+      modelContext: {registerTool},
+    }))).toBe(true);
+    expect(nativeWebMcpAvailable(fakeDocument({
+      enabled: false,
+      modelContext: {registerTool},
+    }))).toBe(false);
+    expect(nativeWebMcpAvailable(fakeDocument({enabled: true}))).toBe(false);
+  });
+
+  it("does nothing in unsupported browsers", async () => {
+    const registerTool = vi.fn();
+    vi.stubGlobal("document", fakeDocument({
+      enabled: false,
+      modelContext: {registerTool},
+    }));
+    await registerWebMcpTools([dashboardTools()[0]!], new AbortController().signal);
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+
+  it("reconciles dashboard tools and aborts the previous registration", async () => {
+    const registerTool = vi.fn(async (
+      _tool: unknown,
+      _options: {signal: AbortSignal},
+    ) => undefined);
+    vi.stubGlobal("document", fakeDocument({
+      enabled: true,
+      modelContext: {registerTool},
+    }));
+
+    await reconcileAdminWebMcpTools();
+    const firstSignal = registerTool.mock.calls[0]?.[1]?.signal as AbortSignal;
+    expect(registerTool).toHaveBeenCalledTimes(5);
+    expect(firstSignal.aborted).toBe(false);
+
+    await reconcileAdminWebMcpTools();
+    expect(registerTool).toHaveBeenCalledTimes(10);
+    expect(firstSignal.aborted).toBe(true);
+  });
+
+  it("keeps the implementation behind a native feature-gated import", async () => {
+    const source = await readFile(
+      new URL("../../src/layouts/AdminShell.astro", import.meta.url),
+      "utf8",
+    );
+    expect(source).toContain("nativeWebMcpAvailable()");
+    expect(source).toContain('import("@/client/webmcp/admin-tools")');
+    expect(source).not.toContain(
+      'from "@/client/webmcp/admin-tools"',
+    );
+    expect(source).not.toContain('from "@/client/webmcp/schemas"');
+    expect(source).not.toContain("navigator.modelContext");
+    expect(source).not.toContain("exposedTo");
+  });
+});
+
+describe("WebMCP tool contracts", () => {
+  it("defines the seven concise, non-overlapping tools and annotations", () => {
+    const readTools = dashboardTools();
+    const saveTools = [
+      itemDraftTool(async () => ({})),
+      pageDraftTool(async () => ({})),
+    ];
+    expect([...readTools, ...saveTools].map(({name}) => name)).toEqual([
+      "microfeed_list_items",
+      "microfeed_get_item",
+      "microfeed_list_pages",
+      "microfeed_get_page",
+      "microfeed_start_draft",
+      "microfeed_save_item_draft",
+      "microfeed_save_page_draft",
+    ]);
+    for (const tool of readTools.slice(0, 4)) {
+      expect(tool.annotations).toEqual({
+        readOnlyHint: true,
+        untrustedContentHint: true,
+      });
+    }
+    for (const tool of saveTools) {
+      expect(tool.annotations).toEqual({
+        readOnlyHint: false,
+        untrustedContentHint: true,
+      });
+    }
+  });
+
+  it("validates arguments in application code and never accepts status", async () => {
+    const signal = new AbortController().signal;
+    const itemSave = vi.fn(async () => ({}));
+    const pageSave = vi.fn(async () => ({}));
+    expect(() => itemDraftTool(itemSave).execute(
+      {status: "published", title: "No"},
+      {signal},
+    )).toThrow(/Unrecognized key/u);
+    expect(() => pageDraftTool(pageSave).execute({}, {signal}))
+      .toThrow(/at least one Page field/u);
+    expect(itemSave).not.toHaveBeenCalled();
+    expect(pageSave).not.toHaveBeenCalled();
+  });
+
+  it("uses authenticated same-origin fetches for read tools", async () => {
+    vi.stubGlobal("document", fakeDocument({adminPath: "admin"}));
+    const fetch = vi.fn(async () => new Response(JSON.stringify({
+      items: [{id: "draft-1", status: 2, title: "Draft", updatedAtMs: 1}],
+      nextCursor: "next",
+    }), {headers: {"content-type": "application/json"}}));
+    vi.stubGlobal("fetch", fetch);
+    const result = await dashboardTools()[0]!.execute(
+      {limit: 1, status: "unpublished"},
+      {signal: new AbortController().signal},
+    ) as Record<string, any>;
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://feed.example.com/admin/ajax/items/?status=unpublished&limit=1",
+      expect.objectContaining({credentials: "same-origin"}),
+    );
+    expect(result.items[0]).toMatchObject({
+      editor_url: "https://feed.example.com/admin/items/draft-1/",
+      status: "unpublished",
+    });
+  });
+});

--- a/tests/worker/admin-collections.test.ts
+++ b/tests/worker/admin-collections.test.ts
@@ -3,6 +3,7 @@ import type {APIContext, APIRoute} from "astro";
 import {beforeEach, describe, expect, it} from "vitest";
 
 import {GET as listAdminItems} from "@/pages/[adminPath]/ajax/items/index";
+import {GET as getAdminItem} from "@/pages/[adminPath]/ajax/items/[itemId]";
 import {GET as listAdminPages} from "@/pages/[adminPath]/ajax/pages/index";
 import {GET as listAdminSiteFiles} from "@/pages/[adminPath]/ajax/site-files/index";
 import FeedDb from "@/server/feed/FeedDb";
@@ -12,11 +13,15 @@ import {STATUSES} from "@/shared/Constants";
 const ORIGIN = "https://feed.example.com";
 const NOW = "2026-08-14T20:00:00.000Z";
 
-async function responseFrom(handler: APIRoute, pathname: string) {
+async function responseFrom(
+  handler: APIRoute,
+  pathname: string,
+  params: Record<string, string> = {},
+) {
   const request = new Request(`${ORIGIN}${pathname}`);
   const response = await handler({
     locals: {},
-    params: {adminPath: "admin"},
+    params: {adminPath: "admin", ...params},
     request,
     url: new URL(request.url),
   } as unknown as APIContext);
@@ -49,6 +54,7 @@ beforeEach(async () => {
       STATUSES.UNLISTED,
       JSON.stringify({
         contentHtml: "<p>This body must not be listed.</p>",
+        description: "<p>Editable Item body.</p>",
         image: "images/summary.png",
         mediaFile: {category: "audio", durationSecond: 42, url: "audio/summary.mp3"},
         title: "Summary item",
@@ -135,6 +141,28 @@ describe("admin collection endpoints", () => {
     });
     expect(item).not.toHaveProperty("contentHtml");
     expect(item).not.toHaveProperty("contentText");
+  });
+
+  it("returns one Item's editable WebMCP fields without caching", async () => {
+    const response = await responseFrom(
+      getAdminItem,
+      "/admin/ajax/items/admin-summary-item/",
+      {itemId: "admin-summary-item"},
+    );
+    await expect(response.json()).resolves.toEqual({
+      content_html: "<p>Editable Item body.</p>",
+      id: "admin-summary-item",
+      status: STATUSES.UNLISTED,
+      title: "Summary item",
+    });
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+
+    const missing = await responseFrom(
+      getAdminItem,
+      "/admin/ajax/items/missing/",
+      {itemId: "missing"},
+    );
+    expect(missing.status).toBe(404);
   });
 
   it("returns Page summaries and theme compatibility together", async () => {

--- a/tests/worker/webhooks.test.ts
+++ b/tests/worker/webhooks.test.ts
@@ -37,6 +37,11 @@ import {
   createApiItem,
   updateApiItem,
 } from "@/server/api/handlers";
+import {updateAdminFeed} from "@/pages/[adminPath]/ajax/feed";
+import {
+  WEBMCP_INTERACTION_SOURCE,
+  WEBMCP_INTERACTION_SOURCE_HEADER,
+} from "@/shared/WebMcp";
 
 const ENCRYPTION_KEY = "worker-test-webhook-encryption-key-32-bytes";
 
@@ -138,7 +143,47 @@ beforeEach(async () => {
       "DELETE FROM settings WHERE category LIKE 'webhook-atomic-%'",
     ),
     env.FEED_DB.prepare("DELETE FROM items WHERE id = 'explorer-item'"),
+    env.FEED_DB.prepare("DELETE FROM items WHERE id = 'webmcp-origin-item'"),
   ]);
+});
+
+describe("WebMCP webhook provenance", () => {
+  it("records agent-created Item drafts with a webmcp origin", async () => {
+    await insertEndpoint("webmcp-origin");
+    await env.FEED_DB.prepare(
+      "INSERT INTO webhook_subscriptions (endpoint_id, event_type) " +
+        "VALUES ('webmcp-origin', 'item.created')",
+    ).run();
+    const queueIds: string[] = [];
+    const response = await updateAdminFeed(
+      new Request("https://feed.example.com/admin/ajax/feed/", {
+        body: JSON.stringify({
+          item: {
+            id: "webmcp-origin-item",
+            pubDateMs: Date.now(),
+            status: 2,
+            title: "Agent-created draft",
+          },
+        }),
+        headers: {
+          "content-type": "application/json",
+          [WEBMCP_INTERACTION_SOURCE_HEADER]: WEBMCP_INTERACTION_SOURCE,
+        },
+        method: "POST",
+      }),
+      runtime(queueIds),
+      () => undefined,
+    );
+    expect(response.status).toBe(200);
+    expect(queueIds).toHaveLength(1);
+
+    const event = await env.FEED_DB.prepare(
+      "SELECT origin, payload_json FROM webhook_events " +
+        "WHERE subject_id = 'webmcp-origin-item' LIMIT 1",
+    ).first<{origin: string; payload_json: string}>();
+    expect(event?.origin).toBe("webmcp");
+    expect(JSON.parse(event!.payload_json).context.origin).toBe("webmcp");
+  });
 });
 
 describe("webhook fanout and accounting", () => {

--- a/tests/worker/webmcp.test.ts
+++ b/tests/worker/webmcp.test.ts
@@ -1,0 +1,186 @@
+import {env} from "cloudflare:workers";
+import type {APIContext, APIRoute} from "astro";
+import {beforeEach, describe, expect, it} from "vitest";
+
+import {updateAdminFeed} from "@/pages/[adminPath]/ajax/feed";
+import {
+  createAdminPage,
+  updateAdminPage,
+} from "@/server/admin/page-handlers";
+import FeedDb from "@/server/feed/FeedDb";
+import {STATUSES} from "@/shared/Constants";
+import {
+  WEBMCP_INTERACTION_SOURCE,
+  WEBMCP_INTERACTION_SOURCE_HEADER,
+} from "@/shared/WebMcp";
+
+const ORIGIN = "https://feed.example.com";
+
+function webMcpRequest(
+  pathname: string,
+  method: string,
+  body: unknown,
+): Request {
+  return new Request(`${ORIGIN}${pathname}`, {
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers: {
+      "content-type": "application/json",
+      [WEBMCP_INTERACTION_SOURCE_HEADER]: WEBMCP_INTERACTION_SOURCE,
+    },
+    method,
+  });
+}
+
+async function routeResponse(
+  handler: APIRoute,
+  request: Request,
+  params: Record<string, string> = {},
+): Promise<Response> {
+  const response = await handler({
+    locals: {},
+    params: {adminPath: "admin", ...params},
+    request,
+    url: new URL(request.url),
+  } as unknown as APIContext);
+  if (!(response instanceof Response)) throw new Error("Expected a response.");
+  return response;
+}
+
+beforeEach(async () => {
+  await new FeedDb(env, new Request(`${ORIGIN}/admin/`)).getContent();
+  await env.FEED_DB.batch([
+    env.FEED_DB.prepare("DELETE FROM items WHERE id LIKE 'webmcp-test-%'"),
+    env.FEED_DB.prepare(
+      "DELETE FROM page_paths WHERE page_id IN " +
+        "(SELECT id FROM pages WHERE slug LIKE 'webmcp-test-%')",
+    ),
+    env.FEED_DB.prepare("DELETE FROM pages WHERE slug LIKE 'webmcp-test-%'"),
+  ]);
+});
+
+describe("WebMCP draft-only Worker enforcement", () => {
+  it("accepts only unpublished Item results and rechecks stored status", async () => {
+    const itemId = "webmcp-test-item";
+    const create = await updateAdminFeed(
+      webMcpRequest("/admin/ajax/feed/", "POST", {
+        item: {
+          id: itemId,
+          pubDateMs: Date.now(),
+          status: STATUSES.UNPUBLISHED,
+          title: "Draft",
+        },
+      }),
+      env,
+      () => undefined,
+    );
+    expect(create.status).toBe(200);
+
+    const publicResult = await updateAdminFeed(
+      webMcpRequest("/admin/ajax/feed/", "POST", {
+        item: {
+          id: itemId,
+          pubDateMs: Date.now(),
+          status: STATUSES.PUBLISHED,
+          title: "Must not publish",
+        },
+      }),
+      env,
+      () => undefined,
+    );
+    expect(publicResult.status).toBe(409);
+
+    await env.FEED_DB.prepare(
+      "UPDATE items SET status = ? WHERE id = ?",
+    ).bind(STATUSES.PUBLISHED, itemId).run();
+    const staleEditor = await updateAdminFeed(
+      webMcpRequest("/admin/ajax/feed/", "POST", {
+        item: {
+          id: itemId,
+          pubDateMs: Date.now(),
+          status: STATUSES.UNPUBLISHED,
+          title: "Must not revert",
+        },
+      }),
+      env,
+      () => undefined,
+    );
+    expect(staleEditor.status).toBe(409);
+    const stored = await env.FEED_DB.prepare(
+      "SELECT status, json_extract(data, '$.title') AS title FROM items WHERE id = ?",
+    ).bind(itemId).first<{status: number; title: string}>();
+    expect(stored).toEqual({status: STATUSES.PUBLISHED, title: "Draft"});
+
+    const invalid = await updateAdminFeed(
+      webMcpRequest("/admin/ajax/feed/", "POST", "{"),
+      env,
+      () => undefined,
+    );
+    expect(invalid.status).toBe(400);
+    const missingId = await updateAdminFeed(
+      webMcpRequest("/admin/ajax/feed/", "POST", {
+        item: {status: STATUSES.UNPUBLISHED, title: "No ID"},
+      }),
+      env,
+      () => undefined,
+    );
+    expect(missingId.status).toBe(400);
+  });
+
+  it("accepts new and existing Page drafts but rejects stale or public writes", async () => {
+    const create = await routeResponse(
+      createAdminPage,
+      webMcpRequest("/admin/ajax/pages/", "POST", {
+        navigation_label: "WebMCP",
+        show_in_navigation: true,
+        slug: "webmcp-test-page",
+        status: "unpublished",
+        title: "WebMCP draft",
+      }),
+    );
+    expect(create.status).toBe(201);
+    const page = await create.json() as {id: string};
+
+    const update = await routeResponse(
+      updateAdminPage,
+      webMcpRequest(`/admin/ajax/pages/${page.id}/`, "PUT", {
+        status: "unpublished",
+        title: "Updated draft",
+      }),
+      {pageId: page.id},
+    );
+    expect(update.status).toBe(200);
+
+    const publicResult = await routeResponse(
+      updateAdminPage,
+      webMcpRequest(`/admin/ajax/pages/${page.id}/`, "PUT", {
+        status: "published",
+        title: "Must not publish",
+      }),
+      {pageId: page.id},
+    );
+    expect(publicResult.status).toBe(409);
+
+    await env.FEED_DB.prepare(
+      "UPDATE pages SET status = ? WHERE id = ?",
+    ).bind(STATUSES.PUBLISHED, page.id).run();
+    const staleEditor = await routeResponse(
+      updateAdminPage,
+      webMcpRequest(`/admin/ajax/pages/${page.id}/`, "PUT", {
+        status: "unpublished",
+        title: "Must not revert",
+      }),
+      {pageId: page.id},
+    );
+    expect(staleEditor.status).toBe(409);
+
+    const missing = await routeResponse(
+      updateAdminPage,
+      webMcpRequest("/admin/ajax/pages/missing/", "PUT", {
+        status: "unpublished",
+        title: "Missing",
+      }),
+      {pageId: "missing"},
+    );
+    expect(missing.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- Automatically expose seven concise WebMCP tools when a protected dashboard runs in a browser with the native `document.modelContext` API.
- Keep agent writes draft-only by binding saves to the visible Item or Page editor, preserving unsaved UI state, and enforcing unpublished content in Worker handlers.
- Tolerate compatible clients that invoke tool handlers without supplying optional execution options or an abort signal.
- Add protected Item detail retrieval plus `webmcp` webhook provenance and a preserving D1 migration.
- Advertise WebMCP accurately in the README, public and API `llms.txt` output, OpenAPI description, API guide, and release notes.
- Document the supported surface, security boundary, browser fallback, discovery behavior, and measured performance impact.

This gives browser-based AI agents a structured way to read content and help edit drafts without introducing a remote MCP server, a new setting, polling, or public-site runtime work.

## Release note

microfeed now supports experimental WebMCP site tools in protected dashboards. After a compatible browser agent opens the signed-in dashboard, it can automatically discover tools to read Items and Pages and save only new or unpublished drafts. Public pages, unsupported browsers, publishing, deletion, uploads, and settings remain unchanged.

## Related issue

N/A

## Testing

- [x] `yarn check` — 731 unit tests and 142 Worker tests passed; type checks, OpenAPI validation, production build/dry run, and docs checks passed.
- [x] `yarn docs:check`
- [x] `yarn lint:openapi`
- [x] `git diff --check`
- [x] ChatGPT desktop built-in-browser WebMCP smoke test — discovered the site tools, saved a new unpublished Item draft with title `hello` and description `world`, and read it back.
- [x] Production bundle comparison against `origin/main`: public client assets unchanged; unsupported protected dashboard +596 bytes gzip; supported lazy registry and validators +2,680 bytes gzip; eligible editor callback +397 bytes gzip.

## Screenshots

N/A — this change adds no visible interface.

## Risks

- WebMCP is experimental and the native browser contract may evolve. Unsupported browsers silently keep existing behavior and do not download the lazy implementation.
- Existing databases receive migration `0022`, which preserves webhook events while extending the allowed `context.origin` values with `webmcp`.
- Save tools are deliberately unavailable for published, unlisted, deleted, and default-404 content; publishing, deletion, uploads, settings, and other privileged operations remain outside the tool surface.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
