### PR TITLE
Prefer clone-free management commands

### DIFF
--- a/.agents/skills/deploy-microfeed/agents/openai.yaml
+++ b/.agents/skills/deploy-microfeed/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Deploy microfeed"
-  short_description: "Deploy microfeed safely through yarn manage"
-  default_prompt: "Use $deploy-microfeed to deploy this microfeed repository to Cloudflare."
+  short_description: "Deploy microfeed safely from any folder"
+  default_prompt: "Use $deploy-microfeed to run `npx @microfeed/cli manage` and follow every instruction until `status` verifies the deployment."

--- a/.agents/skills/export-microfeed-theme/SKILL.md
+++ b/.agents/skills/export-microfeed-theme/SKILL.md
@@ -5,20 +5,23 @@ description: Initialize or export a microfeed theme from a saved instance into a
 
 # Initialize or export a microfeed theme
 
-Use the project-owned `yarn manage` CLI from the microfeed repository root.
-Read the theme section of [`docs/manage-cli.md`](../../../docs/manage-cli.md)
-before using an unfamiliar option.
+Prefer the clone-free `npx @microfeed/cli manage` launcher from any working
+directory. A user who is already working inside a trusted microfeed clone may
+use the project-owned `yarn manage` command instead. Use one prefix consistently
+for the whole task. Read the theme section of
+[`docs/manage-cli.md`](../../../docs/manage-cli.md) before using an unfamiliar
+option.
 
 ## Choose the repository identity
 
-1. Run `yarn manage instances --json` and select the exact saved instance the
+1. Run `npx @microfeed/cli manage instances --json` and select the exact saved instance the
    user named. If several instances remain plausible, report their names and
    ask the user to choose.
 2. Use `theme init` when the user wants a new independently versioned theme
    based on the site's effective appearance:
 
    ```console
-   yarn manage theme init <output-directory> --instance <instance-name> --json
+   npx @microfeed/cli manage theme init <output-directory> --instance <instance-name> --json
    ```
 
    Let the CLI choose the initial `local.<directory-name>` package ID unless
@@ -29,7 +32,7 @@ before using an unfamiliar option.
    package identity. Export the active installed version by default:
 
    ```console
-   yarn manage theme export --active --instance <instance-name> --git --json
+   npx @microfeed/cli manage theme export --active --instance <instance-name> --git --json
    ```
 
    When the user names an immutable theme ID, replace `--active` with that ID.

--- a/.agents/skills/manage-microfeed-content/SKILL.md
+++ b/.agents/skills/manage-microfeed-content/SKILL.md
@@ -72,8 +72,8 @@ the saved browser login does not need to be recreated.
 Browser OAuth also requires the site's built-in login. Cloudflare Access may
 protect routes, but it does not create the microfeed application session OAuth
 needs. If the CLI reports that OAuth authorization is unavailable, tell the
-owner to run `yarn manage auth setup` from the connected repository, then retry
-login. Newer sites report this capability explicitly; follow the CLI's
+owner to run `npx @microfeed/cli manage auth setup`, then retry login. Newer
+sites report this capability explicitly; follow the CLI's
 compatible setup guidance for older sites that do not.
 
 When authorization is missing, run:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,17 +23,20 @@
 
 ## Instance management and Cloudflare deployment
 
-- When a user asks a coding agent to operate `yarn manage` against local or
-  Cloudflare state, use the repository's `deploy-microfeed` skill. This covers
+- When a user asks a coding agent to operate `npx @microfeed/cli manage` or
+  `yarn manage` against local or Cloudflare state, use the repository's
+  `deploy-microfeed` skill. This covers
   accounts, initialization, connection, development, deployment, themes,
   snapshots, status, destruction, Pages migration, domains, Access, built-in
   authentication, configuration, and instance selection.
-- Perform every Cloudflare deployment change through `yarn manage`. Do not
-  improvise with raw Wrangler commands, direct Cloudflare API calls, or a
-  separate deployment implementation.
+- Perform every Cloudflare deployment change through the management engine.
+  Prefer `npx @microfeed/cli manage` outside a user-managed clone; use
+  `yarn manage` when already working inside one. When the launcher selected the
+  `npx` prefix, translate every `yarn manage` and `yarn dev` example below to
+  `npx @microfeed/cli manage` and `npx @microfeed/cli manage dev`.
 - Do not use or recommend Cloudflare repository imports, Workers Builds,
-  deploy buttons, GitHub Actions, or API-token deployment. Both people and
-  agents deploy from a local clone through `yarn manage`.
+  deploy buttons, GitHub Actions, or API-token deployment. People and agents
+  can use the clone-free launcher without creating a local source checkout.
 - Treat `docs/manage-cli.md` as the canonical command, option, side-effect, and
   safety reference for both people and agents. Read the relevant command
   section before using an unfamiliar or destructive option. Keep that reference

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ microfeed makes it easy for individuals to self-host their own feed on Cloudflar
 * a content curation feed of external news article urls
 * a marketing site with updates and press coverage (e.g., [microfeed.org](https://www.microfeed.org/))
 * a headless CMS with a GUI dashboard, RSS Feed, JSON Feed, API, Webhooks, and [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli). Explore the public demo’s [interactive API docs](https://www.microfeed.org/api/v1/), [OpenAPI JSON](https://www.microfeed.org/api/v1/openapi.json) and [YAML](https://www.microfeed.org/api/v1/openapi.yaml), or agent-ready [llms.txt](https://www.microfeed.org/api/v1/llms.txt) and [llms-full.txt](https://www.microfeed.org/api/v1/llms-full.txt).
-* a themeable publishing platform with immutable D1-backed versions, isolated Admin drafts and previews, GitHub installation through `yarn manage theme`, and the standalone [`@microfeed/theme-kit`](https://www.npmjs.com/package/@microfeed/theme-kit) authoring CLI.
+* a themeable publishing platform with immutable D1-backed versions, isolated Admin drafts and previews, GitHub installation through `npx @microfeed/cli manage theme`, and the standalone [`@microfeed/theme-kit`](https://www.npmjs.com/package/@microfeed/theme-kit) authoring CLI.
 * standalone public Pages, credential-free typeahead search with Command/Ctrl-K, and editable generated `robots.txt`, `llms.txt`, and `sitemap.xml` files.
 * a list of domain names for sale (e.g., [ListenHost.com](https://www.listenhost.com/)...)
 * a website for an entire book (e.g., [The Art of War](https://the-art-of-war.microfeed.org/))
@@ -211,7 +211,7 @@ work after an upgrade because their complete manifests and templates are
 already stored with the site.
 
 Themes developed by the community can be installed from public GitHub
-repositories with `yarn manage theme`. Developers and AI coding agents can
+repositories with `npx @microfeed/cli manage theme`. Developers and AI coding agents can
 initialize a standalone theme repository, work with fixtures or a live public
 JSON Feed, use tools such as Tailwind CSS, and validate the package before it
 is installed. See [Build and release a theme](https://docs.microfeed.org/themes/)
@@ -314,7 +314,7 @@ checksums:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn manage snapshot create --instance <instance-name> --output backup.tar.gz
+npx @microfeed/cli manage snapshot create --instance <instance-name> --output backup.tar.gz
 ```
 
 You can also download a Cloudflare site and immediately create a new local copy
@@ -322,13 +322,13 @@ with its real content:
 
 ```console
 # Replace both placeholders with saved or new instance names.
-yarn manage snapshot pull \
+npx @microfeed/cli manage snapshot pull \
   --instance <instance-name> \
   --local-instance <local-instance-name>
 ```
 
-Restore archives only with a checkout whose migration history exactly extends
-the snapshot's recorded history. Local restore requires a new local instance.
+Restore archives only with a microfeed release whose migration history exactly
+extends the snapshot's recorded history. Local restore requires a new local instance.
 Cloudflare restore requires a newly initialized site with nonreused, unchanged
 D1 and R2 resources, a successful dry run, and exact site-name confirmation.
 See the canonical [`snapshot` command reference](docs/manage-cli.md#yarn-manage-snapshot)

--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -43,7 +43,7 @@ content changes → signed webhook → policy, platform, or remote agent
 
 Use the API by itself for scheduled content imports, exports, synchronization,
 one-time editorial migrations, or other jobs that already know when to run.
-Use [`yarn manage snapshot`](/manage/backups-and-migrations/) for portable whole-site
+Use [`npx @microfeed/cli manage snapshot`](/manage/backups-and-migrations/) for portable whole-site
 backups and restores. Read the [API overview](../api/) and create one named
 credential with only the required read or write permissions.
 

--- a/docs/dashboard/media-and-feeds.md
+++ b/docs/dashboard/media-and-feeds.md
@@ -21,8 +21,8 @@ Most sites should leave it unchanged. Update it only when you deliberately
 change the bucket’s public address or add a custom media domain, then open an
 existing image to verify the new address.
 
-The deployment’s R2 connection is managed by `yarn manage`; changing this text
-field does not create, attach, or move a bucket or any files.
+The deployment’s R2 connection is managed by `npx @microfeed/cli manage`;
+changing this text field does not create, attach, or move a bucket or any files.
 
 ## Items settings
 

--- a/docs/dashboard/publish.md
+++ b/docs/dashboard/publish.md
@@ -46,9 +46,9 @@ page.
 ## Upload media
 
 Media uploads require an R2 bucket attached to the instance. If the uploader is
-unavailable, check the R2 state with `yarn manage status`. For a content-only
-instance, run `yarn manage deploy --enable-r2` only after R2 is available in the
-correct Cloudflare account.
+unavailable, check the R2 state with `npx @microfeed/cli manage status`. For a
+content-only instance, run `npx @microfeed/cli manage deploy --enable-r2` only
+after R2 is available in the correct Cloudflare account.
 
 Use meaningful titles and descriptions even when an image, audio file, or video
 carries most of the content. Text improves accessibility, search, and feed-reader

--- a/docs/dashboard/themes.md
+++ b/docs/dashboard/themes.md
@@ -59,7 +59,7 @@ packages and versions you trust.
 The Themes screen separates the catalog into two tabs:
 
 - **Built-in themes** groups versions by their `microfeed.*` package lineage.
-  The current checkout release appears first, and preserved older releases are
+  The current microfeed release appears first, and preserved older releases are
   available under **Version history**. Deployment synchronizes these packages,
   so Admin never offers a Delete action for them.
 - **Custom themes** contains Admin-created, GitHub, local-directory, and
@@ -120,7 +120,7 @@ CSS.
 ### Preview, activate, roll back, or delete
 
 Use **Preview** before activating any installed version. Activation records the
-previous version so an operator can roll back with `yarn manage theme rollback`
+previous version so an operator can roll back with `npx @microfeed/cli manage theme rollback`
 if the new design causes a problem. Delete only inactive Custom versions that
 are no longer needed; the active version and every Built-in version are
 protected from manual deletion.

--- a/docs/manage/backups-and-migrations.md
+++ b/docs/manage/backups-and-migrations.md
@@ -18,7 +18,7 @@ R2 bucket, declared theme assets restore in the same archive.
 ## Create a backup
 
 ```console
-yarn manage snapshot create \
+npx @microfeed/cli manage snapshot create \
   --instance <source-name> \
   --output <new-backup-file>.tar.gz
 ```
@@ -34,7 +34,7 @@ before managing restored content.
 ## Test a production snapshot locally
 
 ```console
-yarn manage snapshot pull \
+npx @microfeed/cli manage snapshot pull \
   --instance <source-name> \
   --local-instance <new-local-name>
 ```
@@ -57,7 +57,7 @@ eligibility checks, resumable maintenance state, and all options.
 [Older microfeed deployments](https://github.com/microfeed/microfeed/tree/microfeed-classic) hosted with Cloudflare Pages use:
 
 ```console
-yarn manage migrate-pages
+npx @microfeed/cli manage migrate-pages
 ```
 
 The command creates a new Worker beside the existing Pages project and connects

--- a/docs/manage/domains-and-access.md
+++ b/docs/manage/domains-and-access.md
@@ -9,18 +9,18 @@ can open the Admin dashboard.
 
 | Goal | Use |
 | --- | --- |
-| Give the site your own web address | `yarn manage domain` |
-| Use microfeed’s email-and-password login | `yarn manage auth setup` |
+| Give the site your own web address | `npx @microfeed/cli manage domain` |
+| Use microfeed’s email-and-password login | `npx @microfeed/cli manage auth setup` |
 | Change a known password or sign-in email | **Account settings** in the dashboard |
-| Recover a forgotten password or change the dashboard path | `yarn manage auth <action>` |
-| Add Cloudflare’s identity screen in front of the dashboard | `yarn manage access` |
+| Recover a forgotten password or change the dashboard path | `npx @microfeed/cli manage auth <action>` |
+| Add Cloudflare’s identity screen in front of the dashboard | `npx @microfeed/cli manage access` |
 
 ## Add or inspect a custom domain
 
-From the connected clone, run:
+From any folder, run:
 
 ```console
-yarn manage domain
+npx @microfeed/cli manage domain
 ```
 
 Follow the prompts for the exact saved instance and hostname. A hostname is the
@@ -44,13 +44,13 @@ folder in a terminal. If you do not know the saved name for your site, list the
 available sites first:
 
 ```console
-yarn manage instances
+npx @microfeed/cli manage instances
 ```
 
 Then run this command, replacing `<instance-name>` with the name shown above:
 
 ```console
-yarn manage auth setup --instance <instance-name>
+npx @microfeed/cli manage auth setup --instance <instance-name>
 ```
 
 Check the site and dashboard shown by the command, then follow its prompts. For
@@ -59,11 +59,11 @@ the administrator password.
 
 The setup command automatically redeploys microfeed when enabling built-in
 login requires a configuration change. If built-in login is already enabled,
-it skips the redeploy. You do not need to run `yarn manage deploy` separately.
+it skips the redeploy. You do not need to run `npx @microfeed/cli manage deploy` separately.
 After setup, verify the result:
 
 ```console
-yarn manage status --instance <instance-name>
+npx @microfeed/cli manage status --instance <instance-name>
 ```
 
 You can also ask an AI coding agent that has access to your microfeed project:
@@ -76,18 +76,18 @@ Cloudflare browser authorization and create the password in the private browser
 page yourself. Never paste the password or private page URL into a conversation.
 
 If you are signed in and know the current password, use **Account settings**
-for routine email or password changes. From a connected repository clone, use
-`yarn manage auth` for forgotten-password recovery, dashboard-path changes, or
+for routine email or password changes. Use `npx @microfeed/cli manage auth` for
+forgotten-password recovery, dashboard-path changes, or
 disabling the built-in login. Always include an action:
 
 ```console
-yarn manage auth reset-password
-yarn manage auth change-email
-yarn manage auth change-path
-yarn manage auth disable
+npx @microfeed/cli manage auth reset-password
+npx @microfeed/cli manage auth change-email
+npx @microfeed/cli manage auth change-path
+npx @microfeed/cli manage auth disable
 ```
 
-Running `yarn manage auth` by itself only prints help. Password creation and
+Running `npx @microfeed/cli manage auth` by itself only prints help. Password creation and
 reset use a private browser page; do not paste the password or private URL into
 the terminal or a conversation.
 
@@ -122,10 +122,10 @@ authorized, and a separate Cloudflare Access identity does not change.
 ### Recover a forgotten password
 
 The dashboard dialogs require the current password. If you cannot sign in or
-do not know it, run this from the connected repository clone:
+do not know it, run this from any folder:
 
 ```console
-yarn manage auth reset-password --instance <instance-name>
+npx @microfeed/cli manage auth reset-password --instance <instance-name>
 ```
 
 For a deployed site, the command opens or prints a private, single-use browser
@@ -139,7 +139,7 @@ password change when the current password is available.
 Cloudflare Access can add an outer identity layer in front of the dashboard:
 
 ```console
-yarn manage access
+npx @microfeed/cli manage access
 ```
 
 The dashboard can have built-in login, Access, or both. When both are enabled,
@@ -152,7 +152,7 @@ unless you deliberately accept that anyone who finds its address can manage the
 site.
 :::
 
-Verify with `yarn manage status`, then test sign-in and sign-out in a private
+Verify with `npx @microfeed/cli manage status`, then test sign-in and sign-out in a private
 browser window.
 
 ## Review account security
@@ -171,5 +171,5 @@ page keeps owner-specific security controls separate from site-wide settings:
 
 Account settings are unavailable when the dashboard has no built-in login or
 Cloudflare Access identity. Initial setup and forgotten-password recovery stay
-in `yarn manage auth` so a signed-out owner cannot weaken account security from
+in `npx @microfeed/cli manage auth` so a signed-out owner cannot weaken account security from
 the dashboard.

--- a/docs/manage/index.md
+++ b/docs/manage/index.md
@@ -17,16 +17,16 @@ If the Cloudflare terms below are unfamiliar, start with
 
 | Outcome | Start here |
 | --- | --- |
-| Verify the hosted application, database, media, and login | `yarn manage status` |
-| Deploy current repository code | `yarn manage deploy` |
-| Connect local launcher or clone state to an existing site | `yarn manage connect` |
-| List or select saved sites | `yarn manage instances` / `yarn manage use` |
-| Add a custom hostname | `yarn manage domain` |
+| Verify the hosted application, database, media, and login | `npx @microfeed/cli manage status` |
+| Deploy the latest microfeed release | `npx @microfeed/cli manage deploy` |
+| Connect local launcher state to an existing site | `npx @microfeed/cli manage connect` |
+| List or select saved sites | `npx @microfeed/cli manage instances` / `npx @microfeed/cli manage use` |
+| Add a custom hostname | `npx @microfeed/cli manage domain` |
 | Change the current login email or password | Dashboard avatar → **Account settings** |
-| Set up, recover, change the path, or disable built-in login | `yarn manage auth <action>` |
-| Add optional Cloudflare Access | `yarn manage access` |
-| Back up or restore a whole site | `yarn manage snapshot <action>` |
-| Plan removal without changing anything | `yarn manage destroy --dry-run` |
+| Set up, recover, change the path, or disable built-in login | `npx @microfeed/cli manage auth <action>` |
+| Add optional Cloudflare Access | `npx @microfeed/cli manage access` |
+| Back up or restore a whole site | `npx @microfeed/cli manage snapshot <action>` |
+| Plan removal without changing anything | `npx @microfeed/cli manage destroy --dry-run` |
 
 Content integrations are configured inside the dashboard’s **API** area. They
 use named API keys and do not reuse the dashboard password or Cloudflare login.
@@ -42,6 +42,7 @@ use named API keys and do not reuse the dashboard password or Cloudflare login.
   arguments, issue reports, and screenshots.
 - Create a snapshot before a high-risk content migration.
 
-The [`yarn manage` reference](/manage-cli/) is authoritative if this
-task-oriented guide and an option listing ever appear to differ. Outside a
-clone, replace every `yarn manage` prefix with `npx @microfeed/cli manage`.
+The [management CLI reference](/manage-cli/) is authoritative if this
+task-oriented guide and an option listing ever appear to differ. Its
+`yarn manage` examples document the same engine for people already inside a
+clone; the clone-free prefix is `npx @microfeed/cli manage`.

--- a/docs/manage/multiple-instances.md
+++ b/docs/manage/multiple-instances.md
@@ -1,6 +1,6 @@
 ---
 title: Multiple instances
-description: Manage several production, preview, or local microfeed sites from one repository clone.
+description: Manage several production, preview, or local microfeed sites from one clone-free launcher.
 ---
 
 An instance name is the local label that selects one site’s saved configuration.
@@ -10,7 +10,7 @@ name that clearly identifies its purpose or hostname.
 ## List saved instances
 
 ```console
-yarn manage instances
+npx @microfeed/cli manage instances
 ```
 
 The output identifies production, preview, and local state and marks the
@@ -19,29 +19,29 @@ current default when one exists.
 ## Select the default
 
 ```console
-yarn manage use <instance-name>
+npx @microfeed/cli manage use <instance-name>
 ```
 
 You can also avoid changing the default by adding `--instance <name>` to a
 supported command:
 
 ```console
-yarn manage status --instance personal-notes-example-com
-yarn manage deploy --instance studio-updates-example-com
+npx @microfeed/cli manage status --instance personal-notes-example-com
+npx @microfeed/cli manage deploy --instance studio-updates-example-com
 ```
 
 ## Add another site
 
-Use `yarn manage init --instance <name>` for a new site. Use
-`yarn manage connect --worker <worker-name> --instance <name>` for an existing
-compatible Worker. Initialization may create Cloudflare resources; connect is
-read-only in Cloudflare.
+Use `npx @microfeed/cli manage init --instance <name>` for a new site. Use
+`npx @microfeed/cli manage connect --worker <worker-name> --instance <name>`
+for an existing compatible Worker. Initialization may create Cloudflare
+resources; connect is read-only in Cloudflare.
 
 ## Avoid targeting mistakes
 
 Before a deployment, restore, authentication change, or removal:
 
-1. Run `yarn manage status --instance <name>`.
+1. Run `npx @microfeed/cli manage status --instance <name>`.
 2. Match the Worker name and Cloudflare account to the intended site.
 3. Use the same explicit `--instance` value for the change.
 

--- a/docs/manage/remove.md
+++ b/docs/manage/remove.md
@@ -7,7 +7,7 @@ Removal can delete a Worker and site-owned data. Always begin with a read-only
 plan for the exact instance:
 
 ```console
-yarn manage destroy --instance <name> --dry-run
+npx @microfeed/cli manage destroy --instance <name> --dry-run
 ```
 
 ## Inspect the complete plan
@@ -35,7 +35,7 @@ The destructive command requires the exact site name as confirmation. Follow
 the plan’s printed command after you have approved that precise scope:
 
 ```console
-yarn manage destroy --instance <name> --confirm <name>
+npx @microfeed/cli manage destroy --instance <name> --confirm <name>
 ```
 
 `destroy` rejects blanket `--yes` approval and preserves resources recorded as

--- a/docs/manage/troubleshooting.md
+++ b/docs/manage/troubleshooting.md
@@ -6,10 +6,10 @@ description: Diagnose account, deployment, media, login, and public-feed problem
 Start with the read-only status report:
 
 ```console
-yarn manage status
+npx @microfeed/cli manage status
 ```
 
-For a multi-site clone, add the exact `--instance <name>`.
+When several sites are saved, add the exact `--instance <name>`.
 
 Read the final recovery message before trying a different command. The
 management CLI is designed to resume interrupted work; creating or deleting a
@@ -17,7 +17,7 @@ similarly named resource by hand can make recovery harder.
 
 ## The wrong Cloudflare account appears
 
-Run `yarn manage accounts`. If you intentionally need another named Wrangler
+Run `npx @microfeed/cli manage accounts`. If you intentionally need another named Wrangler
 login, select or create it with `--profile <name>`; use `--reauthorize` only
 when you deliberately want fresh browser authorization. If several accounts
 are listed, choose by name and full ID rather than position.
@@ -25,26 +25,26 @@ are listed, choose by name and full ID rather than position.
 ## A Worker already uses the requested name
 
 Initialization will not overwrite an unknown Worker. If it is an existing
-microfeed site, use the printed `yarn manage connect --worker ... --instance ...`
+microfeed site, use the printed `npx @microfeed/cli manage connect --worker ... --instance ...`
 command. Otherwise choose a different, distinctive project name.
 
 ## A new Cloudflare account cannot serve workers.dev yet
 
 Cloudflare may take a few minutes to prepare the first Workers subdomain. Wait,
-then rerun the same `yarn manage init` command. Saved progress resumes the
+then rerun the same `npx @microfeed/cli manage init` command. Saved progress resumes the
 unfinished work.
 
 ## Media upload is unavailable
 
 Check whether the status report says R2 is ready, pending, or deliberately
 disabled. Cloudflare may require R2 activation in the correct account. Once it
-is available, use `yarn manage deploy --enable-r2`; do not create an unrelated
+is available, use `npx @microfeed/cli manage deploy --enable-r2`; do not create an unrelated
 bucket by hand.
 
 ## The dashboard login does not work
 
 Confirm the dashboard path and authentication state in the status report. Use
-`yarn manage auth reset-password` for built-in login. If Cloudflare Access is
+`npx @microfeed/cli manage auth reset-password` for built-in login. If Cloudflare Access is
 also enabled, test each layer and logout flow in a private browser window.
 
 ## The dashboard saves, but public content is missing
@@ -64,14 +64,14 @@ rotated or revoked, update the integration immediately.
 ## Webhook deliveries fail or stop
 
 Open **Admin → Webhooks → Deliveries** to inspect the status, attempts,
-response diagnostics, and suppression reason. Then run `yarn manage status` to
+response diagnostics, and suppression reason. Then run `npx @microfeed/cli manage status` to
 check the saved infrastructure state. Enabled webhooks require the exact Queue,
 producer binding, Worker consumer, resumed delivery, and hourly Cron. Disabled
 webhooks require the retained Queue to be paused and empty with no binding,
 consumer, or Cron. Do not rotate a signing secret or redeliver an event until
 you know which receiver configuration and deployed environment are active.
 
-If disabling or re-enabling was interrupted, rerun the same `yarn manage
+If disabling or re-enabling was interrupted, rerun the same `npx @microfeed/cli manage
 deploy --disable-webhooks` or `--enable-webhooks` command for the exact instance
 and environment. The operation resumes from saved progress. Do not create,
 rename, resume, purge, or delete a similarly named Queue by hand; an unexpected

--- a/docs/manage/update.md
+++ b/docs/manage/update.md
@@ -20,8 +20,7 @@ latest release, and continue until `status` verifies the site.
 The launcher obtains the exact release in a private cache. The agent discovers
 saved and compatible existing sites, asks before choosing among candidates,
 connects only if needed, deploys through the same `yarn manage` engine, and
-runs a status check. Complete any Git or Cloudflare browser handoffs it
-requests.
+runs a status check. Complete any Cloudflare browser handoffs it requests.
 
 ## Manual update from a clone
 

--- a/docs/microfeed-cli.md
+++ b/docs/microfeed-cli.md
@@ -140,9 +140,9 @@ Browser authorization requires the site's built-in login. Cloudflare Access
 can protect dashboard routes, but it does not create the microfeed application
 session required by OAuth. When the identity document reports that OAuth
 authorization is unavailable, the CLI tells the site owner to enable built-in
-login from the connected repository with `yarn manage auth setup`. Older sites
-without this identity capability receive compatible setup guidance instead of
-an ambiguous discovery error.
+login with `npx @microfeed/cli manage auth setup`. Older sites without this
+identity capability receive compatible setup guidance instead of an ambiguous
+discovery error.
 
 New instances keep API access disabled by default. Browser login can be saved
 while access is off, but content commands return `404` until the site owner
@@ -222,10 +222,10 @@ must complete within five minutes.
 The site must have built-in login enabled for browser authorization. Cloudflare
 Access is compatible as an outer route protection layer, but it is not a
 microfeed login session and cannot complete OAuth by itself. If built-in login
-is disabled, run `yarn manage auth setup` from the repository connected to the
-site, then retry login. The CLI reads `oauthAuthorizationAvailable` from newer
-identity documents and provides the same fallback guidance for older sites
-that do not publish the field.
+is disabled, run `npx @microfeed/cli manage auth setup`, select or connect the
+intended site, then retry login. The CLI reads `oauthAuthorizationAvailable`
+from newer identity documents and provides the same fallback guidance for
+older sites that do not publish the field.
 
 The CLI generates a random, non-secret connection ID for each saved site and
 stores it separately from the encrypted token bundle. Logging the same saved

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -83,8 +83,9 @@ different website or app presents the content. microfeed can hide its generated
 web pages without deleting the content.
 
 **Git clone**
-A local copy of this repository containing the source code and `yarn manage`
-tool.
+A local copy of this repository containing the source code and project-owned
+`yarn manage` tool. It is optional for people using the clone-free
+`npx @microfeed/cli manage` launcher.
 
 **Instance**
 The locally saved connection to one production, preview, or local microfeed
@@ -159,9 +160,9 @@ the body flag only after signature verification and prevent every test from
 producing production side effects.
 
 **Wrangler**
-Cloudflare’s command-line tool. microfeed invokes it behind the supported
-`yarn manage` interface; people and agents should not replace management
-workflows with improvised Wrangler commands.
+Cloudflare’s command-line tool. microfeed invokes it behind
+`npx @microfeed/cli manage`, or `yarn manage` inside a clone; people and agents
+should not replace management workflows with improvised Wrangler commands.
 
 **workers.dev address**
 The free Cloudflare-provided web address for a Worker. A microfeed site can use

--- a/docs/start-here/concepts.md
+++ b/docs/start-here/concepts.md
@@ -9,8 +9,8 @@ dashboard to publish content, while coding agents can use the official
 the public site or subscribe to its feeds.
 
 You do not need to operate these Cloudflare services separately during normal
-use. The supported `yarn manage` command creates, connects, updates, and checks
-them as one microfeed site.
+use. The clone-free `npx @microfeed/cli manage` launcher creates, connects,
+updates, and checks them as one microfeed site.
 
 ## The important words
 
@@ -34,12 +34,15 @@ for uploaded images, audio, video, documents, and packaged theme assets. It is
 optional: a content-only installation can publish text and link to files hosted
 elsewhere without enabling R2.
 
-**Repository clone** is a local copy of microfeed’s source code. The copy
-includes both microfeed and the supported `yarn manage` deployment tool.
+**Repository clone** is an optional local copy of microfeed’s source code. It
+includes the project-owned `yarn manage` command for contributors and people
+who prefer the manual deployment workflow. A clone is not required when using
+the published management launcher.
 
 **Instance** is the short local name that selects one saved microfeed site. The
-name is not a Cloudflare login or website address. One repository clone can
-remember several instances.
+name is not a Cloudflare login or website address. The launcher can remember
+several instances without putting state in your current folder; a repository
+clone keeps its own instance state instead.
 
 **Admin dashboard** is the private management area where you create items,
 upload media, and customize the channel. It is separate from the public site.
@@ -79,10 +82,13 @@ API docs are enabled.
 
 ## What the local management tool changes
 
-`yarn manage` creates and updates the Cloudflare resources for your chosen
-instance. It checks for name collisions, applies database migrations, builds
-the application, deploys it, and verifies the result. It stores local connection
-details in the repository’s ignored `.microfeed/` directory.
+`npx @microfeed/cli manage` prepares the matching microfeed release in a private
+cache and runs the same guarded management engine used by `yarn manage` inside
+a clone. It checks for name collisions, applies database migrations, builds the
+application, deploys it, and verifies the result. Launcher connection details
+live in the platform microfeed configuration directory, separate from the
+replaceable source cache.
 
 For exact behavior and safety rules, use the
-[`yarn manage` reference](/manage-cli/).
+[management CLI reference](/manage-cli/). Its `yarn manage` examples map to the
+clone-free `npx @microfeed/cli manage` prefix.

--- a/docs/theme-kit-cli.md
+++ b/docs/theme-kit-cli.md
@@ -9,8 +9,8 @@ It creates, validates, tests, and previews a theme package on your computer. It
 does not deploy microfeed, install a theme into an instance, or activate a live
 theme.
 
-Use [`yarn manage theme`](/manage-cli/#yarn-manage-theme) from a microfeed
-checkout for instance operations such as export, install, update, activation,
+Use [`npx @microfeed/cli manage theme`](/manage-cli/#yarn-manage-theme) from any
+folder for instance operations such as export, install, update, activation,
 rollback, and deletion. See [Build and release a theme](/themes/) for the
 authoring workflow, [Theme contract and rendering](/themes/contract/) for the
 package contract, and [Bundle CSS, JavaScript, and assets](/themes/assets/) for
@@ -126,7 +126,7 @@ other dependency.
   creating and publishing a standalone repository.
 
 To initialize from a specific microfeed instance's active theme instead, use
-`yarn manage theme init` from a microfeed checkout.
+`npx @microfeed/cli manage theme init` from any folder.
 
 ## `validate`
 
@@ -238,4 +238,5 @@ theme-kit preview . --fixture media
 
 After the local checks pass, increment the theme's semantic version and commit
 both source files and generated runtime files. Installation and activation are
-separate `yarn manage theme` operations performed from a microfeed checkout.
+separate `npx @microfeed/cli manage theme` operations that can run from any
+folder.

--- a/docs/themes/assets.md
+++ b/docs/themes/assets.md
@@ -127,7 +127,7 @@ Load them without repeating the `assets/` directory:
 ```
 
 The local preview maps `_theme.asset_base_url` to its `/assets/` handler. On
-installation, `yarn manage theme` validates declared files, uploads them to
+installation, `npx @microfeed/cli manage theme` validates declared files, uploads them to
 immutable R2 keys, verifies the uploads, and stores their paths, checksums,
 sizes, and content types with the installed theme. The live asset base URL uses
 microfeed's public media route; the Worker never contacts GitHub or runs the
@@ -136,7 +136,7 @@ bundler while rendering a page.
 Enable R2 before installing a theme with declared assets:
 
 ```console
-yarn manage deploy --enable-r2 --instance <instance-name>
+npx @microfeed/cli manage deploy --enable-r2 --instance <instance-name>
 ```
 
 Use `--local` for a local-only site's simulated media store. External HTTPS

--- a/docs/themes/index.md
+++ b/docs/themes/index.md
@@ -4,16 +4,16 @@ description: Start a standalone theme repository, develop and preview it safely,
 ---
 
 A theme repository is an independent project containing the templates and
-optional assets that render a microfeed public site. Develop it outside the
-microfeed source checkout, validate it locally, and install each semantic
-version as an inactive release before activation.
+optional assets that render a microfeed public site. Develop it in its own
+folder, validate it locally, and install each semantic version as an inactive
+release before activation.
 
 ## Choose a starting point
 
 | Goal | Command |
 | --- | --- |
-| Fork the selected site's current appearance under a new identity | `yarn manage theme init <directory> --instance <instance-name>` |
-| Export an exact installed immutable version with its existing identity | `yarn manage theme export <theme-id> --instance <instance-name>` |
+| Fork the selected site's current appearance under a new identity | `npx @microfeed/cli manage theme init <directory> --instance <instance-name>` |
+| Export an exact installed immutable version with its existing identity | `npx @microfeed/cli manage theme export <theme-id> --instance <instance-name>` |
 | Start from a generic package without reading an instance | `yarn dlx @microfeed/theme-kit init <directory>` |
 
 Use `theme init` for a new design derived from the site's effective theme. Use
@@ -23,11 +23,10 @@ source files or build tools that were not part of the installed package.
 
 ## Start from the current site
 
-Run this from the connected microfeed clone, using a destination outside that
-checkout:
+Run this from any folder:
 
 ```console
-yarn manage theme init ~/microfeed-themes/my-theme \
+npx @microfeed/cli manage theme init ~/microfeed-themes/my-theme \
   --instance <instance-name>
 cd ~/microfeed-themes/my-theme
 yarn install
@@ -52,9 +51,10 @@ theme, or choose a package ID you control for a distributable theme. Use
 List installed versions, then export the exact one you intend to preserve:
 
 ```console
-yarn manage theme list --instance <instance-name>
-yarn manage theme export <theme-id> \
+npx @microfeed/cli manage theme list --instance <instance-name>
+npx @microfeed/cli manage theme export <theme-id> \
   --instance <instance-name> \
+  --output ~/microfeed-themes/exported-theme \
   --git \
   --json
 ```
@@ -68,10 +68,10 @@ An export preserves the installed package identity for inspection and archival.
 Do not modify and republish an exported `microfeed.*` theme. Run `theme init`
 instead; it forks the same appearance under a new `local.*` identity.
 
-Inside a microfeed clone, the default export destination is the ignored
-`.microfeed/themes/<package-id>-<version>/` workspace. Commit and push the
-standalone repository when you are ready to preserve it independently; cleanup
-of ignored files can otherwise remove it.
+When `--output` is omitted, export writes under
+`.microfeed/themes/<package-id>-<version>/` in the current folder. Prefer a
+visible destination under `~/microfeed-themes/` for standalone development.
+Commit and push the repository when you are ready to preserve it independently.
 
 ## Start from the generic package
 
@@ -147,13 +147,12 @@ For every option and output contract, use the
 
 ## Install and release a version
 
-After validation and review, install the repository from the connected
-microfeed clone:
+After validation and review, install the repository from any folder:
 
 ```console
-yarn manage theme install https://github.com/owner/theme-repository \
+npx @microfeed/cli manage theme install https://github.com/owner/theme-repository \
   --instance <instance-name>
-yarn manage theme list --instance <instance-name>
+npx @microfeed/cli manage theme list --instance <instance-name>
 ```
 
 Installation resolves a Git ref to one exact commit, validates the declared
@@ -162,7 +161,7 @@ needed. It never activates the result. Preview the installed version, then
 activate its exact theme ID separately:
 
 ```console
-yarn manage theme activate <theme-id> --instance <instance-name>
+npx @microfeed/cli manage theme activate <theme-id> --instance <instance-name>
 ```
 
 Use `theme update` to install a newer version from the recorded source and
@@ -170,7 +169,7 @@ Use `theme update` to install a newer version from the recorded source and
 package ID and version for different content. Delete only inactive versions
 that are no longer needed.
 
-See the canonical [`yarn manage theme`
+See the canonical [management CLI theme
 reference](/manage-cli/#yarn-manage-theme) for source selection, local and
 preview environments, update, rollback, export, and deletion behavior.
 

--- a/docs/webhooks/index.md
+++ b/docs/webhooks/index.md
@@ -49,16 +49,16 @@ its installed microfeed version and event catalog exactly.
 
 ### Local development
 
-Plain `yarn dev` automatically starts Wrangler's isolated Queue simulation,
+Plain `npx @microfeed/cli manage dev` automatically starts Wrangler's isolated Queue simulation,
 consumer, maintenance trigger, and local signing-secret encryption. It creates
 no Cloudflare resources, requests no Cloudflare permissions, and incurs no
-Cloudflare Queue or Worker charges. `yarn dev --enable-webhooks` is accepted as
+Cloudflare Queue or Worker charges. `npx @microfeed/cli manage dev --enable-webhooks` is accepted as
 an explicit alias, but the flag is not required and does not change preview or
 production. To omit Queue and Cron simulation for one run, use:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn dev --disable-webhooks --instance <instance-name>
+npx @microfeed/cli manage dev --disable-webhooks --instance <instance-name>
 ```
 
 This local-only flag does not change the next local run or either deployed
@@ -68,40 +68,41 @@ environment.
 
 Deployed webhooks are opt-in because they create a Queue, producer and consumer
 bindings, a Cron trigger, and an endpoint-secret encryption key. Enable them
-from a trusted local clone:
+from any folder:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn manage deploy --enable-webhooks --instance <instance-name>
+npx @microfeed/cli manage deploy --enable-webhooks --instance <instance-name>
 ```
 
 For an isolated preview environment:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn manage deploy --preview --enable-webhooks --instance <instance-name>
+npx @microfeed/cli manage deploy --preview --enable-webhooks --instance <instance-name>
 ```
 
 ### Ask a coding agent to enable webhooks
 
-Run the agent from the trusted repository clone and replace `<instance-name>`
-with the saved instance name. Expand only the environment you intend to change.
+Open a local coding agent in any folder and replace `<instance-name>` with the
+saved instance name. Expand only the environment you intend to change.
 
 <details>
 <summary>Production coding-agent prompt</summary>
 
 ```text
-Enable production webhooks for my saved microfeed instance "<instance-name>". Use the
-deploy-microfeed skill and the repository's yarn manage CLI. Review the deploy
-section of docs/manage-cli.md, confirm the exact instance and production
-environment, then run:
+Run `npx @microfeed/cli manage` and follow every instruction it prints to
+enable production webhooks for my existing microfeed instance
+"<instance-name>". Confirm the exact instance and production environment, then
+run:
 
-yarn manage deploy --enable-webhooks --instance <instance-name>
+npx @microfeed/cli manage deploy --enable-webhooks --instance <instance-name>
 
 Do not change preview, another instance, or unrelated Cloudflare resources.
-After deployment, run yarn manage status --instance <instance-name> and report whether
-the webhook Queue, binding, maintenance trigger, and signing-secret encryption
-are ready. Do not ask me for a Cloudflare token or dashboard password.
+Continue until `npx @microfeed/cli manage status --instance <instance-name>`
+verifies that the webhook Queue, binding, maintenance trigger, and
+signing-secret encryption are ready. Do not ask me for a Cloudflare token or
+dashboard password.
 ```
 
 </details>
@@ -110,18 +111,17 @@ are ready. Do not ask me for a Cloudflare token or dashboard password.
 <summary>Preview coding-agent prompt</summary>
 
 ```text
-Enable preview webhooks for my saved microfeed instance "<instance-name>". Use the
-deploy-microfeed skill and the repository's yarn manage CLI. Review the deploy
-section of docs/manage-cli.md, confirm the exact instance and preview
-environment, then run:
+Run `npx @microfeed/cli manage` and follow every instruction it prints to
+enable preview webhooks for my existing microfeed instance "<instance-name>".
+Confirm the exact instance and preview environment, then run:
 
-yarn manage deploy --preview --enable-webhooks --instance <instance-name>
+npx @microfeed/cli manage deploy --preview --enable-webhooks --instance <instance-name>
 
 Do not change production, another instance, or unrelated Cloudflare resources.
-After deployment, run yarn manage status --preview --instance <instance-name> and report
-whether the preview webhook Queue, binding, maintenance trigger, and
-signing-secret encryption are ready. Do not ask me for a Cloudflare token or
-dashboard password.
+Continue until
+`npx @microfeed/cli manage status --preview --instance <instance-name>` verifies
+that the preview webhook Queue, binding, maintenance trigger, and signing-secret
+encryption are ready. Do not ask me for a Cloudflare token or dashboard password.
 ```
 
 </details>
@@ -132,7 +132,7 @@ no new Queue or encryption key. Confirm the Queue identity, consumer, binding,
 delivery state, and Cron schedule after deployment:
 
 ```console
-yarn manage status --instance <instance-name>
+npx @microfeed/cli manage status --instance <instance-name>
 ```
 
 Preview and production use separate Queues. Enabling one does not enable the
@@ -154,14 +154,14 @@ disable the intended deployed environment:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn manage deploy --disable-webhooks --instance <instance-name>
+npx @microfeed/cli manage deploy --disable-webhooks --instance <instance-name>
 ```
 
 For preview:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn manage deploy --preview --disable-webhooks --instance <instance-name>
+npx @microfeed/cli manage deploy --preview --disable-webhooks --instance <instance-name>
 ```
 
 The command pauses the environment's dedicated Queue, cancels pending
@@ -182,7 +182,7 @@ Queue and encryption secret. Repeating either command is safe and verifies the
 saved state without creating another Queue. Production and preview remain
 independent.
 
-The reviewed `yarn manage destroy` flow removes the retained Queue together
+The reviewed `npx @microfeed/cli manage destroy` flow removes the retained Queue together
 with the environment. Its dry run shows the exact Queue name and ID before any
 deletion.
 

--- a/docs/webhooks/operations.md
+++ b/docs/webhooks/operations.md
@@ -61,7 +61,7 @@ budget; Explorer previews, copy actions, and loopback terminal prints are free
 and do not create delivery records. Retries do not reserve another delivery,
 but each attempt can increase Queue operations and Worker execution. The Admin
 overview shows used, available, and projected operation counts before a budget
-change. `yarn manage status` verifies the Queue and reports its realtime
+change. `npx @microfeed/cli manage status` verifies the Queue and reports its realtime
 backlog and oldest message; Cloudflare-observed writes, reads, deletes, total
 billable operations, and average retries for both the site Queue and the
 account-wide UTC-day window; microfeed-side delivery accounting; and the
@@ -102,13 +102,13 @@ idempotency key, and destination operation ID. Never log signing secrets, API
 keys, raw authorization headers, or unnecessary private content.
 
 Use **Admin → Webhooks → Deliveries** for event payloads, attempt history,
-response diagnostics, and suppression reasons. Use `yarn manage status` for
+response diagnostics, and suppression reasons. Use `npx @microfeed/cli manage status` for
 Queue bindings, backlog, oldest-message age, and account-wide operation
 telemetry. The Cloudflare Queues dashboard is the final place to inspect Queue
 health and billing-related usage.
 
 The deployment contract owns reconciliation, retention, and Worker binding
-details. See the [`yarn manage deploy` reference](/manage-cli/#yarn-manage-deploy)
+details. See the [management CLI deploy reference](/manage-cli/#yarn-manage-deploy)
 when diagnosing provisioning or maintenance behavior instead of depending on
 those implementation details in a receiver.
 
@@ -128,7 +128,7 @@ the appropriate infrastructure command after reviewing its target:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn manage deploy --disable-webhooks --instance <instance-name>
+npx @microfeed/cli manage deploy --disable-webhooks --instance <instance-name>
 ```
 
 Add `--preview` before `--disable-webhooks` for preview. The command cancels

--- a/docs/webhooks/testing.md
+++ b/docs/webhooks/testing.md
@@ -14,14 +14,14 @@ does not create or edit that endpoint for you.
 
 ## Choose a listener mode
 
-- **Local development:** Run `yarn microfeed webhook listen` and register
+- **Local development:** Run `npx @microfeed/cli webhook listen` and register
   `http://127.0.0.1:8978/webhook`. The endpoint is reachable only from this
   computer.
-- **Deployed preview or production:** Run `yarn microfeed webhook listen
+- **Deployed preview or production:** Run `npx @microfeed/cli webhook listen
   --tunnel` and register the random HTTPS URL printed by the CLI. The endpoint
   is public only while the command runs.
 
-Run either command from the root of a microfeed repository clone. Event
+Run either command from any folder. Event
 Explorer sends are real signed deliveries that use the normal Queue, retry
 policy, delivery history, and daily budget. Previewing an event does not send a
 delivery.
@@ -31,10 +31,10 @@ delivery.
 Plain `webhook listen` starts a loopback-only receiver. It does not expose your
 computer to the internet or require `cloudflared`.
 
-1. From the microfeed repository root, start the listener:
+1. From any folder, start the listener:
 
    ```console
-   yarn microfeed webhook listen
+   npx @microfeed/cli webhook listen
    ```
 
 2. Open the local site's **Admin → Webhooks → Endpoints** page, choose **Add
@@ -54,11 +54,11 @@ you do not want later events to retry while the listener is stopped.
 ## Test a production deployment with a temporary endpoint
 
 You can receive a real signed event from a deployed production site on your
-computer without first deploying a receiver. From a microfeed repository clone,
-start the verified listener with a temporary Cloudflare Quick Tunnel:
+computer without first deploying a receiver. From any folder, start the
+verified listener with a temporary Cloudflare Quick Tunnel:
 
 ```console
-yarn microfeed webhook listen --tunnel
+npx @microfeed/cli webhook listen --tunnel
 ```
 
 Plain `webhook listen` accepts only local traffic. With `--tunnel`, the CLI uses

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -137,7 +137,7 @@ OAuth browser authorization requires the site's built-in login. Cloudflare
 Access can protect routes, but it does not create the microfeed application
 session OAuth needs. If the CLI reports that authorization is unavailable,
 enable built-in login from the connected repository with
-`yarn manage auth setup`, then retry. New sites expose this capability in their
+`npx @microfeed/cli manage auth setup`, then retry. New sites expose this capability in their
 identity document; the CLI gives compatible guidance for older sites too.
 
 CLI credential bundles are encrypted with AES-256-GCM. Only the encryption key is

--- a/packages/cli/src/discovery.ts
+++ b/packages/cli/src/discovery.ts
@@ -64,8 +64,8 @@ export async function discoverInstance(originInput: string): Promise<{
       "Browser authorization is unavailable because this microfeed site has " +
       "built-in login disabled. Cloudflare Access can protect dashboard " +
       "routes, but it does not create the microfeed application session " +
-      "required for OAuth. The site owner can enable built-in login from the " +
-      "connected repository with `yarn manage auth setup`, then retry. Guide: " +
+      "required for OAuth. The site owner can enable built-in login with " +
+      "`npx @microfeed/cli manage auth setup`, then retry. Guide: " +
       "https://docs.microfeed.org/manage/domains-and-access/#enable-built-in-login",
     );
   }
@@ -81,8 +81,8 @@ export async function discoverInstance(originInput: string): Promise<{
         "The site did not provide OAuth discovery metadata. Built-in login " +
         "may be disabled, or this microfeed version may not support browser " +
         "authorization. Cloudflare Access alone does not create a microfeed " +
-        "application session. The site owner can run `yarn manage auth setup` " +
-        "from the connected repository, then retry. Guide: " +
+        "application session. The site owner can run " +
+        "`npx @microfeed/cli manage auth setup`, then retry. Guide: " +
         "https://docs.microfeed.org/manage/domains-and-access/#enable-built-in-login",
       );
     }

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -197,7 +197,7 @@ export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
       "<computer-name> identifies this computer under Account settings → App access, such as Home Mac or Publishing server. It is separate from the local saved-instance name and accepts 1–64 printable characters.",
       "The CLI creates a random connection ID for this saved site. Logging in again reuses that ID, replaces its token family, and avoids adding a duplicate computer connection.",
       "Login verifies the microfeed site, opens administrator sign-in and consent in a browser, and stores only encrypted credentials. The person using the instance must approve the browser step.",
-      "Browser authorization requires the site's built-in login. Cloudflare Access may protect dashboard routes, but it does not create the microfeed application session required for OAuth. When built-in login is disabled, the owner enables it from the connected repository with `yarn manage auth setup`.",
+      "Browser authorization requires the site's built-in login. Cloudflare Access may protect dashboard routes, but it does not create the microfeed application session required for OAuth. When built-in login is disabled, the owner enables it with `npx @microfeed/cli manage auth setup`.",
       "Browser login can be saved while API access is disabled, but content commands return 404 until the site owner enables access.",
       ...apiAccessDetails,
     ],

--- a/packages/theme-kit/README.md
+++ b/packages/theme-kit/README.md
@@ -17,7 +17,7 @@ microfeed site or change an active theme:
 | Tool | Purpose |
 | --- | --- |
 | `theme-kit` from `@microfeed/theme-kit` | Develop and preview a theme package locally |
-| `yarn manage theme …` from a microfeed checkout | Export an instance theme; install, update, activate, or delete versions |
+| `npx @microfeed/cli manage theme …` | Export an instance theme; install, update, activate, or delete versions |
 | `microfeed` from `@microfeed/cli` | Publish and manage feed content through the public API |
 
 ## Requirements
@@ -29,24 +29,22 @@ microfeed site or change an active theme:
 
 ## Start a standalone theme repository
 
-Keep initialized and generic theme repositories outside the microfeed checkout
-by default so generated files are not accidentally committed to the
-application repository. When an exact installed version should stay in the
-same coding-agent workspace, export it to the ignored
-`.microfeed/themes/<package-id>-<version>/` directory with
-`yarn manage theme export --active ... --git`.
+Keep initialized and generic theme repositories in their own folders by
+default. When an exact installed version should stay in the same coding-agent
+workspace, choose an explicit export directory with
+`npx @microfeed/cli manage theme export --active ... --output <directory> --git`.
 Do not use `dist/themes/`; application builds may replace that disposable
 output.
 
 ### Start from your site’s current theme
 
 This is the recommended path when you already have a microfeed instance. Run
-the command from a microfeed checkout. It exports the effective active theme,
+the command from any folder. It exports the effective active theme,
 declared assets, schemas, fixtures, local scripts, agent skill, and Claude Code
 bridge, then starts an independent Git repository:
 
 ```console
-yarn manage theme init ~/microfeed-themes/my-theme \
+npx @microfeed/cli manage theme init ~/microfeed-themes/my-theme \
   --instance <instance-name>
 cd ~/microfeed-themes/my-theme
 yarn install
@@ -59,11 +57,15 @@ You do not need to create `~/microfeed-themes/` first. The command creates
 missing parents and refuses to overwrite a non-empty destination.
 
 To preserve the active installed package ID and version instead of creating a
-new identity, keep it inside the checkout with:
+new identity, export it to another standalone folder:
 
 ```console
-yarn manage theme export --active --instance <instance-name> --git --json
-cd .microfeed/themes/<package-id>-<version>
+npx @microfeed/cli manage theme export --active \
+  --instance <instance-name> \
+  --output ~/microfeed-themes/exported-theme \
+  --git \
+  --json
+cd ~/microfeed-themes/exported-theme
 yarn install
 yarn validate
 yarn test
@@ -207,10 +209,10 @@ R2. Use declared assets for larger, independently cacheable bundles. See the
    can never identify different content.
 7. Commit the source and generated runtime files, then push the standalone
    repository to GitHub.
-8. From a microfeed checkout, install the exact repository version as inactive:
+8. From any folder, install the exact repository version as inactive:
 
    ```console
-   yarn manage theme install https://github.com/owner/my-theme \
+   npx @microfeed/cli manage theme install https://github.com/owner/my-theme \
      --instance <instance-name>
    ```
 

--- a/scripts/check-theme-kit-package.ts
+++ b/scripts/check-theme-kit-package.ts
@@ -96,7 +96,7 @@ try {
     ]);
   if (!packedReadme.includes("Normal development workflow") ||
       !packedReadme.includes("npm install --global @microfeed/theme-kit") ||
-      !packedReadme.includes("yarn manage theme install") ||
+    !packedReadme.includes("npx @microfeed/cli manage theme install") ||
       !packedReadme.includes("immutable D1 theme row") ||
       !packedReadme.includes("immutable R2") ||
       !packedReadme.includes("Vite, Webpack, Tailwind CSS") ||

--- a/src/components/admin/AdminAboutDialog.tsx
+++ b/src/components/admin/AdminAboutDialog.tsx
@@ -18,10 +18,17 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {OUR_BRAND} from "@/shared/Constants";
+import {
+  MICROFEED_MANAGE_COMMAND,
+  managementCommand,
+} from "@/shared/ManagementCli";
 import {MICROFEED_VERSION} from "@/shared/Version";
 import type {AdminDeploymentSummary} from "./admin-shell-types";
 
-export const ADMIN_UPDATE_PROMPT = "Update this microfeed site to the latest version and deploy it.";
+export const ADMIN_UPDATE_PROMPT =
+  `Run \`${MICROFEED_MANAGE_COMMAND}\` and follow every instruction it prints ` +
+  "to update this microfeed site to the latest version. Continue until " +
+  "`status` verifies it.";
 const CLOUDFLARE_WORKER_NAME_PATTERN =
   /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/iu;
 
@@ -38,9 +45,11 @@ export function adminUpdatePrompt(
   }
 
   return [
-    ADMIN_UPDATE_PROMPT,
-    `First run \`yarn manage connect --worker ${workerName}\`. Use the existing or newly created local instance name reported by that command. Then run \`yarn manage status --instance <instance-name>\`, deploy with \`yarn manage deploy --instance <instance-name>\`, and run status again to verify it.`,
-    "Do not initialize a new site or target another Worker.",
+    `Run \`${MICROFEED_MANAGE_COMMAND}\` and follow every instruction it ` +
+      `prints to update the existing Cloudflare Worker \`${workerName}\` to ` +
+      "the latest version.",
+    "Do not initialize a new site or target another Worker. Continue until " +
+      "`status` verifies it.",
   ].join("\n\n");
 }
 
@@ -182,7 +191,7 @@ export default function AdminAboutDialog({defaultOpen = false, deployment}: Prop
                     </Button>
                   </span>
                 ) : (
-                  <span className="text-muted-foreground">Available after the next <code>yarn manage deploy</code>.</span>
+                  <span className="text-muted-foreground">Available after the next <code>{managementCommand("deploy")}</code>.</span>
                 )}
               </dd>
             </div>
@@ -192,9 +201,9 @@ export default function AdminAboutDialog({defaultOpen = false, deployment}: Prop
         <section aria-labelledby="update-title">
           <h3 className="text-sm font-semibold" id="update-title">Update to the latest version</h3>
           <ol className="mt-3 grid gap-2 text-sm text-muted-foreground">
-            <li className="flex gap-3"><span className="font-semibold text-brand-light">1</span><span>Open your local microfeed repository in an AI coding agent.</span></li>
+            <li className="flex gap-3"><span className="font-semibold text-brand-light">1</span><span>Open a local AI coding agent in any folder.</span></li>
             <li className="flex gap-3"><span className="font-semibold text-brand-light">2</span><span>Paste the prompt below.</span></li>
-            <li className="flex gap-3"><span className="font-semibold text-brand-light">3</span><span>Complete any requested Git or Cloudflare browser handoffs while the agent deploys and verifies the site.</span></li>
+            <li className="flex gap-3"><span className="font-semibold text-brand-light">3</span><span>Complete any requested Cloudflare browser authorization or choices while the agent deploys and verifies the site.</span></li>
           </ol>
           <div className="mt-3 flex items-start gap-2 rounded-xl bg-brand-dark p-3 text-white dark:bg-background dark:ring-1 dark:ring-border">
             <code className="min-w-0 flex-1 whitespace-pre-wrap text-xs leading-relaxed">{updatePrompt}</code>

--- a/src/components/admin/home/AdminHomeApp/component/SetupChecklistApp/index.tsx
+++ b/src/components/admin/home/AdminHomeApp/component/SetupChecklistApp/index.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/field";
 import {Input} from "@/components/ui/input";
 import {ONBOARDING_TYPES} from "@/shared/Constants";
+import {managementCommand} from "@/shared/ManagementCli";
 import {
   ADMIN_URLS,
   normalizeR2CustomDomainUrl,
@@ -92,8 +93,7 @@ export function AdminProtectionDescription({
         Your dashboard is protected by the built-in email and password login.{" "}
         <CloudflareAccessLink dashboardUrl={dashboardUrl} /> was not detected
         on this request. To add it as an optional second gate, run{" "}
-        <CloudflareValue>yarn manage access</CloudflareValue> from your
-        deployment checkout.
+        <CloudflareValue>{managementCommand("access")}</CloudflareValue>.
       </>
     );
   }
@@ -115,8 +115,9 @@ export function AdminProtectionDescription({
       <CloudflareAccessLink dashboardUrl={dashboardUrl} /> authentication was
       not detected on this request. Anyone who can reach the admin dashboard
       may be able to change your content. Run{" "}
-      <CloudflareValue>yarn manage auth setup</CloudflareValue> to add a login
-      or <CloudflareValue>yarn manage access</CloudflareValue> to configure
+      <CloudflareValue>{managementCommand("auth setup")}</CloudflareValue> to
+      add a login or{" "}
+      <CloudflareValue>{managementCommand("access")}</CloudflareValue> to configure
       Cloudflare Access.
     </>
   );
@@ -158,8 +159,8 @@ export function SiteCustomDomainDescription({
           </>
         )}
       To configure or change it safely, run{" "}
-      <CloudflareValue>yarn manage domain</CloudflareValue> from your deployment
-      checkout. The command updates the Worker configuration, deploys, and
+      <CloudflareValue>{managementCommand("domain")}</CloudflareValue>. The
+      command updates the Worker configuration, deploys, and
       verifies the domain and TLS.
     </>
   );
@@ -306,8 +307,7 @@ export function MediaStorageDescription({
       <>
         Media uploads are disabled for this instance. Text publishing and
         external URLs continue to work. To opt in later, run{" "}
-        <CloudflareValue>yarn manage deploy --enable-r2</CloudflareValue> from
-        the deployment checkout.
+        <CloudflareValue>{managementCommand("deploy --enable-r2")}</CloudflareValue>.
       </>
     );
   }
@@ -328,7 +328,7 @@ export function MediaStorageDescription({
         )
         : "Activate R2 in the Cloudflare dashboard"}
       , complete billing setup if Cloudflare requests it, then run{" "}
-      <CloudflareValue>yarn manage deploy --enable-r2</CloudflareValue>.
+      <CloudflareValue>{managementCommand("deploy --enable-r2")}</CloudflareValue>.
     </>
   );
 }

--- a/src/components/admin/shared/MediaStorageUnavailableDialog/index.tsx
+++ b/src/components/admin/shared/MediaStorageUnavailableDialog/index.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {cn} from "@/lib/utils";
+import {managementCommand} from "@/shared/ManagementCli";
 
 type MediaStorageState = "disabled" | "pending" | "ready";
 
@@ -30,8 +31,8 @@ export function MediaStorageSetupInstructions({
 }) {
   const local = !dashboardUrl;
   const command = local
-    ? "yarn manage deploy --local --enable-r2"
-    : "yarn manage deploy --enable-r2";
+    ? managementCommand("deploy --local --enable-r2")
+    : managementCommand("deploy --enable-r2");
 
   return (
     <div className="rounded-lg border bg-muted/40 p-3">
@@ -45,7 +46,7 @@ export function MediaStorageSetupInstructions({
           </li>
         )}
         <li>
-          From the microfeed repository checkout, run{" "}
+          From any folder, run{" "}
           <code className="rounded bg-background px-1.5 py-0.5 text-xs text-foreground ring-1 ring-foreground/10">
             {command}
           </code>

--- a/src/components/admin/themes/ThemeInstallHelpDialog.tsx
+++ b/src/components/admin/themes/ThemeInstallHelpDialog.tsx
@@ -2,6 +2,10 @@ import {BookOpenIcon, ExternalLinkIcon} from "lucide-react";
 
 import {Button} from "@/components/ui/button";
 import {
+  MICROFEED_MANAGE_COMMAND,
+  managementCommand,
+} from "@/shared/ManagementCli";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -44,17 +48,23 @@ export default function ThemeInstallHelpDialog({
         </DialogHeader>
 
         <div className="grid gap-6 text-sm leading-relaxed">
+          <p className="rounded-lg border bg-muted/40 p-3 text-muted-foreground">
+            Run these commands from any folder. If this computer has not saved
+            the site yet, first give a local coding agent{" "}
+            <code>{MICROFEED_MANAGE_COMMAND}</code> and ask it to connect to the
+            existing Worker.
+          </p>
           <section className="grid gap-3">
             <div>
               <h3 className="font-semibold">Install a community theme</h3>
               <p className="mt-1 text-muted-foreground">
-                From your microfeed checkout, install a public GitHub repository.
+                Install a public GitHub repository through the management CLI.
                 The new version is inactive, so you can preview it before it
                 changes the public site.
               </p>
             </div>
             <Command>
-              {`yarn manage theme install https://github.com/owner/theme-repository --instance ${instanceName}`}
+              {managementCommand(`theme install https://github.com/owner/theme-repository --instance ${instanceName}`)}
             </Command>
           </section>
 
@@ -63,12 +73,12 @@ export default function ThemeInstallHelpDialog({
               <h3 className="font-semibold">Install a Built-in theme</h3>
               <p className="mt-1 text-muted-foreground">
                 Deployment synchronizes the Built-in catalog automatically.
-                You can also install a specific release from the current
-                microfeed checkout; it remains inactive for preview.
+                You can also install a specific release through the management
+                CLI; it remains inactive for preview.
               </p>
             </div>
             <Command>
-              {`yarn manage theme install bundled:default --instance ${instanceName}`}
+              {managementCommand(`theme install bundled:default --instance ${instanceName}`)}
             </Command>
           </section>
 
@@ -96,7 +106,7 @@ export default function ThemeInstallHelpDialog({
               </p>
             </div>
             <Command>
-              {`yarn manage theme init ~/microfeed-themes/my-theme --instance ${instanceName}`}
+              {managementCommand(`theme init ~/microfeed-themes/my-theme --instance ${instanceName}`)}
             </Command>
           </section>
 

--- a/src/components/admin/themes/ThemesApp.tsx
+++ b/src/components/admin/themes/ThemesApp.tsx
@@ -7,6 +7,10 @@ import ThemePreviewDialog from "@/components/admin/themes/ThemePreviewDialog";
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
 import {ADMIN_URLS} from "@/shared/StringUtils";
+import {
+  MICROFEED_MANAGE_COMMAND,
+  managementCommand,
+} from "@/shared/ManagementCli";
 import type {
   BuiltInThemeGroup,
   ThemeAdminTab,
@@ -114,9 +118,12 @@ function VersionCard({
 }: VersionCardProps) {
   const canUpdate = builtIn || Boolean(theme.sourceUrl || theme.sourcePath);
   const updateCommand = builtIn && builtInSource
-    ? `yarn manage theme install ${builtInSource} --instance ${instanceName}`
-    : `yarn manage theme update ${theme.id} --instance ${instanceName}`;
-  const exportCommand = `yarn manage theme export ${theme.id} --instance ${instanceName} --output .microfeed/themes/${theme.packageId}-${theme.version} --git`;
+    ? managementCommand(`theme install ${builtInSource} --instance ${instanceName}`)
+    : managementCommand(`theme update ${theme.id} --instance ${instanceName}`);
+  const exportCommand = managementCommand(
+    `theme export ${theme.id} --instance ${instanceName} ` +
+      `--output ~/microfeed-themes/${theme.packageId}-${theme.version} --git`,
+  );
   return (
     <article className="rounded-xl border p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -176,7 +183,7 @@ function VersionCard({
 
       {builtIn && (
         <p className="mt-3 rounded-lg bg-muted/60 p-3 text-xs leading-5 text-muted-foreground">
-          This Built-in theme is maintained by your microfeed checkout and
+          This Built-in theme is maintained by the current microfeed release and
           synchronized during deployment. Create a Custom version to change it.
         </p>
       )}
@@ -200,7 +207,7 @@ function VersionCard({
               <p className="mb-2 text-muted-foreground">
                 <strong className="text-foreground">Update this theme:</strong>{" "}
                 {builtIn
-                  ? "Install the current Built-in release from this checkout as an inactive version. Preview it before activating."
+                  ? "Install the current Built-in release as an inactive version. Preview it before activating."
                   : "Check its original source and install a newer SemVer as another inactive version."}
               </p>
               <div className="flex items-center gap-2 rounded-lg bg-muted p-2">
@@ -376,6 +383,12 @@ export default function ThemesApp({
 
   return (
     <div className="grid gap-5">
+      <p className="rounded-xl border bg-muted/30 p-4 text-sm text-muted-foreground">
+        Run copied management commands from any folder. If this computer has
+        not saved the site yet, first give a local coding agent{" "}
+        <code>{MICROFEED_MANAGE_COMMAND}</code> and ask it to connect to the
+        existing Worker.
+      </p>
       <section className="rounded-[14px] border bg-card p-5 shadow-xs">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
@@ -424,7 +437,7 @@ export default function ThemesApp({
         {tab === "built-in" && (
           <div aria-labelledby="built-in-theme-tab" className="mt-5 grid gap-3" id="built-in-theme-panel" role="tabpanel">
             <p className="text-sm text-muted-foreground">
-              Built-in themes are synchronized from this microfeed checkout.
+              Built-in themes are synchronized from the current microfeed release.
               Updates are installed inactive and never change the public site
               until you activate them.
             </p>

--- a/src/components/admin/webhooks/WebhookEventExplorerApp.tsx
+++ b/src/components/admin/webhooks/WebhookEventExplorerApp.tsx
@@ -149,7 +149,7 @@ export default function WebhookEventExplorerApp({
         method: "POST",
       });
       setPreview(result);
-      showToast("Payload printed in the yarn dev terminal.", "success");
+      showToast("Payload printed in the local development terminal.", "success");
     } catch (error) {
       showToast(error instanceof Error ? error.message : String(error), "error");
     } finally {
@@ -274,7 +274,7 @@ export default function WebhookEventExplorerApp({
 
           <div className="flex flex-wrap gap-2">
             <Button disabled={busy || !endpoint || endpoint.status === "disabled" || !preview} onClick={send} type="button">Send test delivery</Button>
-            {localPrintAvailable && <Button disabled={busy || !preview} onClick={print} type="button" variant="outline">Print in yarn dev</Button>}
+            {localPrintAvailable && <Button disabled={busy || !preview} onClick={print} type="button" variant="outline">Print in local development</Button>}
           </div>
           <p className="text-xs text-muted-foreground">Sending reserves 1 delivery from the {dailyLimit.toLocaleString("en-US")}-delivery daily budget and can retry. Previewing, copying, and local printing are free and side-effect-free.</p>
           {deliveryId && <p className="rounded-lg border p-3 text-sm">Delivery <code>{deliveryId}</code> was created. <a className="underline underline-offset-4" href={deliveriesUrl}>Open Delivery details</a>.</p>}

--- a/src/components/admin/webhooks/WebhookOverviewApp.tsx
+++ b/src/components/admin/webhooks/WebhookOverviewApp.tsx
@@ -23,6 +23,10 @@ import {Input} from "@/components/ui/input";
 import {Label} from "@/components/ui/label";
 import {adminUrl, browserAdminPath} from "@/shared/AdminPath";
 import {
+  MICROFEED_MANAGE_COMMAND,
+  managementCommand,
+} from "@/shared/ManagementCli";
+import {
   WEBHOOK_QUICKSTARTS,
   WEBHOOK_QUICKSTART_ENDPOINT_URL,
   type WebhookQuickstartLanguage,
@@ -75,17 +79,23 @@ export default function WebhookOverviewApp({
   const deploymentLabel = deploymentEnvironment === "preview"
     ? "Preview"
     : "Production";
-  const deploymentCommand = `yarn manage deploy ${
+  const deploymentCommand = managementCommand(`deploy ${
     deploymentEnvironment === "preview" ? "--preview " : ""
-  }--enable-webhooks --instance ${instanceName}`;
-  const disableCommand = `yarn manage deploy ${
+  }--enable-webhooks --instance ${instanceName}`);
+  const disableCommand = managementCommand(`deploy ${
     deploymentEnvironment === "preview" ? "--preview " : ""
-  }--disable-webhooks --instance ${instanceName}`;
+  }--disable-webhooks --instance ${instanceName}`);
   const infrastructureState = overview.infrastructureState ??
     (overview.enabled ? "enabled" : "unprovisioned");
   const localSimulationEnabled = localDevelopment && overview.enabled &&
     infrastructureState === "enabled";
-  const agentDeploymentPrompt = `Enable ${deploymentLabel.toLowerCase()} webhooks for my saved microfeed site "${instanceName}". Follow the deploy-microfeed skill, review the deploy section of docs/manage-cli.md, and run ${deploymentCommand}. Do not change another site or environment. After deployment, run yarn manage status --instance ${instanceName} and report whether the webhook Queue and binding are ready.`;
+  const agentDeploymentPrompt =
+    `Run \`${MICROFEED_MANAGE_COMMAND}\` and follow every instruction it ` +
+    `prints to enable ${deploymentLabel.toLowerCase()} webhooks for my ` +
+    `existing microfeed site "${instanceName}". When instructed, run ` +
+    `\`${deploymentCommand}\`. Do not change another site or environment. ` +
+    `Continue until \`${managementCommand(`status --instance ${instanceName}`)}\` ` +
+    "verifies that the webhook Queue and binding are ready.";
 
   const copy = async (value: string, label: string) => {
     await navigator.clipboard.writeText(value);
@@ -128,8 +138,8 @@ export default function WebhookOverviewApp({
             <p className="mt-1 text-sm leading-6 text-muted-foreground">
               {localDevelopment
                 ? localSimulationEnabled
-                  ? "yarn dev uses Wrangler's local Queue simulation. It creates no Cloudflare resources, requests no Queue permissions, and incurs no Cloudflare charge."
-                  : "This yarn dev run omitted the local Queue and Cron simulation. The saved preview and production webhook states were not changed."
+                  ? `${managementCommand("dev")} uses Wrangler's local Queue simulation. It creates no Cloudflare resources, requests no Queue permissions, and incurs no Cloudflare charge.`
+                  : `This ${managementCommand("dev")} run omitted the local Queue and Cron simulation. The saved preview and production webhook states were not changed.`
                 : overview.enabled
                 ? "Deliveries are stored in D1 and dispatched through this deployment's dedicated Cloudflare Queue. Reconciliation runs hourly and cleanup runs once daily while at least one endpoint is configured."
                 : infrastructureState === "disabled"
@@ -863,10 +873,10 @@ function WebhookEnablementDialog({
           <div className="rounded-xl border p-4">
             <p className="font-medium">Local development</p>
             <p className="mt-1 text-muted-foreground">
-              Plain <code>yarn dev</code> runs Wrangler's local Queue simulation
+              Plain <code>{managementCommand("dev")}</code> runs Wrangler's local Queue simulation
               with an isolated D1 database and local secret. It requires no
               Cloudflare permission, resource, deployment, or payment. Use
-              <code> yarn dev --disable-webhooks</code> to omit the Queue and
+              <code> {managementCommand("dev --disable-webhooks")}</code> to omit the Queue and
               Cron simulation for one run without changing a deployed site.
             </p>
           </div>

--- a/src/pages/[adminPath]/login/set_password/index.astro
+++ b/src/pages/[adminPath]/login/set_password/index.astro
@@ -10,7 +10,10 @@ const adminPath = normalizeAdminPath(env.MICROFEED_ADMIN_PATH);
 const setup = await currentAdminPasswordSetup(env.FEED_DB, Astro.request);
 if (!setup) {
   return new Response(
-    "This password link has expired or was replaced. Run `yarn manage auth setup` for first-time administrator setup, or `yarn manage auth reset-password` for an existing administrator.",
+    "This password link has expired or was replaced. Run " +
+      "`npx @microfeed/cli manage auth setup` for first-time administrator " +
+      "setup, or `npx @microfeed/cli manage auth reset-password` for an " +
+      "existing administrator.",
     {
       headers: {
         "Cache-Control": "no-store",

--- a/src/server/auth/admin-owner.ts
+++ b/src/server/auth/admin-owner.ts
@@ -1,4 +1,5 @@
 import {escapeHtml} from "@/shared/StringUtils";
+import {managementCommand} from "@/shared/ManagementCli";
 
 export interface AdminOwner {
   email: string;
@@ -25,7 +26,7 @@ function dashboardAuthCommand(
       /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(normalizedInstanceName)
     ? ` --instance ${normalizedInstanceName}`
     : "";
-  return `yarn manage auth ${action}${instanceOption}`;
+  return managementCommand(`auth ${action}${instanceOption}`);
 }
 
 export async function adminOwner(
@@ -63,7 +64,7 @@ export function adminDashboardLockedResponse(
     <main>
       <h1>Admin dashboard locked</h1>
       <p>${ADMIN_DASHBOARD_LOCKED_MESSAGE}</p>
-      <p>Set up the administrator email and password by running this command from your microfeed checkout:</p>
+      <p>Set up the administrator email and password by running this command from any folder:</p>
       <pre><code>${escapeHtml(setupCommand)}</code></pre>
       ${disableCommand
         ? `<p>For this local instance, you can instead disable dashboard authentication:</p>

--- a/src/server/auth/password-setup.ts
+++ b/src/server/auth/password-setup.ts
@@ -5,6 +5,7 @@ import {
   validateAdminSetupCredentials,
 } from "@/shared/AdminCredentials";
 import {adminUrl} from "@/shared/AdminPath";
+import {managementCommand} from "@/shared/ManagementCli";
 
 export const ADMIN_PASSWORD_SETUP_TTL_SECONDS = 30 * 60;
 export const ADMIN_PASSWORD_SETUP_COOKIE =
@@ -51,7 +52,10 @@ function textResponse(body: string, status: number): Response {
 
 function goneResponse(): Response {
   return textResponse(
-    "This password link has expired or was replaced. Run `yarn manage auth setup` for first-time administrator setup, or `yarn manage auth reset-password` for an existing administrator.",
+    "This password link has expired or was replaced. Run " +
+      `\`${managementCommand("auth setup")}\` for first-time administrator ` +
+      `setup, or \`${managementCommand("auth reset-password")}\` for an ` +
+      "existing administrator.",
     410,
   );
 }

--- a/src/server/webhooks/events.ts
+++ b/src/server/webhooks/events.ts
@@ -4,6 +4,7 @@ import {
   type WebhookEventType,
   webhookSubjectType,
 } from "@/shared/Webhooks";
+import {managementCommand} from "@/shared/ManagementCli";
 import {WebhookRequestError, WebhookUnavailableError} from "./validation";
 
 export type WebhookOrigin = "api" | "dashboard" | "system" | "webmcp";
@@ -571,7 +572,7 @@ export async function createWebhookTestDelivery(
 ): Promise<{deliveryId: string; eventId: string; suppressed?: string}> {
   if (!webhooksAvailable(runtimeEnv)) {
     throw new WebhookUnavailableError(
-      "Enable webhooks with yarn manage deploy --enable-webhooks first.",
+      `Enable webhooks with ${managementCommand("deploy --enable-webhooks")} first.`,
     );
   }
   const endpoint = await endpointForDirectDelivery(
@@ -610,7 +611,7 @@ export async function createWebhookExplorerDelivery(
 ): Promise<{deliveryId: string; eventId: string; suppressed?: string}> {
   if (!webhooksAvailable(runtimeEnv)) {
     throw new WebhookUnavailableError(
-      "Enable webhooks with yarn manage deploy --enable-webhooks first.",
+      `Enable webhooks with ${managementCommand("deploy --enable-webhooks")} first.`,
     );
   }
   const endpoint = await endpointForDirectDelivery(

--- a/src/shared/ManagementCli.ts
+++ b/src/shared/ManagementCli.ts
@@ -1,0 +1,8 @@
+export const MICROFEED_MANAGE_COMMAND = "npx @microfeed/cli manage";
+
+export function managementCommand(arguments_: string): string {
+  const normalizedArguments = arguments_.trim();
+  return normalizedArguments
+    ? `${MICROFEED_MANAGE_COMMAND} ${normalizedArguments}`
+    : MICROFEED_MANAGE_COMMAND;
+}

--- a/tests/unit/cli/credentials.test.ts
+++ b/tests/unit/cli/credentials.test.ts
@@ -297,7 +297,7 @@ describe("CLI discovery", () => {
     await expect(discoverInstance("https://feed.example"))
       .rejects.toThrow("Cloudflare Access can protect dashboard routes");
     await expect(discoverInstance("https://feed.example"))
-      .rejects.toThrow("yarn manage auth setup");
+      .rejects.toThrow("npx @microfeed/cli manage auth setup");
     await expect(discoverInstance("https://feed.example"))
       .rejects.toThrow("domains-and-access/#enable-built-in-login");
     expect(fetchMock).toHaveBeenCalledTimes(3);

--- a/tests/unit/components/admin-dashboard-shell.test.ts
+++ b/tests/unit/components/admin-dashboard-shell.test.ts
@@ -147,17 +147,21 @@ describe("admin dashboard shell models", () => {
       "https://github.com/microfeed/microfeed",
     );
     expect(ADMIN_UPDATE_PROMPT).toBe(
-      "Update this microfeed site to the latest version and deploy it.",
+      "Run `npx @microfeed/cli manage` and follow every instruction it prints " +
+        "to update this microfeed site to the latest version. Continue until " +
+        "`status` verifies it.",
     );
     expect(adminUpdatePrompt({
       deployedAt: "2026-08-03T20:00:00.000Z",
       productionWorkerName: "my-microfeed",
       protected: true,
-    })).toBe([
-      ADMIN_UPDATE_PROMPT,
-      "First run `yarn manage connect --worker my-microfeed`. Use the existing or newly created local instance name reported by that command. Then run `yarn manage status --instance <instance-name>`, deploy with `yarn manage deploy --instance <instance-name>`, and run status again to verify it.",
-      "Do not initialize a new site or target another Worker.",
-    ].join("\n\n"));
+    })).toBe(
+      "Run `npx @microfeed/cli manage` and follow every instruction it " +
+        "prints to update the existing Cloudflare Worker `my-microfeed` to " +
+        "the latest version.\n\n" +
+        "Do not initialize a new site or target another Worker. Continue " +
+        "until `status` verifies it.",
+    );
     expect(adminUpdatePrompt({
       deployedAt: "2026-08-03T20:00:00.000Z",
       productionWorkerName: "my-microfeed",

--- a/tests/unit/components/admin-themes.test.ts
+++ b/tests/unit/components/admin-themes.test.ts
@@ -89,10 +89,11 @@ describe("Admin versioned themes", () => {
   });
 
   it("separates Built-in groups from quota-scoped Custom versions", async () => {
-    const [themes, installHelp, route] = await Promise.all([
+    const [themes, installHelp, route, managementCli] = await Promise.all([
       source("components/admin/themes/ThemesApp.tsx"),
       source("components/admin/themes/ThemeInstallHelpDialog.tsx"),
       source("pages/[adminPath]/settings/themes/index.astro"),
+      source("shared/ManagementCli.ts"),
     ]);
     expect(themes).toContain("Built-in themes (");
     expect(themes).toContain("Custom themes (");
@@ -140,6 +141,8 @@ describe("Admin versioned themes", () => {
     expect(installHelp).toContain("Install a community theme");
     expect(installHelp).toContain("Install a Built-in theme");
     expect(installHelp).toContain("bundled:default");
+    expect(installHelp).toContain("MICROFEED_MANAGE_COMMAND");
+    expect(managementCli).toContain("npx @microfeed/cli manage");
     expect(installHelp).toContain("Create a new version in Admin");
     expect(installHelp).toContain("https://docs.microfeed.org/dashboard/themes/");
     expect(installHelp).toContain(
@@ -149,13 +152,14 @@ describe("Admin versioned themes", () => {
     expect(themes).not.toContain("Origin theme: ${theme.originThemeId}");
     expect(themes).toContain("!builtIn && (");
     expect(themes).toContain("Update this theme");
+    expect(themes).toContain("MICROFEED_MANAGE_COMMAND");
     expect(themes).toContain("theme install ${builtInSource}");
     expect(themes).toContain("Copy update command");
     expect(themes).toContain("Export this version");
     expect(themes).toContain("Copy export command");
     expect(themes).toContain("for backup or continued development");
     expect(themes).toContain(
-      ".microfeed/themes/${theme.packageId}-${theme.version} --git",
+      "~/microfeed-themes/${theme.packageId}-${theme.version} --git",
     );
   });
 

--- a/tests/unit/components/admin-webhooks.test.ts
+++ b/tests/unit/components/admin-webhooks.test.ts
@@ -92,7 +92,7 @@ describe("Webhook Admin", () => {
     expect(output).toContain("Current content");
     expect(output).toContain("Copy raw JSON");
     expect(output).toContain("Copy formatted JSON");
-    expect(output).toContain("Print in yarn dev");
+    expect(output).toContain("Print in local development");
     expect(output).toContain("Subscription mismatch");
     expect(output).toContain("1,000-delivery daily budget");
     expect(output).toContain('aria-label="Payload JSON"');
@@ -224,7 +224,7 @@ describe("Webhook Admin", () => {
     ));
     expect(disabledOutput).toContain("Ordinary deployments keep webhooks off");
     expect(disabledOutput).toContain(
-      "yarn manage deploy --enable-webhooks --instance personal",
+      "npx @microfeed/cli manage deploy --enable-webhooks --instance personal",
     );
     expect(disabledOutput).toContain("Enable production webhooks");
 
@@ -250,7 +250,7 @@ describe("Webhook Admin", () => {
     expect(retainedOutput).toContain("Queue is paused and detached");
     expect(retainedOutput).toContain("Re-enable production webhooks");
     expect(retainedOutput).toContain(
-      "yarn manage deploy --enable-webhooks --instance personal",
+      "npx @microfeed/cli manage deploy --enable-webhooks --instance personal",
     );
   });
 

--- a/tests/unit/components/media-storage-unavailable-dialog.test.ts
+++ b/tests/unit/components/media-storage-unavailable-dialog.test.ts
@@ -16,7 +16,7 @@ describe("media storage unavailable guidance", () => {
     );
 
     expect(output).toContain("Activate R2 in Cloudflare");
-    expect(output).toContain("yarn manage deploy --enable-r2");
+    expect(output).toContain("npx @microfeed/cli manage deploy --enable-r2");
     expect(output).not.toContain("deploy --local");
   });
 
@@ -28,7 +28,7 @@ describe("media storage unavailable guidance", () => {
     );
 
     expect(output).toContain(
-      "yarn manage deploy --local --enable-r2",
+      "npx @microfeed/cli manage deploy --local --enable-r2",
     );
     expect(output).not.toContain("Activate R2 in Cloudflare");
   });

--- a/tests/unit/server/admin-protection.test.ts
+++ b/tests/unit/server/admin-protection.test.ts
@@ -187,7 +187,7 @@ describe("media delivery onboarding", () => {
         state,
       }),
     );
-    expect(output).toContain("yarn manage deploy --enable-r2");
+    expect(output).toContain("npx @microfeed/cli manage deploy --enable-r2");
     expect(output).toContain(
       state === "pending" ? "subscription is pending" : "uploads are disabled",
     );
@@ -322,7 +322,7 @@ describe("Cloudflare onboarding links", () => {
     );
     expect(output).toContain(
       '<code class="font-semibold text-cloudflare-orange">' +
-        "yarn manage domain</code>",
+        "npx @microfeed/cli manage domain</code>",
     );
   });
 });

--- a/tests/unit/server/password-setup.test.ts
+++ b/tests/unit/server/password-setup.test.ts
@@ -42,10 +42,10 @@ describe("admin password setup routing", () => {
     const body = await response.text();
     expect(body).toContain("The admin dashboard is locked");
     expect(body).toContain(
-      "<pre><code>yarn manage auth setup --instance " +
+      "<pre><code>npx @microfeed/cli manage auth setup --instance " +
         "production-feed</code></pre>",
     );
-    expect(body).not.toContain("yarn manage auth disable");
+    expect(body).not.toContain("npx @microfeed/cli manage auth disable");
     expect(body).toContain(
       `To learn more about dashboard login: <a href="${ADMIN_DASHBOARD_LOGIN_HELP_URL}">` +
         "Manage the dashboard login</a>",
@@ -65,10 +65,10 @@ describe("admin password setup routing", () => {
     const body = await response.text();
     expect(body).toContain("The admin dashboard is locked");
     expect(body).toContain(
-      "<pre><code>yarn manage auth setup --instance local</code></pre>",
+      "<pre><code>npx @microfeed/cli manage auth setup --instance local</code></pre>",
     );
     expect(body).toContain(
-      "<pre><code>yarn manage auth disable --instance local</code></pre>",
+      "<pre><code>npx @microfeed/cli manage auth disable --instance local</code></pre>",
     );
     expect(body).toContain(ADMIN_DASHBOARD_LOGIN_HELP_URL);
   });
@@ -84,8 +84,8 @@ describe("admin password setup routing", () => {
       "text/plain; charset=utf-8",
     );
     const body = await response.text();
-    expect(body).toContain("yarn manage auth setup --instance local");
-    expect(body).toContain("yarn manage auth disable --instance local");
+    expect(body).toContain("npx @microfeed/cli manage auth setup --instance local");
+    expect(body).toContain("npx @microfeed/cli manage auth disable --instance local");
     expect(body).toContain(ADMIN_DASHBOARD_LOGIN_HELP_URL);
   });
 });

--- a/tests/worker/password-setup.test.ts
+++ b/tests/worker/password-setup.test.ts
@@ -236,7 +236,7 @@ describe("browser-based admin password setup", () => {
       newToken,
     );
     expect(expired.status).toBe(410);
-    expect(await expired.text()).toContain("yarn manage auth setup");
+    expect(await expired.text()).toContain("npx @microfeed/cli manage auth setup");
   });
 
   it("atomically resets the password, revokes sessions, and consumes one concurrent use", async () => {


### PR DESCRIPTION
## Summary

- make Admin update, setup, authentication, media, domain, and webhook guidance start from the clone-free `npx @microfeed/cli manage` launcher
- make theme install, update, initialization, and export commands work from any folder, with visible export destinations
- synchronize public docs, package docs, agent skills, CLI recovery messages, and focused tests while retaining `yarn manage` for the explicit manual-clone workflow

## Related issue

None.

## Testing

- [x] `yarn check`
- [x] `yarn docs:check`
- [x] CLI packed-package check
- [x] theme-kit packed-package check
- [x] focused unit and Worker tests
- [x] `git diff --check`

## Screenshots

N/A — no screenshots added; this changes command copy and guidance without changing component structure or styling.

## Risks

Low. Existing clone-based `yarn manage` commands remain supported. The new default requires the published `@microfeed/cli` launcher and its documented Node.js, Git, and Corepack prerequisites.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.