### PR TITLE
Add clone-free deployment launcher

### DIFF
--- a/.agents/skills/deploy-microfeed/SKILL.md
+++ b/.agents/skills/deploy-microfeed/SKILL.md
@@ -1,26 +1,39 @@
 ---
 name: deploy-microfeed
-description: Deploy and administer microfeed from a local repository clone using the project-owned yarn manage CLI. Use when a user asks a coding agent to operate a local or Cloudflare instance, including accounts, initialization, connection, development, deployment, themes, snapshots, status, destruction, Pages migration, domains, Access, built-in authentication, configuration, or instance selection.
+description: Deploy and administer microfeed through the clone-free @microfeed/cli launcher or the project-owned yarn manage CLI. Use when a user asks a coding agent to operate a local or Cloudflare instance, including accounts, initialization, connection, development, deployment, themes, snapshots, status, destruction, Pages migration, domains, Access, built-in authentication, configuration, or instance selection.
 ---
 
 # Deploy microfeed
 
-Use `yarn manage` as the only interface that changes Cloudflare. Do not replace
-the CLI workflow with raw Wrangler commands, Cloudflare API calls, an MCP
-server, a plugin, or dashboard-created Worker, D1, or R2 resources.
+Use the repository-owned `yarn manage` engine as the only interface that
+changes Cloudflare. Outside a repository clone, invoke that same engine through
+`npx @microfeed/cli manage`. Do not replace the CLI workflow with raw Wrangler
+commands, Cloudflare API calls, an MCP server, a plugin, or dashboard-created
+Worker, D1, or R2 resources.
 
 Read the relevant command section in the canonical
 [`yarn manage` reference](../../../docs/manage-cli.md) before using an unfamiliar
 command or option. Treat that document as the complete capability and
 side-effect contract; keep this skill focused on agent sequencing and safety.
 
-microfeed supports one deployment engine: `yarn manage` from a local repository
-clone. A person may run it directly or ask a local agent to operate it, but do
-not offer Cloudflare repository imports, Workers Builds, deploy buttons, GitHub
-Actions, raw Wrangler deploys, or API-token deployment as alternatives. If a
-user asks for a dashboard-only or hosted deployment, explain that it is not
-supported and guide them to the local `yarn manage` workflow. Never request
-their Cloudflare email, password, private password-setup link, or token in chat.
+microfeed supports one deployment engine. A person may run `yarn manage` from
+a trusted clone, or a local coding agent may use `npx @microfeed/cli manage` to
+download the exact release into a private cache and forward commands to that
+engine. Do not offer Cloudflare repository imports, Workers Builds, deploy
+buttons, GitHub Actions, raw Wrangler deploys, or API-token deployment as
+alternatives. If a user asks for a dashboard-only or hosted deployment,
+explain that it is not supported and guide them to the local launcher or clone
+workflow. Never request their Cloudflare email, password, private
+password-setup link, or token in chat.
+
+Choose one command prefix for the session:
+
+- When the user or launcher invoked `npx @microfeed/cli manage`, use that exact
+  prefix for every management command. Translate every `yarn manage …` example
+  below to `npx @microfeed/cli manage …`, and translate `yarn dev …` to
+  `npx @microfeed/cli manage dev …`.
+- When operating inside a user-managed trusted microfeed clone, use the
+  documented `yarn manage` and `yarn dev` commands directly.
 
 ## Guardrails
 
@@ -37,9 +50,12 @@ their Cloudflare email, password, private password-setup link, or token in chat.
   has served its handoff.
 - Stop before deployment when the Wrangler browser OAuth callback is
   unavailable.
-- Inspect `git status --short` before deploying. If the working tree is dirty,
-  identify that the current files will be built and obtain explicit approval
-  to deploy them. Do not modify, discard, or stash the changes.
+- In a user-managed clone, inspect `git status --short` before deploying. If
+  the working tree is dirty, identify that the current files will be built and
+  obtain explicit approval to deploy them. Do not modify, discard, or stash
+  the changes. The clone-free launcher instead verifies a clean exact release
+  tag before every forwarded command and recreates only its private source
+  cache when that verification fails; never edit the launcher cache.
 - Treat changes to `package.json`, `yarn.lock`, `.yarn/`, `manage-cli/`,
   `wrangler.jsonc`, `wrangler.template.jsonc`, `astro.config.ts`, or this skill
   as security-sensitive because deployment executes or trusts them. Inspect
@@ -187,34 +203,28 @@ disabled interval are not replayed. Rerunning enable or disable is idempotent;
 never recreate, rename, adopt, purge, resume, or delete the Queue outside
 `yarn manage`.
 
-## Fresh-clone workflow
+## Prepared-workspace workflow
 
-1. Confirm the repository root contains `package.json`, `yarn.lock`, and
+1. When the clone-free launcher handed off this skill, use its printed cached
+   repository and reference paths and keep using the public `npx` command
+   prefix. The launcher has already verified the exact release tag, checked
+   that its source is clean, and run `yarn install --immutable`; do not edit the
+   cached source or run a second checkout. In a user-managed clone, confirm the
+   repository root contains `package.json`, `yarn.lock`, and
    `manage-cli/index.ts`.
-2. Check `node --version` and require Node.js 24. Check Corepack and enable it
-   when Yarn is unavailable. Obtain approval before a command writes outside
+2. Require Node.js 22.12 or newer with npm, plus Git and Corepack. The
+   clone-free launcher checks these prerequisites itself and creates a private
+   Yarn shim without changing the global installation. In a user-managed clone,
+   check the tools directly and obtain approval before a command writes outside
    the workspace.
-3. Before any command receives OAuth input, obtain network
-   approval and run `yarn install --immutable --check-cache`. This must
+3. In a user-managed clone, before any command receives OAuth input, obtain
+   network approval and run `yarn install --immutable --check-cache`. This must
    revalidate the locked packages and relink local dependencies even when
    `node_modules` already exists, unless the same trusted session just
-   completed that exact command.
-4. Collect non-secret choices in the plain language described above. Ask only
-   for the site name and administrator sign-in email initially. Then require an
-   explicit choice between a custom web address and the free Cloudflare
-   address; do not silently assume either. If the user wants a custom address,
-   collect its exact hostname. Map those answers to the internal values and
-   recommend the documented defaults:
-   - site name, internally used as the instance and Worker name: the user's
-     globally distinctive name
-   - content database (D1): `<worker-name>-db`
-   - media storage (R2): `<worker-name>-media`
-   - dashboard path (`--admin-path`): `admin`
-   - authentication: built-in email/password
-   - administrator sign-in email, internally passed as owner email: supplied by
-     the user
-   - custom domain: optional; collect an exact hostname when selected
-5. Discover the user's Cloudflare access before any deployment mutation:
+   completed that exact command. The launcher-owned workspace has already
+   completed its locked installation.
+4. Do not assume the user needs a new site. Discover their Cloudflare access
+   before collecting new-site choices or making any deployment mutation:
 
    ```console
    yarn manage accounts --json
@@ -231,17 +241,38 @@ never recreate, rename, adopt, purge, resume, or delete the Queue outside
    user wants to preserve the current login and add another, use
    `yarn manage accounts --profile <name> --reauthorize` instead. Do not work
    around OAuth with a token.
-6. When exactly one account is returned, use its full ID. When several are
+5. When exactly one account is returned, use its full ID. When several are
    returned, show each plain-language account name and the last eight ID
    characters, then ask the user which one owns the site. Duplicate names are
    expected; use the selected full ID. Never select the first account, and
    never begin initialization before this choice is resolved.
+6. Run `yarn manage instances --account-id <account-id> --json`. Use the
+   selected saved instance when one exists. Otherwise show every exact
+   compatible Worker candidate. Ask the user to choose when more than one is
+   available, then use the ready-to-run read-only `connect` command for the
+   chosen Worker and continue with **Existing installations**. Continue below
+   only when no compatible Worker is selected and the user wants a new site.
+   Collect the new site's non-secret choices in plain language. Ask only for
+   the site name and administrator sign-in email initially. Then require an
+   explicit choice between a custom web address and the free Cloudflare
+   address; do not silently assume either. If the user wants a custom address,
+   collect its exact hostname. Map those answers to the internal values and
+   recommend the documented defaults:
+   - site name, internally used as the instance and Worker name: the user's
+     globally distinctive name
+   - content database (D1): `<worker-name>-db`
+   - media storage (R2): `<worker-name>-media`
+   - dashboard path (`--admin-path`): `admin`
+   - authentication: built-in email/password
+   - administrator sign-in email, internally passed as owner email: supplied by
+     the user
+   - custom domain: optional; collect an exact hostname when selected
 7. Summarize the selected site and the services Cloudflare will create in
    plain language: the hosted application (Worker), content database (D1),
-   optional media storage (R2), protected dashboard path and administrator login, and
-   optional custom web address. Show the exact technical resource names in
-   parentheses for an auditable approval. Obtain approval for the browser
-   Cloudflare sign-in and exact Cloudflare changes before starting the
+   optional media storage (R2), protected dashboard path and administrator
+   login, and optional custom web address. Show the exact technical resource
+   names in parentheses for an auditable approval. Obtain approval for the
+   browser Cloudflare sign-in and exact Cloudflare changes before starting the
    initialization command.
 8. Start initialization with every known non-secret choice and the exact
    account ID so the user is not asked twice:
@@ -307,6 +338,15 @@ never recreate, rename, adopt, purge, resume, or delete the Queue outside
     the admin dashboard is public.
 
 ## Existing installations
+
+With clone-free launcher state, start with `accounts --json`; when several
+accounts are available, show their names and ID suffixes and ask the user to
+select one. Then run `instances --account-id <account-id> --json`. Use the
+selected saved instance when one exists. Otherwise show every exact compatible
+Worker candidate, ask the user to choose when more than one is available, and
+run the listed read-only `connect` command for the selected Worker. Obtain
+deployment approval before `deploy`. Run `init` only when the user chooses a
+new site rather than a discovered installation.
 
 Before updating, show the selected instance with `yarn manage instances` and
 confirm the target. Run `yarn manage accounts --json`, verify that the saved

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
     ·    
     <a href="https://www.microfeed.org/api/"><b>API</b></a>   
     ·
-    <a href="https://www.npmjs.com/package/@microfeed/cli"><b>Content CLI</b></a>
+    <a href="https://www.npmjs.com/package/@microfeed/cli"><b>CLI</b></a>
     ·        
     <a href="https://github.com/microfeed/microfeed/issues/new?assignees=&labels=bug"><b>Report Bug</b></a>
     ·
@@ -106,28 +106,22 @@ Inside this repository the same command is available as `yarn microfeed`, withou
 
 ### Quickstarts
 
-The simplest way to install microfeed is with a local AI coding agent:
+The simplest way to install microfeed is with a local AI coding agent. Open
+OpenAI Codex, Claude Code, Cursor, or another local agent that can run terminal
+commands and open a browser, then give it this prompt:
 
-1. Create a local copy of this Git repository on your computer. [Install Git](https://git-scm.com/downloads) first if
-   the `git` command is not available on your computer:
+```text
+Run `npx @microfeed/cli manage` and follow every instruction it prints until
+`status` verifies the deployment.
+```
 
-   ```console
-   git clone https://github.com/microfeed/microfeed.git
-   ```
-
-2. Open the new `microfeed` folder in an AI coding agent such as OpenAI Codex,
-   Claude Code, Cursor, or another local agent that can run terminal commands
-   and open a browser.
-
-3. Give the agent this prompt:
-
-   ```text
-   Deploy microfeed to Cloudflare.
-   ```
-
-That's it. The agent guides the setup, runs the deployment, and verifies the
-finished site. You only step in for Cloudflare browser authorization, choices
-that require your approval, and creating your private dashboard password.
+That's it. The launcher requires Node.js 22.12 or newer with npm, Git, and
+Corepack. It downloads the exact microfeed release and locked dependencies into
+a private cache instead of creating source files in your current folder. The
+first setup may use about 1.3 GB and take several minutes; later runs reuse it.
+The agent guides the setup, runs the deployment, and verifies the finished
+site. You only step in for Cloudflare browser authorization, choices that
+require your approval, and creating your private dashboard password.
 
 
 https://github.com/user-attachments/assets/96c73a94-2068-4172-9003-8bf3a262121d
@@ -138,9 +132,10 @@ https://github.com/user-attachments/assets/96c73a94-2068-4172-9003-8bf3a262121d
 
 ### Details
 
-microfeed has one supported deployment engine: `yarn manage`, run from a local
-Git copy of this repository. A local AI coding agent can operate it for you, or
-you can run the same guided commands yourself.
+microfeed has one supported deployment engine: `yarn manage`. A local AI coding
+agent can reach it without a user-managed clone through
+`npx @microfeed/cli manage`, or you can clone the repository and run the same
+guided commands yourself.
 
 * **Recommended:** [deploy with an AI coding agent](https://docs.microfeed.org/start-here/ai-agent/).
 * **Manual:** [deploy with `yarn manage`](https://docs.microfeed.org/start-here/manual/).

--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -40,8 +40,46 @@ Run `yarn manage help <command>` for the corresponding terminal reference.
 
 ## Before running commands
 
-Run `yarn manage` from a local clone of microfeed. The command is part of this
-repository and is not installed globally.
+The management engine remains part of the microfeed repository. Choose the
+invocation that matches how you are working.
+
+For a local coding agent without a clone, start with:
+
+```console
+npx @microfeed/cli manage
+```
+
+The launcher downloads the exact tagged release matching the installed CLI
+into a private operating-system cache, verifies that source before every
+forwarded command, installs its locked dependencies with a cache-local Yarn
+shim, and prints the deployment skill and reference paths for the agent. It
+stores saved deployment state separately under the microfeed configuration
+directory. The first setup may use about 1.3 GB and take several minutes;
+later commands reuse it.
+
+Coding agents do not generally discover skills inside npm or cache directories
+automatically. The launcher therefore prints both cached file paths explicitly
+and tells the agent to read them completely. See the official
+[Codex skill discovery behavior](https://learn.chatgpt.com/docs/build-skills).
+
+The replaceable workspace lives under `~/Library/Caches/microfeed/manage` on
+macOS, `${XDG_CACHE_HOME:-~/.cache}/microfeed/manage` on Linux, or
+`%LOCALAPPDATA%\microfeed\manage` on Windows. Saved deployment state instead
+lives under `${XDG_CONFIG_HOME:-~/.config}/microfeed/manage` on macOS and
+Linux, or `%APPDATA%\microfeed\manage` on Windows. `MICROFEED_CACHE_DIR` and
+`MICROFEED_CONFIG_DIR` override the respective base directories; the launcher
+still appends its `manage` child directory.
+
+Every command in this reference can then be invoked by replacing `yarn manage`
+with `npx @microfeed/cli manage`. For example:
+
+```console
+npx @microfeed/cli manage accounts --json
+npx @microfeed/cli manage deploy --instance <instance-name>
+npx @microfeed/cli manage status --instance <instance-name>
+```
+
+People working from a local clone can continue to run:
 
 ```console
 git clone https://github.com/microfeed/microfeed.git
@@ -51,18 +89,21 @@ yarn install --immutable
 yarn manage help
 ```
 
-Cloudflare operations use Wrangler browser authorization. Credentials are
+Both paths require Node.js 22.12 or newer, Git, Corepack, and an interactive
+local session. Cloudflare operations use Wrangler browser authorization. Credentials are
 managed by Wrangler; do not paste Cloudflare tokens into command arguments or
 agent conversations.
 
 Cloudflare repository imports, Workers Builds, deploy buttons, GitHub Actions,
-and API-token deployment are not supported. Both people and local coding agents
-use this `yarn manage` interface.
+and API-token deployment are not supported. Both invocations use the same
+repository-owned management engine.
 
 ## Safety model
 
-- `yarn manage` is the only supported CLI interface for microfeed Cloudflare
-  mutations. Do not replace it with improvised Wrangler or REST commands.
+- The repository-owned `yarn manage` engine is the only supported interface
+  for microfeed Cloudflare mutations. Use it directly from a clone or through
+  `npx @microfeed/cli manage`; do not replace it with improvised Wrangler or
+  REST commands.
 - Initialization validates the selected account and checks Worker, Pages, D1,
   and, unless `--no-r2` is used, R2 name collisions before creating resources.
 - Existing D1 or R2 resources require explicit reuse approval. Resources

--- a/docs/manage/index.md
+++ b/docs/manage/index.md
@@ -3,9 +3,11 @@ title: Manage your site
 description: Update, inspect, protect, back up, migrate, and safely remove a microfeed instance.
 ---
 
-Run management commands from the local microfeed repository clone connected to
-the site. The ignored `.microfeed/` directory stores the instance mapping; the
-Cloudflare resources and content remain in your Cloudflare account.
+Run management commands through `npx @microfeed/cli manage`, or from a local
+microfeed repository clone with `yarn manage`. The launcher keeps its saved
+instance mapping in the platform microfeed configuration directory; a clone
+uses its ignored `.microfeed/` directory. Cloudflare resources and content
+remain in your Cloudflare account.
 
 An **instance name** is only the short local label used to select a saved site.
 If the Cloudflare terms below are unfamiliar, start with
@@ -17,7 +19,7 @@ If the Cloudflare terms below are unfamiliar, start with
 | --- | --- |
 | Verify the hosted application, database, media, and login | `yarn manage status` |
 | Deploy current repository code | `yarn manage deploy` |
-| Connect a new clone to an existing site | `yarn manage connect` |
+| Connect local launcher or clone state to an existing site | `yarn manage connect` |
 | List or select saved sites | `yarn manage instances` / `yarn manage use` |
 | Add a custom hostname | `yarn manage domain` |
 | Change the current login email or password | Dashboard avatar → **Account settings** |
@@ -33,7 +35,7 @@ use named API keys and do not reuse the dashboard password or Cloudflare login.
 
 - Discover Cloudflare accounts before creating a new instance. Never guess
   when a login can access more than one account.
-- Use the exact saved instance name for multi-site clones.
+- Use the exact saved instance name when local state contains several sites.
 - Read a dry-run or collision report completely before approving reuse,
   restore, or removal.
 - Keep passwords, private setup links, and tokens out of chat, command
@@ -41,4 +43,5 @@ use named API keys and do not reuse the dashboard password or Cloudflare login.
 - Create a snapshot before a high-risk content migration.
 
 The [`yarn manage` reference](/manage-cli/) is authoritative if this
-task-oriented guide and an option listing ever appear to differ.
+task-oriented guide and an option listing ever appear to differ. Outside a
+clone, replace every `yarn manage` prefix with `npx @microfeed/cli manage`.

--- a/docs/manage/update.md
+++ b/docs/manage/update.md
@@ -3,23 +3,27 @@ title: Update microfeed
 description: Bring a connected production instance to the latest source and verify the deployment.
 ---
 
-Update from the repository clone connected to the intended site.
+Use the clone-free launcher or update from a repository clone connected to the
+intended site.
 
 ## Recommended: ask your coding agent
 
-Open the clone in a local coding agent and use a prompt that names the saved
-site or Worker when you know it:
+Open a local coding agent and use a prompt that names the saved site or Worker
+when you know it:
 
 ```text
-Connect this repository to the microfeed Worker <worker-name>, update microfeed to the latest version, deploy it, and verify the site.
+Run `npx @microfeed/cli manage` and follow every instruction it prints. Connect
+to the microfeed Worker <worker-name> if it is not already saved, deploy the
+latest release, and continue until `status` verifies the site.
 ```
 
-The agent should show you any uncommitted local changes before deployment,
-fetch the trusted upstream repository, connect only if needed, deploy through
-`yarn manage`, and run a status check.
-Complete any Git or Cloudflare browser handoffs it requests.
+The launcher obtains the exact release in a private cache. The agent discovers
+saved and compatible existing sites, asks before choosing among candidates,
+connects only if needed, deploys through the same `yarn manage` engine, and
+runs a status check. Complete any Git or Cloudflare browser handoffs it
+requests.
 
-## Manual update
+## Manual update from a clone
 
 First run `git status` and protect any local work. Then fetch and inspect
 upstream changes using your normal Git workflow. Once the clone contains the

--- a/docs/microfeed-cli.md
+++ b/docs/microfeed-cli.md
@@ -16,6 +16,7 @@ the command you need.
 ## Contents
 
 - [Run the CLI](#run-the-cli)
+- [Deploy or administer a site](#deploy-or-administer-a-site)
 - [Agent skill](#agent-skill)
 - [Authentication and safety](#authentication-and-safety)
 - [Command summary](#command-summary)
@@ -56,6 +57,35 @@ matches where you are working.
 
 The examples below use `yarn microfeed`. Replace that prefix with
 `yarn dlx @microfeed/cli` or `microfeed` when using one of the other modes.
+
+## Deploy or administer a site
+
+Ask a local coding agent to run the clone-free launcher when you do not have a
+microfeed repository open:
+
+```console
+npx @microfeed/cli manage
+```
+
+The launcher also requires Git and Corepack. It downloads the exact tagged
+microfeed release matching the CLI into a persistent private cache, verifies
+the checkout, installs its locked dependencies, and prints the exact
+deployment skill and management-reference paths for the agent. It does not
+write source files into the current project. The initial workspace may use
+about 1.3 GB and take several minutes to prepare; later commands reuse it.
+
+Pass any repository management command and options after `manage`; arguments
+such as `--instance` and `--json` are forwarded unchanged:
+
+```console
+npx @microfeed/cli manage accounts --json
+npx @microfeed/cli manage deploy --instance <instance-name>
+npx @microfeed/cli manage status --instance <instance-name>
+```
+
+Saved deployment state is stored separately from the replaceable source cache.
+The [`yarn manage` reference](/manage-cli/) documents every forwarded command,
+side effect, confirmation, and recovery path.
 
 To install the command globally and confirm it is available:
 
@@ -132,6 +162,7 @@ For every authenticated REST request, the CLI:
 
 | Command | Purpose | Local or remote change |
 | --- | --- | --- |
+| `manage [command]` | Prepare a clone-free deployment workspace, print the coding-agent handoff, or forward a repository management command. | The bare command updates only the private cache. Forwarded commands retain the effects and safeguards documented in the [`yarn manage` reference](/manage-cli/). |
 | `login <site-url>` | Authorize the official public CLI client in a browser and save an instance for this computer connection. | Creates or replaces a local encrypted saved instance after browser consent. |
 | `logout` | Revoke this computer's selected credential family and remove its saved instance locally. | Leaves the server-side connection listed as Inactive until the owner revokes it. |
 | `instances list` | List saved instances and the current selection. | Read-only. |
@@ -1044,7 +1075,8 @@ When refresh fails or no refresh token exists, log in again.
 | `MICROFEED_URL` | Set the target site URL for API-key operations or `webhook sample`. HTTPS is required except for local loopback site URLs. |
 | `MICROFEED_INSTANCE` | Select a saved instance when `--instance` is omitted. |
 | `MICROFEED_WEBHOOK_SECRET` | Supply the signing secret to `webhook listen` without a prompt. Prefer a development secret manager; never commit it. |
-| `MICROFEED_CONFIG_DIR` | Override the instance-store directory. Intended for isolated environments and tests; it does not weaken encryption or replace the OS keychain. |
+| `MICROFEED_CACHE_DIR` | Override the base cache directory. The deployment launcher keeps its replaceable source and dependencies in a `manage/` child directory. |
+| `MICROFEED_CONFIG_DIR` | Override the base configuration directory. Content instances live directly in this directory; deployment state lives in its separate `manage/` child directory. Intended for isolated environments and tests; it does not weaken encryption or replace the OS keychain. |
 
 Never place a credential directly in a command, checked-in file, log,
 generated example, or agent conversation.
@@ -1052,6 +1084,7 @@ generated example, or agent conversation.
 ## Built-in help
 
 ```console
+npx @microfeed/cli manage --help
 yarn microfeed --help
 yarn microfeed help
 yarn microfeed login --help

--- a/docs/start-here/after-deploy.md
+++ b/docs/start-here/after-deploy.md
@@ -3,13 +3,13 @@ title: After deployment
 description: Verify, secure, customize, and publish from a new microfeed site.
 ---
 
-Use this checklist after `yarn manage init` completes.
+Use this checklist after deployment completes.
 
 ## Confirm the site is healthy
 
-Run `yarn manage status` from the same repository clone. Confirm the displayed
-hosted application, database, media-storage state, and dashboard protection
-match what you expected.
+Run `npx @microfeed/cli manage status`, or `yarn manage status` from the same
+repository clone. Confirm the displayed hosted application, database,
+media-storage state, and dashboard protection match what you expected.
 
 Open these public addresses:
 
@@ -34,19 +34,20 @@ Create a clearly labeled test item, preview its public page, and check the RSS
 and JSON feeds. You can publish it yourself in the Admin dashboard. To publish
 with a coding agent, first [enable API access and connect the
 CLI](/automation/cli/), then ask the agent to use the official
-[`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli). Inside this
-clone, the agent should run `yarn microfeed`; you remain responsible for
-browser authorization and approval of destructive actions. Delete or unpublish
-the test when finished.
+[`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli). Inside a
+clone, the agent should run `yarn microfeed`; elsewhere it can use the
+published package. You remain responsible for browser authorization and
+approval of destructive actions. Delete or unpublish the test when finished.
 
 Next: [compare the dashboard and agent publishing workflows](/dashboard/publish/).
 
 ## Save the local connection
 
-The clone’s ignored `.microfeed/` directory remembers the instance connection.
-Keep the clone on a trusted computer. If you use a different clone later, the
-read-only `yarn manage connect` workflow can reconnect to an existing compatible
-microfeed Worker.
+The clone-free launcher stores instance connections in the platform microfeed
+configuration directory, separately from its replaceable cache. A repository
+clone instead uses its ignored `.microfeed/` directory. Keep either workspace
+on a trusted computer; the read-only `connect` workflow can reconnect to an
+existing compatible microfeed Worker when local state is unavailable.
 
 ## Optional next steps
 

--- a/docs/start-here/ai-agent.md
+++ b/docs/start-here/ai-agent.md
@@ -4,34 +4,40 @@ description: The recommended three-step route to a new microfeed site.
 ---
 
 Use a local coding agent that can run terminal commands and open browser pages.
-The agent reads microfeed’s repository instructions and operates the same
-guarded `yarn manage` CLI available to people.
+The published launcher prepares an exact microfeed release in a private cache,
+then directs the agent to the same guarded `yarn manage` engine available to
+people. You do not need to clone or open the source repository.
 
-## 1. Copy microfeed to your computer
+## 1. Open a local coding agent
 
-Open a terminal and run:
+Open OpenAI Codex, Claude Code, Cursor, or another coding agent that can run
+terminal commands on your computer and complete a browser handoff. The current
+folder does not need to contain source code.
 
-```console
-git clone https://github.com/microfeed/microfeed.git
-cd microfeed
-```
+Your computer needs Node.js 22.12 or newer with npm, plus Git and Corepack. The
+launcher checks these tools before downloading anything and prints a specific
+recovery step when one is unavailable.
 
-Expected result: a new `microfeed` folder containing this repository.
+## 2. Give the agent one command
 
-## 2. Open the folder in your coding agent
-
-Open that folder in OpenAI Codex, Claude Code, Cursor, or another local coding
-agent. Claude Code reads the repository's `CLAUDE.md` bridge, which imports the
-shared `AGENTS.md` guidance and routes matching work to the canonical skills
-under `.agents/skills/`. Then paste this prompt:
+Paste this prompt:
 
 ```text
-Deploy microfeed to Cloudflare.
+Run `npx @microfeed/cli manage` and follow every instruction it prints until
+`status` verifies the deployment.
 ```
 
-The agent should discover your Cloudflare login, ask you to choose an account
-if more than one is available, initialize a site, and verify the finished
-deployment.
+The first run downloads the exact release matching `@microfeed/cli`, creates a
+private Yarn launcher, and installs the locked dependencies in your operating
+system cache. This may use about 1.3 GB and take several minutes, depending on
+your connection and computer. Later commands reuse that workspace, while saved
+deployment state lives separately so a cache refresh cannot erase your site
+connections.
+
+The command prints the exact deployment-skill and reference paths for the
+agent to read. The agent should discover your Cloudflare login, ask you to
+choose an account or existing compatible site when necessary, initialize only
+when you want a new site, and verify the finished deployment.
 
 <video class="docs-walkthrough" controls autoplay muted playsinline preload="metadata" poster="/images/screenshots/1-deploy-1.png" aria-label="A silent Codex deployment walkthrough progressing from the initial request through verification to the ready microfeed dashboard">
   <source src="/images/screenshots/1-deploy-walkthrough.mp4" type="video/mp4">
@@ -52,11 +58,11 @@ link into the agent conversation.
 
 ## Verify the result
 
-Ask the agent to run `yarn manage status`. The final report should show the
-site address, dashboard protection, D1 database, and R2 state. Open the
-public address and confirm the site loads. You can sign in to the dashboard and
-publish a test item yourself, or follow the
-[post-deployment checklist](../after-deploy/) to enable `yarn microfeed` for
+Ask the agent to run `npx @microfeed/cli manage status`. The final report
+should show the site address, dashboard protection, D1 database, and R2 state.
+Open the public address and confirm the site loads. You can sign in to the
+dashboard and publish a test item yourself, or follow the
+[post-deployment checklist](../after-deploy/) to enable `@microfeed/cli` for
 the agent.
 
 If setup stops partway through, tell the agent to continue the same microfeed

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -14,36 +14,32 @@ You need:
 - A [Cloudflare account](https://dash.cloudflare.com/sign-up). Cloudflare’s
   included usage is enough for many personal and small sites; usage above the
   published limits may require a paid plan.
-- A computer with [Git](https://git-scm.com/downloads) and
-  [Node.js 24](https://nodejs.org/) installed.
+- A computer with [Git](https://git-scm.com/downloads),
+  [Node.js 22.12 or newer](https://nodejs.org/), npm, and Corepack installed.
 - A local coding agent such as OpenAI Codex, Claude Code, or Cursor that can run
   terminal commands in a folder on your computer.
 - An email address for the private dashboard login.
 
 ## Deploy with an agent
 
-1. Open a terminal and copy microfeed to your computer:
+1. Open a local coding agent in any folder on your computer. The agent must run
+   locally so Cloudflare can hand browser authorization back to it.
 
-   ```console wrap
-   git clone https://github.com/microfeed/microfeed.git
-   cd microfeed
-   ```
-
-2. Open the new `microfeed` folder in your coding agent. The agent must run on
-   your computer so Cloudflare can hand browser authorization back to it.
-
-3. Ask the agent:
+2. Ask the agent:
 
    ```text frame="terminal" wrap
-   Deploy microfeed to Cloudflare.
+   Run `npx @microfeed/cli manage` and follow every instruction it prints
+   until `status` verifies the deployment.
    ```
 
-4. Stay nearby while the agent works. Cloudflare opens a browser page for you
-   to sign in, and the agent may ask you to select an account or approve an
-   important choice. Never paste a Cloudflare token or dashboard password into
-   the conversation.
+3. Stay nearby while the agent works. The first command downloads the exact
+   microfeed release and its dependencies into a private cache; it does not
+   create source files in your current folder. Cloudflare opens a browser page
+   for you to sign in, and the agent may ask you to select an account or
+   approve an important choice. Never paste a Cloudflare token or dashboard
+   password into the conversation.
 
-5. When deployment finishes, open the private one-time setup page and choose
+4. When deployment finishes, open the private one-time setup page and choose
    your dashboard password. Then open the public site and publish a test item.
    Use the dashboard yourself, or follow the
    [post-deployment checklist](./after-deploy/) to enable the official
@@ -60,16 +56,16 @@ website, RSS feed, JSON Feed, and private Admin dashboard.
 
 ## Confirm the installation
 
-Ask the agent to run `yarn manage status`. The report should confirm the hosted
-application, dashboard protection, content database, and media storage. If
-setup stopped partway through, ask the agent to continue the same microfeed
-deployment; the installer is designed to resume safely.
+Ask the agent to run `npx @microfeed/cli manage status`. The report should
+confirm the hosted application, dashboard protection, content database, and
+media storage. If setup stopped partway through, ask the agent to continue the
+same microfeed deployment; the installer is designed to resume safely.
 
 For screenshots, browser handoffs, and recovery steps, continue to
 [Deploy with an AI coding agent](./ai-agent/).
 
 ## Prefer to use the terminal yourself?
 
-Follow [Deploy manually](./manual/) to run the same guided `yarn manage`
-workflow without an agent. If Worker, D1, or R2 are unfamiliar terms, read
+Follow [Deploy manually](./manual/) to clone the repository and run the same
+guided `yarn manage` workflow without an agent. If Worker, D1, or R2 are unfamiliar terms, read
 [How microfeed works](./concepts/) before installing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfeed",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,11 +4,12 @@
 [Guided workflow](https://docs.microfeed.org/automation/cli/) ·
 [`@microfeed/cli` reference](https://docs.microfeed.org/microfeed-cli/)
 
-The official, agent-friendly command for publishing and managing content on
-one or more [microfeed](https://www.microfeed.org/) sites. Use it directly from
-a terminal or let a local coding agent drive it. The CLI uses browser-based
-authorization for interactive work and accepts an existing API key for
-unattended CI jobs.
+The official, agent-friendly command for deploying
+[microfeed](https://www.microfeed.org/) and publishing content on its sites.
+Use it directly from a terminal or let a local coding agent drive it. Site
+deployment uses Cloudflare browser authorization; content management uses
+browser authorization for interactive work and accepts an existing API key
+for unattended CI jobs.
 
 Create, read, update, and delete items; upload cover art, inline media, and RSS
 enclosures; update a channel; or call any documented REST operation without
@@ -17,8 +18,9 @@ giving an agent a raw credential.
 ## Requirements
 
 - Node.js 22.12 or newer
-- A microfeed site with API access enabled
-- Built-in administrator login for browser authorization
+- For clone-free deployment: npm, Git, Corepack, and a Cloudflare account
+- For content management: a microfeed site with API access enabled and
+  built-in administrator login for browser authorization
 
 Instances without built-in login can continue using an API key.
 
@@ -64,8 +66,24 @@ microfeed --help
 
 ## Ask a coding agent
 
-Give an agent a content goal and the site URL instead of a credential. For
-example:
+To deploy a new site or connect and update an existing site without cloning
+the source repository yourself, give a local coding agent this prompt:
+
+```text
+Run `npx @microfeed/cli manage` and follow every instruction it prints until
+`status` verifies the deployment.
+```
+
+The launcher requires npm, Git, and Corepack. It downloads the exact tagged
+release matching the CLI into a private persistent cache, installs its locked
+dependencies, and prints the repository-owned deployment skill and reference
+for the agent. The first setup may use about 1.3 GB and take several minutes.
+Every later management command uses the same prefix, such as
+`npx @microfeed/cli manage status`. The source cache is replaceable; saved
+deployment state is kept separately.
+
+For content management, give an agent a content goal and the site URL instead
+of a credential. For example:
 
 ```text
 Use @microfeed/cli to create a published item on https://feed.example.com.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@microfeed/cli",
-  "version": "1.0.5",
-  "description": "Manage content on a microfeed instance",
+  "version": "1.0.6",
+  "description": "Deploy microfeed and manage content on its sites",
   "keywords": [
     "microfeed",
     "headless cms",
     "cms",
     "cli",
+    "deployment",
     "cloudflare"
   ],
   "homepage": "https://docs.microfeed.org/microfeed-cli/",

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -71,6 +71,26 @@ const itemInputOptions = [
 export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
   {
     details: [
+      "Downloads the exact tagged microfeed release into a private, persistent cache and runs its repository-owned management CLI. It never checks out source into the current project.",
+      "The launcher requires Git and Corepack in addition to Node.js and npm. Its first run installs the locked application dependencies, and the workspace may consume about 1.3 GB; later runs reuse it.",
+      "A bare manage command prepares the workspace and prints exact instructions for a local coding agent. Pass any management command and options after manage to forward them unchanged, including --instance and --json.",
+      "Deployment state is stored separately from the replaceable source cache. Existing sites that are not yet saved can be discovered and connected through the guarded management workflow.",
+      "Use only from a local interactive session that can complete Cloudflare browser authorization. Never paste a Cloudflare token, dashboard password, or private password-setup link into a command or agent conversation.",
+    ],
+    examples: [
+      "npx @microfeed/cli manage",
+      "npx @microfeed/cli manage accounts --json",
+      "npx @microfeed/cli manage init",
+      "npx @microfeed/cli manage deploy --instance personal",
+      "npx @microfeed/cli manage status --instance personal",
+    ],
+    options: [],
+    path: ["manage"],
+    summary: "Deploy and administer microfeed on Cloudflare without a user-managed clone.",
+    usage: "npx @microfeed/cli manage [command] [arguments] [options]",
+  },
+  {
+    details: [
       "Starts a development-only HTTP listener on 127.0.0.1:8978/webhook. It verifies Standard Webhooks signatures against the exact request bytes before printing or forwarding an event.",
       "Provide the signing secret through the visible interactive prompt, MICROFEED_WEBHOOK_SECRET, or --secret-file. The interactive prompt deliberately shows pasted text so terminal paste problems are easy to diagnose. A plaintext --secret option is intentionally unsupported.",
       "Use --json for one NDJSON object per delivery. Repeated delivery IDs are marked duplicate but are still forwarded so your receiver's deduplication can be tested.",
@@ -607,6 +627,9 @@ function alignedLines(
 }
 
 function referenceUrl(path?: readonly string[]): string {
+  if (path?.length === 1 && path[0] === "manage") {
+    return "https://docs.microfeed.org/microfeed-cli/#deploy-or-administer-a-site";
+  }
   const anchor = path?.length ? `#yarn-microfeed-${path.join("-")}` : "";
   return `https://docs.microfeed.org/microfeed-cli/${anchor}`;
 }
@@ -646,6 +669,7 @@ export function renderCliHelp(path?: readonly string[]): string {
   }
 
   const commands = [
+    {syntax: "manage", description: "Deploy or administer microfeed without cloning it yourself."},
     {syntax: "login <site-url>", description: "Authorize a site and save it as an instance."},
     {syntax: "logout", description: "Revoke this computer's tokens and remove its saved instance."},
     {syntax: "instances", description: "List, select, or locally remove saved instances."},
@@ -654,7 +678,7 @@ export function renderCliHelp(path?: readonly string[]): string {
     {syntax: "api", description: "Call one relative /api/v1/ REST operation."},
   ];
   return [
-    "microfeed — manage content on a microfeed instance",
+    "microfeed — deploy sites and manage their content",
     "",
     "Usage:",
     "  yarn microfeed <command> [arguments] [options]",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./commands.js";
 import {CliError} from "./errors.js";
 import {renderCliHelp} from "./help.js";
+import {runManageLauncher} from "./manage.js";
 import {webhookCommand} from "./webhooks.js";
 
 export const HELP = renderCliHelp();
@@ -31,6 +32,19 @@ function requestedHelp(args: string[]): readonly string[] | undefined {
 }
 
 export async function run(argv: string[]): Promise<void> {
+  if (argv[0] === "manage") {
+    const manageArguments = argv.slice(1);
+    if (
+      manageArguments.length === 1 &&
+      (manageArguments[0] === "--help" || manageArguments[0] === "-h")
+    ) {
+      process.stdout.write(renderCliHelp(["manage"]));
+      return;
+    }
+    const exitCode = await runManageLauncher(manageArguments);
+    if (exitCode !== 0) process.exitCode = exitCode;
+    return;
+  }
   const {args, options} = globalOptions(argv);
   const [command, ...rest] = args;
   if (!command) {

--- a/packages/cli/src/manage.ts
+++ b/packages/cli/src/manage.ts
@@ -1,0 +1,607 @@
+import {spawn, type SpawnOptions} from "node:child_process";
+import {constants as osConstants, homedir} from "node:os";
+import path from "node:path";
+import {
+  chmod,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+
+import {CliError} from "./errors.js";
+
+const MICROFEED_REPOSITORY_URL =
+  "https://github.com/microfeed/microfeed.git";
+const MINIMUM_NODE_VERSION = [22, 12, 0] as const;
+const SETUP_LOCK_STALE_MS = 60 * 60 * 1_000;
+
+type StringEnvironment = Record<string, string | undefined>;
+type CommandStdio = "ignore" | "inherit" | "pipe";
+
+export interface ManageCommandOptions {
+  cwd?: string;
+  env?: StringEnvironment;
+  stdio?: CommandStdio;
+}
+
+export interface ManageCommandResult {
+  exitCode: number;
+  signal: NodeJS.Signals | null;
+  stderr: string;
+  stdout: string;
+}
+
+export type ManageCommandRunner = (
+  executable: string,
+  args: readonly string[],
+  options?: ManageCommandOptions,
+) => Promise<ManageCommandResult>;
+
+export interface ManageLauncherOptions {
+  cacheDirectory?: string;
+  environment?: StringEnvironment;
+  homeDirectory?: string;
+  invocationDirectory?: string;
+  output?: (value: string) => void;
+  packageVersion?: string;
+  platform?: NodeJS.Platform;
+  runner?: ManageCommandRunner;
+  stateDirectory?: string;
+}
+
+function signalExitCode(signal: NodeJS.Signals | null): number {
+  if (!signal) return 1;
+  const number = osConstants.signals[signal];
+  return typeof number === "number" ? 128 + number : 1;
+}
+
+export const runManageProcess: ManageCommandRunner = (
+  executable,
+  args,
+  options = {},
+) => new Promise((resolve, reject) => {
+  const stdio = options.stdio ?? "inherit";
+  const spawnOptions: SpawnOptions = {
+    cwd: options.cwd,
+    env: options.env as NodeJS.ProcessEnv | undefined,
+    shell: false,
+    stdio: stdio === "pipe" ? ["ignore", "pipe", "pipe"] : stdio,
+  };
+  const child = spawn(executable, [...args], spawnOptions);
+  let stdout = "";
+  let stderr = "";
+  let settled = false;
+  const forwardedSignals: NodeJS.Signals[] = ["SIGINT", "SIGTERM"];
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
+
+  if (stdio === "pipe") {
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+  }
+
+  const cleanup = (): void => {
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler);
+    }
+  };
+  for (const signal of forwardedSignals) {
+    const handler = (): void => {
+      if (!child.killed) child.kill(signal);
+    };
+    signalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+
+  child.once("error", (error) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    reject(error);
+  });
+  child.once("close", (exitCode, signal) => {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    resolve({
+      exitCode: exitCode ?? signalExitCode(signal),
+      signal,
+      stderr,
+      stdout,
+    });
+  });
+});
+
+export function manageCacheDirectory(
+  environment: StringEnvironment = process.env,
+  platform: NodeJS.Platform = process.platform,
+  homeDirectory: string = homedir(),
+): string {
+  if (environment.MICROFEED_CACHE_DIR?.trim()) {
+    return path.resolve(environment.MICROFEED_CACHE_DIR.trim(), "manage");
+  }
+  if (platform === "win32") {
+    return path.join(
+      environment.LOCALAPPDATA?.trim() ||
+        path.join(homeDirectory, "AppData", "Local"),
+      "microfeed",
+      "manage",
+    );
+  }
+  if (platform === "darwin") {
+    return path.join(homeDirectory, "Library", "Caches", "microfeed", "manage");
+  }
+  return path.join(
+    environment.XDG_CACHE_HOME?.trim() || path.join(homeDirectory, ".cache"),
+    "microfeed",
+    "manage",
+  );
+}
+
+export function manageStateDirectory(
+  environment: StringEnvironment = process.env,
+  platform: NodeJS.Platform = process.platform,
+  homeDirectory: string = homedir(),
+): string {
+  if (environment.MICROFEED_CONFIG_DIR?.trim()) {
+    return path.join(
+      path.resolve(environment.MICROFEED_CONFIG_DIR.trim()),
+      "manage",
+    );
+  }
+  const root = platform === "win32"
+    ? path.join(
+      environment.APPDATA?.trim() ||
+        path.join(homeDirectory, "AppData", "Roaming"),
+      "microfeed",
+    )
+    : path.join(
+      environment.XDG_CONFIG_HOME?.trim() || path.join(homeDirectory, ".config"),
+      "microfeed",
+    );
+  return path.join(root, "manage");
+}
+
+function requireSupportedNodeVersion(version = process.versions.node): void {
+  const actual = version.split(".").map((part) => Number.parseInt(part, 10));
+  for (const [index, minimum] of MINIMUM_NODE_VERSION.entries()) {
+    const part = actual[index] ?? Number.NaN;
+    if (!Number.isInteger(part) || part < minimum) {
+      throw new CliError(
+        "Node.js 22.12.0 or newer is required for clone-free microfeed " +
+          "deployment. Install a current Node.js LTS release from " +
+          "https://nodejs.org/, then rerun the same command.",
+      );
+    }
+    if (part > minimum) return;
+  }
+}
+
+async function installedPackageVersion(): Promise<string> {
+  const metadata = JSON.parse(
+    await readFile(new URL("../package.json", import.meta.url), "utf8"),
+  ) as {version?: unknown};
+  if (typeof metadata.version !== "string" || !metadata.version.trim()) {
+    throw new CliError("The installed @microfeed/cli package has no version.");
+  }
+  return metadata.version;
+}
+
+async function requireExecutable(
+  runner: ManageCommandRunner,
+  executable: string,
+  remediation: string,
+): Promise<void> {
+  try {
+    const result = await runner(executable, ["--version"], {stdio: "pipe"});
+    if (result.exitCode === 0) return;
+  } catch {
+    // The actionable error below is the same for a missing or unusable tool.
+  }
+  throw new CliError(remediation);
+}
+
+async function pathExists(filename: string): Promise<boolean> {
+  try {
+    await stat(filename);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function repositoryMatchesVersion(
+  repositoryDirectory: string,
+  version: string,
+  runner: ManageCommandRunner,
+): Promise<boolean> {
+  try {
+    const metadata = JSON.parse(
+      await readFile(path.join(repositoryDirectory, "package.json"), "utf8"),
+    ) as {version?: unknown};
+    if (metadata.version !== version) return false;
+    const [head, release, status] = await Promise.all([
+      runner(
+        "git",
+        ["-C", repositoryDirectory, "rev-parse", "--verify", "HEAD"],
+        {stdio: "pipe"},
+      ),
+      runner(
+        "git",
+        [
+          "-C",
+          repositoryDirectory,
+          "rev-parse",
+          `refs/tags/v${version}^{commit}`,
+        ],
+        {stdio: "pipe"},
+      ),
+      runner(
+        "git",
+        [
+          "-C",
+          repositoryDirectory,
+          "status",
+          "--porcelain",
+          "--untracked-files=all",
+        ],
+        {stdio: "pipe"},
+      ),
+    ]);
+    return head.exitCode === 0 && release.exitCode === 0 &&
+      status.exitCode === 0 && status.stdout.trim() === "" &&
+      head.stdout.trim() === release.stdout.trim() && Boolean(head.stdout.trim());
+  } catch {
+    return false;
+  }
+}
+
+async function replaceRepository(
+  cacheDirectory: string,
+  repositoryDirectory: string,
+  version: string,
+  runner: ManageCommandRunner,
+): Promise<void> {
+  const candidate = path.join(
+    cacheDirectory,
+    `.repository-${process.pid}-${Date.now()}`,
+  );
+  const previous = path.join(cacheDirectory, ".repository-previous");
+  await rm(candidate, {force: true, recursive: true});
+  await rm(previous, {force: true, recursive: true});
+  try {
+    const clone = await runner(
+      "git",
+      [
+        "clone",
+        "--depth",
+        "1",
+        "--single-branch",
+        "--branch",
+        `v${version}`,
+        MICROFEED_REPOSITORY_URL,
+        candidate,
+      ],
+      {stdio: "inherit"},
+    );
+    if (clone.exitCode !== 0) {
+      throw new CliError(
+        `Could not download microfeed release v${version}. Confirm that the ` +
+          "release tag exists and that GitHub is reachable, then rerun the command.",
+        clone.exitCode,
+      );
+    }
+    if (!await repositoryMatchesVersion(candidate, version, runner)) {
+      throw new CliError(
+        `The downloaded source did not match @microfeed/cli ${version}. ` +
+          "The deployment workspace was not replaced.",
+      );
+    }
+
+    const hadRepository = await pathExists(repositoryDirectory);
+    if (hadRepository) await rename(repositoryDirectory, previous);
+    try {
+      await rename(candidate, repositoryDirectory);
+    } catch (error) {
+      if (hadRepository && await pathExists(previous)) {
+        await rename(previous, repositoryDirectory);
+      }
+      throw error;
+    }
+    await rm(previous, {force: true, recursive: true});
+  } finally {
+    await rm(candidate, {force: true, recursive: true});
+  }
+}
+
+async function recoverInterruptedRepositorySetup(
+  cacheDirectory: string,
+  repositoryDirectory: string,
+): Promise<void> {
+  const previous = path.join(cacheDirectory, ".repository-previous");
+  if (!await pathExists(repositoryDirectory) && await pathExists(previous)) {
+    await rename(previous, repositoryDirectory);
+  } else {
+    await rm(previous, {force: true, recursive: true});
+  }
+  const entries = await readdir(cacheDirectory, {withFileTypes: true});
+  await Promise.all(entries
+    .filter(({name}) => /^\.repository-\d+-\d+$/u.test(name))
+    .map(({name}) =>
+      rm(path.join(cacheDirectory, name), {force: true, recursive: true})
+    ));
+}
+
+async function setupLockOwnerIsActive(
+  lockDirectory: string,
+): Promise<boolean | undefined> {
+  try {
+    const owner = JSON.parse(
+      await readFile(path.join(lockDirectory, "owner.json"), "utf8"),
+    ) as {pid?: unknown};
+    if (typeof owner.pid !== "number" ||
+        !Number.isInteger(owner.pid) || owner.pid <= 0) {
+      return undefined;
+    }
+    try {
+      process.kill(owner.pid, 0);
+      return true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "ESRCH") return false;
+      if (code === "EPERM") return true;
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+async function acquireSetupLock(
+  lockDirectory: string,
+): Promise<() => Promise<void>> {
+  await mkdir(path.dirname(lockDirectory), {recursive: true});
+  try {
+    await mkdir(lockDirectory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    const lock = await stat(lockDirectory).catch(() => undefined);
+    const ownerIsActive = await setupLockOwnerIsActive(lockDirectory);
+    if (
+      !lock || ownerIsActive === true ||
+      (ownerIsActive === undefined &&
+        Date.now() - lock.mtimeMs <= SETUP_LOCK_STALE_MS)
+    ) {
+      throw new CliError(
+        "Another microfeed management command is preparing the private " +
+          "deployment workspace. Wait for it to finish, then retry.",
+      );
+    }
+    await rm(lockDirectory, {force: true, recursive: true});
+    await mkdir(lockDirectory);
+  }
+  await writeFile(
+    path.join(lockDirectory, "owner.json"),
+    `${JSON.stringify({pid: process.pid, startedAt: new Date().toISOString()})}\n`,
+    {mode: 0o600},
+  );
+  return async () => {
+    await rm(lockDirectory, {force: true, recursive: true});
+  };
+}
+
+async function prepareWorkspace(input: {
+  cacheDirectory: string;
+  environment: StringEnvironment;
+  packageVersion: string;
+  platform: NodeJS.Platform;
+  runner: ManageCommandRunner;
+}): Promise<{
+  environment: StringEnvironment;
+  repositoryDirectory: string;
+  tsxExecutable: string;
+}> {
+  await mkdir(input.cacheDirectory, {recursive: true, mode: 0o700});
+  if (process.platform !== "win32") {
+    await chmod(input.cacheDirectory, 0o700);
+  }
+  const repositoryDirectory = path.join(input.cacheDirectory, "repository");
+  const binDirectory = path.join(input.cacheDirectory, "bin");
+  const releaseLock = await acquireSetupLock(
+    path.join(input.cacheDirectory, ".setup-lock"),
+  );
+  try {
+    await recoverInterruptedRepositorySetup(
+      input.cacheDirectory,
+      repositoryDirectory,
+    );
+    if (!await repositoryMatchesVersion(
+      repositoryDirectory,
+      input.packageVersion,
+      input.runner,
+    )) {
+      await replaceRepository(
+        input.cacheDirectory,
+        repositoryDirectory,
+        input.packageVersion,
+        input.runner,
+      );
+    }
+
+    await mkdir(binDirectory, {recursive: true});
+    const environment: StringEnvironment = {
+      ...input.environment,
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+      COREPACK_HOME: path.join(input.cacheDirectory, "corepack"),
+      PATH: [binDirectory, input.environment.PATH].filter(Boolean)
+        .join(path.delimiter),
+    };
+    const corepack = input.platform === "win32" ? "corepack.cmd" : "corepack";
+    const enable = await input.runner(
+      corepack,
+      ["enable", "--install-directory", binDirectory, "yarn"],
+      {env: environment, stdio: "pipe"},
+    );
+    if (enable.exitCode !== 0) {
+      throw new CliError(
+        "Corepack could not create the private Yarn launcher. " +
+          (enable.stderr.trim() || enable.stdout.trim() ||
+            "Rerun after repairing Corepack."),
+        enable.exitCode,
+      );
+    }
+    const yarn = path.join(
+      binDirectory,
+      input.platform === "win32" ? "yarn.cmd" : "yarn",
+    );
+    const install = await input.runner(
+      yarn,
+      ["install", "--immutable"],
+      {cwd: repositoryDirectory, env: environment, stdio: "inherit"},
+    );
+    if (install.exitCode !== 0) {
+      throw new CliError(
+        "The exact microfeed release was downloaded, but its locked " +
+          "dependencies could not be installed. Fix the reported Yarn error " +
+          "and rerun the same command.",
+        install.exitCode,
+      );
+    }
+    return {
+      environment,
+      repositoryDirectory,
+      tsxExecutable: path.join(
+        repositoryDirectory,
+        "node_modules",
+        ".bin",
+        input.platform === "win32" ? "tsx.cmd" : "tsx",
+      ),
+    };
+  } finally {
+    await releaseLock();
+  }
+}
+
+export function manageAgentHandoff(
+  repositoryDirectory: string,
+  version: string,
+): string {
+  const skill = path.join(
+    repositoryDirectory,
+    ".agents",
+    "skills",
+    "deploy-microfeed",
+    "SKILL.md",
+  );
+  const reference = path.join(repositoryDirectory, "docs", "manage-cli.md");
+  return [
+    `microfeed v${version} deployment workspace is ready.`,
+    "",
+    "Coding agent instructions:",
+    `1. Read \`${skill}\` completely.`,
+    `2. Read \`${reference}\` completely.`,
+    "3. Follow that deployment workflow until `status` verifies the site.",
+    "4. Wherever those files print `yarn manage …`, run " +
+      "`npx @microfeed/cli manage …` from this conversation instead.",
+    "5. Wherever they print `yarn dev …`, run " +
+      "`npx @microfeed/cli manage dev …` instead.",
+    "",
+    "Start with:",
+    "  npx @microfeed/cli manage accounts --json",
+    "",
+    "Do not stop after preparing this workspace. Discover whether the site is " +
+      "new or existing, ask before ambiguous or consequential choices, and " +
+      "continue until the final status check succeeds.",
+    "",
+  ].join("\n");
+}
+
+export async function runManageLauncher(
+  args: readonly string[],
+  options: ManageLauncherOptions = {},
+): Promise<number> {
+  const environment = options.environment ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const homeDirectory = options.homeDirectory ?? homedir();
+  const runner = options.runner ?? runManageProcess;
+  const packageVersion = options.packageVersion ?? await installedPackageVersion();
+  const cacheDirectory = options.cacheDirectory ?? manageCacheDirectory(
+    environment,
+    platform,
+    homeDirectory,
+  );
+  const stateDirectory = options.stateDirectory ?? manageStateDirectory(
+    environment,
+    platform,
+    homeDirectory,
+  );
+  const invocationDirectory = options.invocationDirectory ?? process.cwd();
+
+  requireSupportedNodeVersion();
+  await requireExecutable(
+    runner,
+    platform === "win32" ? "npm.cmd" : "npm",
+    "npm is required for clone-free microfeed deployment. Install a current " +
+      "Node.js LTS release, including npm, from https://nodejs.org/, then " +
+      "rerun the same command.",
+  );
+  await requireExecutable(
+    runner,
+    "git",
+    "Git is required for clone-free microfeed deployment. Install Git from " +
+      "https://git-scm.com/downloads, then rerun the same command.",
+  );
+  await requireExecutable(
+    runner,
+    platform === "win32" ? "corepack.cmd" : "corepack",
+    "Corepack is required for clone-free microfeed deployment. Install it " +
+      "with `npm install --global corepack`, then rerun the same command.",
+  );
+
+  const workspace = await prepareWorkspace({
+    cacheDirectory,
+    environment,
+    packageVersion,
+    platform,
+    runner,
+  });
+  if (args.length === 0) {
+    (options.output ?? ((value) => process.stdout.write(value)))(
+      manageAgentHandoff(workspace.repositoryDirectory, packageVersion),
+    );
+    return 0;
+  }
+
+  await mkdir(stateDirectory, {recursive: true, mode: 0o700});
+  if (process.platform !== "win32") {
+    await chmod(stateDirectory, 0o700);
+  }
+  const result = await runner(
+    workspace.tsxExecutable,
+    [
+      "--tsconfig",
+      path.join(workspace.repositoryDirectory, "tsconfig.json"),
+      path.join(workspace.repositoryDirectory, "manage-cli", "index.ts"),
+      ...args,
+    ],
+    {
+      cwd: invocationDirectory,
+      env: {
+        ...workspace.environment,
+        MICROFEED_STATE_DIRECTORY: stateDirectory,
+      },
+      stdio: "inherit",
+    },
+  );
+  return result.exitCode;
+}

--- a/packages/theme-kit/package.json
+++ b/packages/theme-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/theme-kit",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Author, validate, test, and preview microfeed themes.",
   "keywords": [
     "microfeed",

--- a/scripts/check-cli-package.ts
+++ b/scripts/check-cli-package.ts
@@ -1,4 +1,12 @@
-import {mkdir, mkdtemp, readFile, readdir, rm, writeFile} from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import path from "node:path";
 import {spawnSync} from "node:child_process";
@@ -7,11 +15,20 @@ import {x as extractTar} from "tar";
 import {CLI_HELP_TOPICS, renderCliHelp} from "../packages/cli/src/help";
 import {HELP} from "../packages/cli/src/index";
 
-function run(command: string, args: string[], cwd = process.cwd()): string {
+function run(
+  command: string,
+  args: string[],
+  cwd = process.cwd(),
+  environment: Record<string, string | undefined> = {},
+): string {
   const result = spawnSync(command, args, {
     cwd,
     encoding: "utf8",
-    env: {...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"},
+    env: {
+      ...process.env,
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+      ...environment,
+    } as NodeJS.ProcessEnv,
   });
   if (result.status !== 0) {
     throw new Error(
@@ -72,6 +89,7 @@ try {
   );
   if (!packedReadme.includes("yarn microfeed login") ||
       !packedReadme.includes("npm install --global @microfeed/cli") ||
+      !packedReadme.includes("npx @microfeed/cli manage") ||
       !packedReadme.includes("Site URLs and instance names") ||
       !packedReadme.includes("GNU Affero General Public License v3.0")) {
     throw new Error("The packed CLI README is incomplete.");
@@ -224,6 +242,92 @@ try {
   if (!dlxHelp.endsWith(HELP)) {
     throw new Error("The yarn dlx @microfeed/cli behavior diverged.");
   }
+  const expectedManageHelp = renderCliHelp(["manage"]);
+  const dlxManageHelp = run("yarn", [
+    "dlx",
+    "--package",
+    `@microfeed/cli@file:${archive}`,
+    "microfeed",
+    "manage",
+    "--help",
+  ], temporary);
+  if (!dlxManageHelp.endsWith(expectedManageHelp)) {
+    throw new Error("The packed clone-free management help diverged.");
+  }
+
+  const npmConsumer = path.join(temporary, "npm-consumer");
+  await mkdir(npmConsumer);
+  await writeFile(path.join(npmConsumer, "package.json"), JSON.stringify({
+    private: true,
+  }));
+  run("npm", [
+    "install",
+    "--ignore-scripts",
+    "--omit=optional",
+    archive,
+  ], npmConsumer);
+  const npxManageHelp = run("npx", [
+    "--no-install",
+    "microfeed",
+    "manage",
+    "--help",
+  ], npmConsumer);
+  if (npxManageHelp !== expectedManageHelp) {
+    throw new Error("The npx @microfeed/cli management help diverged.");
+  }
+
+  if (process.platform !== "win32") {
+    const cacheRoot = path.join(temporary, "launcher-cache");
+    const manageCache = path.join(cacheRoot, "manage");
+    const repository = path.join(manageCache, "repository");
+    const cacheBin = path.join(manageCache, "bin");
+    const fakeBin = path.join(temporary, "launcher-tools");
+    await Promise.all([
+      mkdir(repository, {recursive: true}),
+      mkdir(cacheBin, {recursive: true}),
+      mkdir(fakeBin, {recursive: true}),
+    ]);
+    await writeFile(
+      path.join(repository, "package.json"),
+      `${JSON.stringify({version: rootPackage.version})}\n`,
+    );
+    const fakeTool = async (name: string, source: string): Promise<void> => {
+      const filename = path.join(fakeBin, name);
+      await writeFile(filename, `#!/usr/bin/env node\n${source}\n`, {
+        mode: 0o755,
+      });
+      await chmod(filename, 0o755);
+    };
+    await Promise.all([
+      fakeTool("npm", "process.stdout.write('10.0.0\\n');"),
+      fakeTool("corepack", "process.stdout.write('0.31.0\\n');"),
+      fakeTool("git", [
+        "const args = process.argv.slice(2);",
+        "if (args[0] === '--version') process.stdout.write('git version 2.50.0\\n');",
+        "else if (args.includes('rev-parse')) process.stdout.write('0123456789abcdef0123456789abcdef01234567\\n');",
+        "else if (!args.includes('status')) process.exitCode = 1;",
+      ].join("\n")),
+    ]);
+    const yarn = path.join(cacheBin, "yarn");
+    await writeFile(yarn, "#!/usr/bin/env node\n", {mode: 0o755});
+    await chmod(yarn, 0o755);
+    const handoff = run("npx", [
+      "--no-install",
+      "microfeed",
+      "manage",
+    ], npmConsumer, {
+      MICROFEED_CACHE_DIR: cacheRoot,
+      MICROFEED_CONFIG_DIR: path.join(temporary, "launcher-config"),
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+    if (!handoff.includes(`microfeed v${rootPackage.version}`) ||
+        !handoff.includes("deploy-microfeed/SKILL.md") ||
+        !handoff.includes("docs/manage-cli.md") ||
+        !handoff.includes("npx @microfeed/cli manage accounts --json") ||
+        !handoff.includes("final status check succeeds")) {
+      throw new Error("The packed npx coding-agent handoff is incomplete.");
+    }
+  }
   const dlxScaffold = path.join(temporary, "dlx-scaffold");
   const dlxScaffoldOutput = run("yarn", [
     "dlx",
@@ -254,7 +358,7 @@ try {
     throw new Error("The packed Python webhook starter file set is incomplete.");
   }
   process.stdout.write(
-    "Workspace, project-local, packed, and yarn dlx @microfeed/cli behavior match.\n",
+    "Workspace, project-local, packed, npx, and yarn dlx @microfeed/cli behavior match.\n",
   );
 } finally {
   await rm(temporary, {force: true, recursive: true});

--- a/tests/unit/cli/manage.test.ts
+++ b/tests/unit/cli/manage.test.ts
@@ -1,0 +1,458 @@
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import path from "node:path";
+
+import {afterEach, describe, expect, it} from "vitest";
+
+import {
+  manageAgentHandoff,
+  manageCacheDirectory,
+  type ManageCommandOptions,
+  type ManageCommandResult,
+  type ManageCommandRunner,
+  manageStateDirectory,
+  runManageLauncher,
+  runManageProcess,
+} from "../../../packages/cli/src/manage";
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory(name: string): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), name));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function commandResult(
+  input: Partial<ManageCommandResult> = {},
+): ManageCommandResult {
+  return {
+    exitCode: 0,
+    signal: null,
+    stderr: "",
+    stdout: "",
+    ...input,
+  };
+}
+
+interface RecordedCommand {
+  args: readonly string[];
+  executable: string;
+  options: ManageCommandOptions;
+}
+
+function workspaceRunner(
+  version: string,
+  commands: RecordedCommand[],
+  finalResult: ManageCommandResult = commandResult(),
+): ManageCommandRunner {
+  return async (executable, args, options = {}) => {
+    commands.push({args: [...args], executable, options});
+    if (executable === "git" && args[0] === "clone") {
+      const destination = args.at(-1)!;
+      await mkdir(destination, {recursive: true});
+      await writeFile(
+        path.join(destination, "package.json"),
+        `${JSON.stringify({version})}\n`,
+      );
+      return commandResult();
+    }
+    if (executable === "git" && args.includes("rev-parse")) {
+      return commandResult({stdout: "0123456789abcdef\n"});
+    }
+    if (executable === "git" && args.includes("status")) {
+      return commandResult();
+    }
+    if (executable.endsWith(`${path.sep}tsx`)) return finalResult;
+    return commandResult({stdout: `${path.basename(executable)} 1.0.0\n`});
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, {force: true, recursive: true})
+  ));
+});
+
+describe("clone-free management launcher", () => {
+  it("uses platform cache and persistent state directories", () => {
+    expect(manageCacheDirectory(
+      {MICROFEED_CACHE_DIR: "/custom/cache"},
+      "linux",
+      "/home/person",
+    )).toBe(path.resolve("/custom/cache", "manage"));
+    expect(manageCacheDirectory({}, "darwin", "/Users/person"))
+      .toBe("/Users/person/Library/Caches/microfeed/manage");
+    expect(manageCacheDirectory({}, "linux", "/home/person"))
+      .toBe("/home/person/.cache/microfeed/manage");
+    expect(manageCacheDirectory(
+      {LOCALAPPDATA: "C:\\Users\\person\\AppData\\Local"},
+      "win32",
+      "C:\\Users\\person",
+    )).toContain(path.join("microfeed", "manage"));
+
+    expect(manageStateDirectory(
+      {MICROFEED_CONFIG_DIR: "/custom/config"},
+      "linux",
+      "/home/person",
+    )).toBe(path.resolve("/custom/config", "manage"));
+    expect(manageStateDirectory(
+      {XDG_CONFIG_HOME: "/xdg/config"},
+      "linux",
+      "/home/person",
+    )).toBe("/xdg/config/microfeed/manage");
+    expect(manageStateDirectory({}, "darwin", "/Users/person"))
+      .toBe("/Users/person/.config/microfeed/manage");
+    expect(manageStateDirectory({}, "win32", "C:\\Users\\person"))
+      .toContain(path.join("AppData", "Roaming", "microfeed", "manage"));
+  });
+
+  it("clones the exact release and prints a complete agent handoff", async () => {
+    const root = await temporaryDirectory("microfeed-manage-bootstrap-");
+    const cacheDirectory = path.join(root, "cache");
+    const stateDirectory = path.join(root, "state");
+    const invocationDirectory = path.join(root, "empty-caller");
+    const commands: RecordedCommand[] = [];
+    const output: string[] = [];
+    await mkdir(invocationDirectory);
+
+    await expect(runManageLauncher([], {
+      cacheDirectory,
+      environment: {PATH: "/usr/bin"},
+      output: (value) => output.push(value),
+      packageVersion: "1.2.3",
+      platform: "linux",
+      invocationDirectory,
+      runner: workspaceRunner("1.2.3", commands),
+      stateDirectory,
+    })).resolves.toBe(0);
+
+    const clone = commands.find(({args, executable}) =>
+      executable === "git" && args[0] === "clone"
+    );
+    expect(clone?.args).toEqual([
+      "clone",
+      "--depth",
+      "1",
+      "--single-branch",
+      "--branch",
+      "v1.2.3",
+      "https://github.com/microfeed/microfeed.git",
+      expect.stringContaining(".repository-"),
+    ]);
+    const install = commands.find(({args}) => args[0] === "install");
+    expect(install?.args).toEqual(["install", "--immutable"]);
+    expect(install?.options.cwd).toBe(path.join(cacheDirectory, "repository"));
+    const corepack = commands.find(({args, executable}) =>
+      executable === "corepack" && args[0] === "enable"
+    );
+    expect(corepack?.args).toEqual([
+      "enable",
+      "--install-directory",
+      path.join(cacheDirectory, "bin"),
+      "yarn",
+    ]);
+    expect(corepack?.options.env?.COREPACK_HOME)
+      .toBe(path.join(cacheDirectory, "corepack"));
+    expect(output.join("\n")).toContain("microfeed v1.2.3");
+    expect(output.join("\n")).toContain("deploy-microfeed");
+    expect(output.join("\n")).toContain("docs/manage-cli.md");
+    expect(output.join("\n")).toContain(
+      "npx @microfeed/cli manage accounts --json",
+    );
+    expect(output.join("\n")).toContain("Do not stop");
+    await expect(readdir(invocationDirectory)).resolves.toEqual([]);
+  });
+
+  it("reuses the checkout and forwards every argument from the original directory", async () => {
+    const root = await temporaryDirectory("microfeed-manage-forward-");
+    const cacheDirectory = path.join(root, "cache");
+    const stateDirectory = path.join(root, "state");
+    const invocationDirectory = path.join(root, "caller");
+    const commands: RecordedCommand[] = [];
+    const runner = workspaceRunner(
+      "1.2.3",
+      commands,
+      commandResult({exitCode: 17}),
+    );
+    await mkdir(invocationDirectory);
+
+    await runManageLauncher([], {
+      cacheDirectory,
+      environment: {MICROFEED_TEST_MARKER: "preserved", PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner,
+      stateDirectory,
+    });
+    commands.splice(0);
+    await expect(runManageLauncher(
+      ["deploy", "--instance", "personal", "--json"],
+      {
+        cacheDirectory,
+        environment: {MICROFEED_TEST_MARKER: "preserved", PATH: "/usr/bin"},
+        invocationDirectory,
+        packageVersion: "1.2.3",
+        platform: "linux",
+        runner,
+        stateDirectory,
+      },
+    )).resolves.toBe(17);
+
+    expect(commands.some(({args}) => args[0] === "clone")).toBe(false);
+    const forwarded = commands.find(({executable}) =>
+      executable.endsWith(`${path.sep}tsx`)
+    );
+    expect(forwarded?.options.cwd).toBe(invocationDirectory);
+    expect(forwarded?.options.env?.MICROFEED_STATE_DIRECTORY)
+      .toBe(stateDirectory);
+    expect(forwarded?.options.env?.PATH?.split(path.delimiter)[0])
+      .toBe(path.join(cacheDirectory, "bin"));
+    expect(forwarded?.options.env?.MICROFEED_TEST_MARKER).toBe("preserved");
+    expect(forwarded?.options.stdio).toBe("inherit");
+    expect(forwarded?.args.slice(-4)).toEqual([
+      "deploy",
+      "--instance",
+      "personal",
+      "--json",
+    ]);
+    if (process.platform !== "win32") {
+      expect((await stat(cacheDirectory)).mode & 0o777).toBe(0o700);
+      expect((await stat(stateDirectory)).mode & 0o777).toBe(0o700);
+    }
+  });
+
+  it("replaces only stale cached source and preserves deployment state", async () => {
+    const root = await temporaryDirectory("microfeed-manage-refresh-");
+    const cacheDirectory = path.join(root, "cache");
+    const repositoryDirectory = path.join(cacheDirectory, "repository");
+    const stateDirectory = path.join(root, "state");
+    const commands: RecordedCommand[] = [];
+    await mkdir(repositoryDirectory, {recursive: true});
+    await mkdir(stateDirectory, {recursive: true});
+    await writeFile(
+      path.join(repositoryDirectory, "package.json"),
+      `${JSON.stringify({version: "1.0.0"})}\n`,
+    );
+    await writeFile(path.join(stateDirectory, "saved-instance"), "preserved");
+
+    await runManageLauncher([], {
+      cacheDirectory,
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: workspaceRunner("1.2.3", commands),
+      stateDirectory,
+    });
+
+    expect(JSON.parse(
+      await readFile(path.join(repositoryDirectory, "package.json"), "utf8"),
+    )).toEqual({version: "1.2.3"});
+    await expect(readFile(path.join(stateDirectory, "saved-instance"), "utf8"))
+      .resolves.toBe("preserved");
+  });
+
+  it("repairs a dirty cached checkout without touching saved state", async () => {
+    const root = await temporaryDirectory("microfeed-manage-dirty-");
+    const cacheDirectory = path.join(root, "cache");
+    const repositoryDirectory = path.join(cacheDirectory, "repository");
+    const stateDirectory = path.join(root, "state");
+    const commands: RecordedCommand[] = [];
+    let statusChecks = 0;
+    const baseRunner = workspaceRunner("1.2.3", commands);
+    const runner: ManageCommandRunner = async (executable, args, options) => {
+      if (executable === "git" && args.includes("status")) {
+        statusChecks += 1;
+        if (statusChecks === 1) return commandResult({stdout: "?? changed\n"});
+      }
+      return await baseRunner(executable, args, options);
+    };
+    await mkdir(repositoryDirectory, {recursive: true});
+    await mkdir(stateDirectory, {recursive: true});
+    await writeFile(
+      path.join(repositoryDirectory, "package.json"),
+      `${JSON.stringify({version: "1.2.3"})}\n`,
+    );
+    await writeFile(path.join(stateDirectory, "saved-instance"), "preserved");
+
+    await runManageLauncher([], {
+      cacheDirectory,
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner,
+      stateDirectory,
+    });
+
+    expect(commands.some(({args}) => args[0] === "clone")).toBe(true);
+    await expect(readFile(path.join(stateDirectory, "saved-instance"), "utf8"))
+      .resolves.toBe("preserved");
+  });
+
+  it("rejects concurrent setup and reports missing prerequisites clearly", async () => {
+    const root = await temporaryDirectory("microfeed-manage-lock-");
+    const cacheDirectory = path.join(root, "cache");
+    await mkdir(path.join(cacheDirectory, ".setup-lock"), {recursive: true});
+    await expect(runManageLauncher([], {
+      cacheDirectory,
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: workspaceRunner("1.2.3", []),
+      stateDirectory: path.join(root, "state"),
+    })).rejects.toThrow(/Another microfeed management command/u);
+
+    const activeCache = path.join(root, "active-lock");
+    const activeLock = path.join(activeCache, ".setup-lock");
+    await mkdir(activeLock, {recursive: true});
+    await writeFile(
+      path.join(activeLock, "owner.json"),
+      `${JSON.stringify({pid: process.pid})}\n`,
+    );
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1_000);
+    await utimes(activeLock, old, old);
+    await expect(runManageLauncher([], {
+      cacheDirectory: activeCache,
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: workspaceRunner("1.2.3", []),
+      stateDirectory: path.join(root, "state"),
+    })).rejects.toThrow(/Another microfeed management command/u);
+
+    const missingGit: ManageCommandRunner = async (executable) => {
+      if (executable === "git") {
+        throw Object.assign(new Error("spawn git ENOENT"), {code: "ENOENT"});
+      }
+      return commandResult();
+    };
+    await expect(runManageLauncher([], {
+      cacheDirectory: path.join(root, "missing-git"),
+      environment: {PATH: ""},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: missingGit,
+      stateDirectory: path.join(root, "state"),
+    })).rejects.toThrow(/Git is required/u);
+
+    const missingCorepack: ManageCommandRunner = async (executable) => {
+      if (executable === "corepack") {
+        throw Object.assign(
+          new Error("spawn corepack ENOENT"),
+          {code: "ENOENT"},
+        );
+      }
+      return commandResult();
+    };
+    await expect(runManageLauncher([], {
+      cacheDirectory: path.join(root, "missing-corepack"),
+      environment: {PATH: ""},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: missingCorepack,
+      stateDirectory: path.join(root, "state"),
+    })).rejects.toThrow(/Corepack is required/u);
+
+    const missingNpm: ManageCommandRunner = async (executable) => {
+      if (executable === "npm") {
+        throw Object.assign(new Error("spawn npm ENOENT"), {code: "ENOENT"});
+      }
+      return commandResult();
+    };
+    await expect(runManageLauncher([], {
+      cacheDirectory: path.join(root, "missing-npm"),
+      environment: {PATH: ""},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: missingNpm,
+      stateDirectory: path.join(root, "state"),
+    })).rejects.toThrow(/npm is required/u);
+  });
+
+  it("recovers an abandoned setup lock", async () => {
+    const root = await temporaryDirectory("microfeed-manage-stale-lock-");
+    const cacheDirectory = path.join(root, "cache");
+    const lockDirectory = path.join(cacheDirectory, ".setup-lock");
+    await mkdir(lockDirectory, {recursive: true});
+    const old = new Date(Date.now() - 2 * 60 * 60 * 1_000);
+    await utimes(lockDirectory, old, old);
+
+    await expect(runManageLauncher([], {
+      cacheDirectory,
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: workspaceRunner("1.2.3", []),
+      stateDirectory: path.join(root, "state"),
+    })).resolves.toBe(0);
+  });
+
+  it("recovers an interrupted repository swap without downloading again", async () => {
+    const root = await temporaryDirectory("microfeed-manage-swap-");
+    const cacheDirectory = path.join(root, "cache");
+    const previous = path.join(cacheDirectory, ".repository-previous");
+    const abandonedCandidate = path.join(cacheDirectory, ".repository-123-456");
+    const commands: RecordedCommand[] = [];
+    await mkdir(previous, {recursive: true});
+    await mkdir(abandonedCandidate, {recursive: true});
+    await writeFile(
+      path.join(previous, "package.json"),
+      `${JSON.stringify({version: "1.2.3"})}\n`,
+    );
+
+    await runManageLauncher([], {
+      cacheDirectory,
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner: workspaceRunner("1.2.3", commands),
+      stateDirectory: path.join(root, "state"),
+    });
+
+    expect(commands.some(({args}) => args[0] === "clone")).toBe(false);
+    await expect(readFile(
+      path.join(cacheDirectory, "repository", "package.json"),
+      "utf8",
+    )).resolves.toContain('"version":"1.2.3"');
+    expect(await readdir(cacheDirectory)).not.toContain(".repository-123-456");
+  });
+
+  it("preserves a child signal as its conventional exit code", async () => {
+    if (process.platform === "win32") return;
+    const result = await runManageProcess(
+      process.execPath,
+      ["-e", "process.kill(process.pid, 'SIGTERM')"],
+      {stdio: "ignore"},
+    );
+    expect(result.signal).toBe("SIGTERM");
+    expect(result.exitCode).toBe(143);
+  });
+
+  it("renders absolute handoff paths and the public command translation", () => {
+    const output = manageAgentHandoff("/private/cache/microfeed", "2.0.0");
+    expect(output).toContain(
+      "`/private/cache/microfeed/.agents/skills/deploy-microfeed/SKILL.md`",
+    );
+    expect(output).toContain("`npx @microfeed/cli manage …`");
+    expect(output).toContain("final status check succeeds");
+  });
+});

--- a/tests/unit/default-theme.test.ts
+++ b/tests/unit/default-theme.test.ts
@@ -234,7 +234,7 @@ describe("bundled theme packages", () => {
       expect(url).toMatch(/^https:\/\/upload\.wikimedia\.org\//u);
       expect(url).not.toContain("example.test");
     }
-    expect(application.version).toBe("1.0.5");
+    expect(application.version).toBe("1.0.6");
   });
 
   it("renders subscription methods without broken or duplicated image text", async () => {


### PR DESCRIPTION
## Summary

- Add a thin clone-free deployment launcher at npx @microfeed/cli manage.
- Cache the exact tagged microfeed release privately, keep deployment state separate, and forward existing manage-cli commands with their terminal behavior and exit status intact.
- Update deployment guidance for coding agents while retaining yarn manage for repository clones.
- Bump the application, @microfeed/cli, and @microfeed/theme-kit to 1.0.6.

## Related issue

N/A.

## Testing

- [x] yarn check
- [x] yarn docs:check
- [x] git diff --check
- [x] Packed npx and yarn dlx launcher checks
- [x] Live Cloudflare acceptance test

The live acceptance test used a disposable blank consumer with the locally packed 1.0.6 CLI and isolated cache/config directories. It exercised the exact npx @microfeed/cli manage command, account discovery, multiple existing-Worker candidates, new-site initialization, D1 and R2 provisioning, browser password setup, final status verification, and confirmed destruction. The cli-test1 Worker, database, bucket, and saved instance state were removed, and final discovery confirmed the test site was absent.

## Screenshots

N/A — no visual interface changes.

## Risks

The v1.0.6 Git tag must exist before publishing @microfeed/cli 1.0.6 because the launcher intentionally checks out that exact release. For pre-release acceptance, the cache was seeded from this PR commit with a local v1.0.6 tag; the public GitHub tag download therefore remains release-order dependent. First-time setup also downloads the source and locked dependencies into the private cache.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.