### PR TITLE
Clarify published and source-local CLI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ your site looks. If you've used WordPress before, you'll find it familiar.
 For agentic content management, the official
 [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli) lets a local
 AI agent create, update, and delete items; upload media files like images, audios, videos and documents. 
-Inside this repository the same command is available as `yarn microfeed`, without global installation.
+Run it from any folder with `npx @microfeed/cli`. If you have Git-cloned the
+microfeed source repository and installed its dependencies, `yarn microfeed`
+is a shortcut that runs the repository's local CLI version.
 
 [Back to 📚TOC](#-table-of-contents)
 
@@ -111,8 +113,8 @@ OpenAI Codex, Claude Code, Cursor, or another local agent that can run terminal
 commands and open a browser, then give it this prompt:
 
 ```text
-Run `npx @microfeed/cli manage` and follow every instruction it prints until
-`status` verifies the deployment.
+Deploy microfeed to Cloudflare. Start by running `npx @microfeed/cli manage`,
+then follow its instructions until deployment is verified.
 ```
 
 That's it. The launcher requires Node.js 22.12 or newer with npm, Git, and
@@ -132,14 +134,15 @@ https://github.com/user-attachments/assets/96c73a94-2068-4172-9003-8bf3a262121d
 
 ### Details
 
-microfeed has one supported deployment engine: `yarn manage`. A local AI coding
-agent can reach it without a user-managed clone through
-`npx @microfeed/cli manage`, or you can clone the repository and run the same
-guided commands yourself.
+Run `npx @microfeed/cli manage` from any folder to use microfeed's supported
+deployment engine without first Git-cloning the microfeed source repository
+yourself. If you already have a Git-cloned microfeed source repository and have
+run `yarn install`, `yarn manage` is a shortcut that uses its local version of
+the same engine.
 
 * **Recommended:** [deploy with an AI coding agent](https://docs.microfeed.org/start-here/ai-agent/).
-* **Manual:** [deploy with `yarn manage`](https://docs.microfeed.org/start-here/manual/).
-* **Every command and option:** read the [canonical `yarn manage` reference](https://docs.microfeed.org/manage-cli/).
+* **Manual:** [deploy from the terminal](https://docs.microfeed.org/start-here/manual/).
+* **Every command and option:** read the [management CLI reference](https://docs.microfeed.org/manage-cli/).
 
 Both paths pause for Cloudflare browser authorization and choices that require
 your approval. Never paste a Cloudflare token, dashboard password, or private
@@ -159,7 +162,7 @@ The documentation site covers advanced setup and ongoing management:
 * [Check status and troubleshoot problems](https://docs.microfeed.org/manage/troubleshooting/)
 * [Remove a deployment safely](https://docs.microfeed.org/manage/remove/)
 
-For exact CLI behavior and safeguards, use the [canonical `yarn manage`
+For exact CLI behavior and safeguards, use the [management CLI
 reference](https://docs.microfeed.org/manage-cli/).
 
 [Back to 📚TOC](#-table-of-contents)
@@ -185,12 +188,13 @@ Choose the publishing workflow that fits the task:
   same content through browser-authorized access after you enable the API. The
   agent may start login, but you sign in and approve permissions in the
   browser. See the [guided CLI workflow](https://docs.microfeed.org/automation/cli/)
-  or the complete [`yarn microfeed`
+  or the complete [`@microfeed/cli`
   reference](https://docs.microfeed.org/microfeed-cli/).
 
-Inside a microfeed clone, ask your agent to use `yarn microfeed`. For one-off
-use elsewhere, it can run `yarn dlx @microfeed/cli`. Never paste an API key or
-CLI credential into an agent conversation.
+Use `npx @microfeed/cli` from any folder. If the agent is already working in a
+Git-cloned microfeed source repository whose dependencies are installed, it
+can use `yarn microfeed` as a shortcut to the repository's local CLI version.
+Never paste an API key or CLI credential into an agent conversation.
 
 ### Change the public theme
 
@@ -331,7 +335,7 @@ Restore archives only with a microfeed release whose migration history exactly
 extends the snapshot's recorded history. Local restore requires a new local instance.
 Cloudflare restore requires a newly initialized site with nonreused, unchanged
 D1 and R2 resources, a successful dry run, and exact site-name confirmation.
-See the canonical [`snapshot` command reference](docs/manage-cli.md#yarn-manage-snapshot)
+See the canonical [`snapshot` command reference](docs/manage-cli.md#npx-microfeedcli-manage-snapshot)
 for restore examples, migration rules, maintenance mode, and resume behavior.
 
 The archive contains administrator password hashes and possibly private media.

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -125,7 +125,7 @@ export default defineConfig({
         {
           label: "Reference",
           items: [
-            { label: "yarn manage reference", link: "/manage-cli/" },
+            { label: "Management CLI reference", link: "/manage-cli/" },
             { label: "@microfeed/cli reference", link: "/microfeed-cli/" },
             { label: "@microfeed/theme-kit reference", link: "/theme-kit-cli/" },
             { label: "Glossary", link: "/reference/glossary/" },
@@ -144,7 +144,7 @@ export default defineConfig({
           description:
             "microfeed is an open-source CMS that publishes one collection as a website, RSS feed, and JSON Feed from the owner's Cloudflare account.",
           details:
-            "Use the Installation guides for deployment workflows. Use the yarn manage reference for site-management commands, the WebMCP guide for browser-based draft editing, and the @microfeed/cli reference for broader content commands and safety rules.",
+            "Use the Installation guides for deployment workflows. Use the management CLI reference for site-management commands, the WebMCP guide for browser-based draft editing, and the @microfeed/cli reference for broader content commands and safety rules.",
           promote: ["index", "start-here/**", "manage-cli", "microfeed-cli", "theme-kit-cli"],
           demote: ["contribute/**"],
           customSets: [

--- a/docs/automation/ai-agents.md
+++ b/docs/automation/ai-agents.md
@@ -61,27 +61,29 @@ endpoints](/webhooks/endpoints/) and the `build-microfeed-automation` skill.
 Include the site, the content outcome, and the approval boundary in the prompt:
 
 ```text
-Use @microfeed/cli to create a draft item on https://feed.example.com from
-article.md. Use --json, show me the draft before publishing, and pause if API
-access, browser authorization, or destructive confirmation is required.
+Use `npx @microfeed/cli` to create a draft item on https://feed.example.com
+from article.md. Use `--json`, show me the draft before publishing, and pause
+if API access, browser authorization, or destructive confirmation is required.
 ```
 
-Inside a microfeed clone, the agent should use `yarn microfeed`. The repository
-also provides the canonical `manage-microfeed-content` skill at
+The command works from any folder. If the agent is already working inside a
+Git-cloned microfeed source repository whose dependencies are installed, it
+may use `yarn microfeed` as a shortcut to the local CLI version. That source
+repository also provides the canonical `manage-microfeed-content` skill at
 `.agents/skills/manage-microfeed-content/`, which teaches the agent to select
 commands, preserve credentials, and confirm destructive operations. The
 published `@microfeed/cli` package bundles the same skill for agent hosts that
 distribute skills with npm packages.
 
-Claude Code reads the clone's `CLAUDE.md`, which imports the repository guidance
-and routes content work to that skill. Other compatible coding agents can
-discover the `.agents/skills/` copy directly. You do not need to install or
-paste the skill into the prompt when the agent is already working inside a
-microfeed clone.
+Claude Code reads `CLAUDE.md` in the Git-cloned source repository, which
+imports the repository guidance and routes content work to that skill. Other
+compatible coding agents can discover the `.agents/skills/` copy directly.
+You do not need to install or paste the skill into the prompt when the agent is
+already working inside that source repository.
 
 ## Keep browser authorization human-controlled
 
-An agent may start `yarn microfeed login <site-url>`, but the administrator
+An agent may start `npx @microfeed/cli login <site-url>`, but the administrator
 must sign in and approve or deny permissions in the browser. The agent must not
 click **Allow**, request a password, or inspect the encrypted credential store
 or operating-system keychain.

--- a/docs/automation/cli.md
+++ b/docs/automation/cli.md
@@ -14,15 +14,14 @@ For every command, option, JSON field, and edge case, use the exhaustive
 
 | Where you are working | Command |
 | --- | --- |
-| Inside a microfeed clone | `yarn microfeed …` |
-| Inside another Yarn project | Install `@microfeed/cli`, then run `yarn microfeed …` |
-| One command without installation | `yarn dlx @microfeed/cli …` |
+| Recommended from any folder | `npx @microfeed/cli …` |
+| Git-cloned microfeed source repository after `yarn install` | `yarn microfeed …` |
 | Global installation | `microfeed …` |
 
-Inside a microfeed clone, start with:
+Start from any folder with:
 
 ```console
-yarn microfeed --help
+npx @microfeed/cli --help
 ```
 
 ## Enable API access and log in
@@ -32,7 +31,7 @@ Then authorize the CLI:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed login https://feed.example.com --instance <instance-name>
+npx @microfeed/cli login https://feed.example.com --instance <instance-name>
 ```
 
 The command opens a browser. The administrator signs in, reviews the requested
@@ -44,8 +43,8 @@ Select and inspect saved sites with:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed instances list
-yarn microfeed instances use <instance-name>
+npx @microfeed/cli instances list
+npx @microfeed/cli instances use <instance-name>
 ```
 
 ## Inspect and change content
@@ -56,13 +55,13 @@ stable idempotency key for every retry of the same logical create:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item list --summary --instance <instance-name> --json
-yarn microfeed item get <item-id> --unwrap --instance <instance-name> --json
-yarn microfeed item create --input item.json --validate-only \
+npx @microfeed/cli item list --summary --instance <instance-name> --json
+npx @microfeed/cli item get <item-id> --unwrap --instance <instance-name> --json
+npx @microfeed/cli item create --input item.json --validate-only \
   --instance <instance-name> --json
-yarn microfeed item create --input item.json \
+npx @microfeed/cli item create --input item.json \
   --idempotency-key <uuid> --verify --instance <instance-name> --json
-yarn microfeed item update <item-id> --input item.json \
+npx @microfeed/cli item update <item-id> --input item.json \
   --instance <instance-name> --json
 ```
 
@@ -82,7 +81,7 @@ For an inline image:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed media upload ./diagram.png --instance <instance-name> --json
+npx @microfeed/cli media upload ./diagram.png --instance <instance-name> --json
 ```
 
 Insert the returned permanent `media_url` into `content_html`, then create or
@@ -97,7 +96,7 @@ explicitly:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item delete <item-id> --instance <instance-name> \
+npx @microfeed/cli item delete <item-id> --instance <instance-name> \
   --confirm <item-id> --json
 ```
 
@@ -110,7 +109,7 @@ For unattended CI, store `MICROFEED_API_KEY` in the CI secret manager and set
 `MICROFEED_URL` or select a saved instance:
 
 ```console
-MICROFEED_URL=https://feed.example.com yarn microfeed item list --json
+MICROFEED_URL=https://feed.example.com npx @microfeed/cli item list --json
 ```
 
 Do not place the key in the command, a repository file, logs, or an agent

--- a/docs/automation/index.md
+++ b/docs/automation/index.md
@@ -144,7 +144,7 @@ both REST operations and webhook envelopes. Enable public API docs, then use
 Every webhook event has an exact named example in that contract. Open **Admin
 → Webhooks → Event explorer** to compare Payload, Schema, and Headers, preview
 generated or current content, and copy the raw JSON. From a terminal, read the
-same per-instance example with `yarn microfeed webhook sample <event> --json`.
+same per-instance example with `npx @microfeed/cli webhook sample <event> --json`.
 
 ## Automation examples
 
@@ -168,7 +168,7 @@ async function dispatch(event: MicrofeedEvent) {
 }
 ```
 
-Use `yarn microfeed webhook sample <event> --json` or Admin Event Explorer to
+Use `npx @microfeed/cli webhook sample <event> --json` or Admin Event Explorer to
 inspect the exact input while building each example. Event Explorer sends count
 toward the daily delivery budget; previews and local terminal prints do not.
 

--- a/docs/automation/platforms/n8n.md
+++ b/docs/automation/platforms/n8n.md
@@ -155,7 +155,7 @@ than copying fields from this guide.
 If n8n cannot securely load the maintained verifier and endpoint secret, do
 not fall back to trusting the webhook URL. Put a receiver in front:
 
-1. Start from `yarn microfeed webhook scaffold` and its official
+1. Start from `npx @microfeed/cli webhook scaffold` and its official
    `standardwebhooks` verification.
 2. Replace in-memory duplicate tracking with durable acceptance and a queue.
 3. Return `202` to microfeed only after the verified event is saved.

--- a/docs/automation/platforms/zapier.md
+++ b/docs/automation/platforms/zapier.md
@@ -71,7 +71,7 @@ microfeed → Standard Webhooks receiver → durable job → Zapier Catch Hook
 Build the receiver from the maintained local starter:
 
 ```console
-yarn microfeed webhook scaffold .microfeed/webhooks/zapier-gateway \
+npx @microfeed/cli webhook scaffold .microfeed/webhooks/zapier-gateway \
   --language javascript
 ```
 

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -15,7 +15,7 @@ cd microfeed
 corepack enable
 yarn install --immutable
 yarn manage init --local --instance local-development
-yarn dev
+yarn manage dev --instance local-development
 ```
 
 Local development uses isolated simulated D1 and optional R2 data. It does not
@@ -33,7 +33,7 @@ yarn docs:dev
 2. Keep application code under `src/`, management tooling under `manage-cli/`,
    and documentation-site content under `docs/`.
 3. Keep the canonical command references synchronized whenever behavior changes:
-   [`yarn manage`](/manage-cli/), [`@microfeed/cli`](/microfeed-cli/), and
+   [management CLI](/manage-cli/), [`@microfeed/cli`](/microfeed-cli/), and
    [`@microfeed/theme-kit`](/theme-kit-cli/).
 4. Add or update tests for observable behavior.
 5. Run `git diff --check` and `yarn check`.

--- a/docs/dashboard/publish.md
+++ b/docs/dashboard/publish.md
@@ -73,16 +73,17 @@ Give the agent a content goal and the root URL of your microfeed site. Do not
 give it an API key or CLI credential. For example:
 
 ```text
-Use @microfeed/cli to create a published item on https://feed.example.com.
-Use --json for deterministic output, and pause for me if API access must be
-enabled, browser authorization is required, or a destructive action needs
-confirmation.
+Use `npx @microfeed/cli` to create a published item on
+https://feed.example.com. Use `--json` for deterministic output, and pause for
+me if API access must be enabled, browser authorization is required, or a
+destructive action needs confirmation.
 ```
 
-Inside a microfeed clone, the agent should prefer `yarn microfeed`. Elsewhere,
-it can use a project-local installation or `yarn dlx @microfeed/cli`. You sign
-in and approve permissions in the browser; the CLI stores and refreshes the
-credential without printing it. Follow the [guided CLI
+The recommended `npx @microfeed/cli` command works from any folder. Inside a
+Git-cloned microfeed source repository whose dependencies are installed,
+`yarn microfeed` is a shortcut to the local CLI version. You sign in and
+approve permissions in the browser; the CLI stores and refreshes the credential
+without printing it. Follow the [guided CLI
 workflow](/automation/cli/), then see the [agent workflow](/automation/ai-agents/)
 and complete [`@microfeed/cli` reference](/microfeed-cli/) for media vocabulary,
 deterministic input, and deletion safeguards.

--- a/docs/dashboard/themes.md
+++ b/docs/dashboard/themes.md
@@ -137,10 +137,12 @@ An environment can keep up to 100 non-deleted Custom versions and 20 drafts.
 Built-in versions do not consume this quota. If a limit is full, delete an
 unused inactive Custom version or draft and retry.
 
-Repository-installed themes are managed from the connected clone with `yarn
-manage theme`. The [Build and release a theme](/themes/) guide covers creating,
-exporting, validating, installing, updating, and rolling back standalone theme
-packages.
+Use `npx @microfeed/cli manage theme` from any folder to install and manage
+repository-hosted themes. If you are already working in a Git-cloned microfeed
+source repository whose dependencies are installed, `yarn manage theme` is a
+shortcut to its local management version. The [Build and release a
+theme](/themes/) guide covers creating, exporting, validating, installing,
+updating, and rolling back standalone theme packages.
 
 ## Pages and Search compatibility
 

--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -1,5 +1,5 @@
 ---
-title: yarn manage reference
+title: Management CLI reference
 description: Canonical commands, options, side effects, and safety contracts for the microfeed management CLI.
 ---
 
@@ -9,7 +9,8 @@ understand what the CLI can do, what it changes, and which safeguards apply.
 
 For a guided task, start with [Manage your site](/manage/) or the installation
 guides. Use this page when you need the complete command and option contract.
-Run `yarn manage help <command>` for the corresponding terminal reference.
+Run `npx @microfeed/cli manage help <command>` for the corresponding terminal
+reference.
 
 ## Contents
 
@@ -18,22 +19,22 @@ Run `yarn manage help <command>` for the corresponding terminal reference.
 - [Command summary](#command-summary)
 - [Shared conventions](#shared-conventions)
 - [Command reference](#command-reference)
-  - [`accounts`](#yarn-manage-accounts)
-  - [`init`](#yarn-manage-init)
-  - [`connect`](#yarn-manage-connect)
-  - [`deploy`](#yarn-manage-deploy)
+  - [`accounts`](#npx-microfeedcli-manage-accounts)
+  - [`init`](#npx-microfeedcli-manage-init)
+  - [`connect`](#npx-microfeedcli-manage-connect)
+  - [`deploy`](#npx-microfeedcli-manage-deploy)
   - [`dev`](#yarn-manage-dev)
-  - [`theme`](#yarn-manage-theme)
-  - [`snapshot`](#yarn-manage-snapshot)
-  - [`status`](#yarn-manage-status)
-  - [`destroy`](#yarn-manage-destroy)
-  - [`migrate-pages`](#yarn-manage-migrate-pages)
-  - [`domain`](#yarn-manage-domain)
-  - [`access`](#yarn-manage-access)
-  - [`auth`](#yarn-manage-auth)
-  - [`config`](#yarn-manage-config)
-  - [`instances`](#yarn-manage-instances)
-  - [`use`](#yarn-manage-use)
+  - [`theme`](#npx-microfeedcli-manage-theme)
+  - [`snapshot`](#npx-microfeedcli-manage-snapshot)
+  - [`status`](#npx-microfeedcli-manage-status)
+  - [`destroy`](#npx-microfeedcli-manage-destroy)
+  - [`migrate-pages`](#npx-microfeedcli-manage-migrate-pages)
+  - [`domain`](#npx-microfeedcli-manage-domain)
+  - [`access`](#npx-microfeedcli-manage-access)
+  - [`auth`](#npx-microfeedcli-manage-auth)
+  - [`config`](#npx-microfeedcli-manage-config)
+  - [`instances`](#npx-microfeedcli-manage-instances)
+  - [`use`](#npx-microfeedcli-manage-use)
 - [Built-in help](#built-in-help)
 - [Environment variables](#environment-variables)
 - [Maintaining this reference](#maintaining-this-reference)
@@ -43,7 +44,8 @@ Run `yarn manage help <command>` for the corresponding terminal reference.
 The management engine remains part of the microfeed repository. Choose the
 invocation that matches how you are working.
 
-For a local coding agent without a clone, start with:
+The recommended invocation works from any folder and does not require you to
+Git-clone or open the microfeed source repository:
 
 ```console
 npx @microfeed/cli manage
@@ -70,8 +72,8 @@ Linux, or `%APPDATA%\microfeed\manage` on Windows. `MICROFEED_CACHE_DIR` and
 `MICROFEED_CONFIG_DIR` override the respective base directories; the launcher
 still appends its `manage` child directory.
 
-Every command in this reference can then be invoked by replacing `yarn manage`
-with `npx @microfeed/cli manage`. For example:
+Deployment and administration examples in this reference use the published
+launcher:
 
 ```console
 npx @microfeed/cli manage accounts --json
@@ -79,15 +81,14 @@ npx @microfeed/cli manage deploy --instance <instance-name>
 npx @microfeed/cli manage status --instance <instance-name>
 ```
 
-People working from a local clone can continue to run:
+If you already have a Git-cloned microfeed source repository and have run
+`yarn install`, you may replace the `npx @microfeed/cli manage` prefix with
+`yarn manage`. For example, `yarn manage help` uses that source repository's
+local version of the same management engine.
 
-```console
-git clone https://github.com/microfeed/microfeed.git
-cd microfeed
-corepack enable
-yarn install --immutable
-yarn manage help
-```
+The `dev` section instead prioritizes `yarn manage dev` from a Git-cloned
+microfeed source repository because local source development requires that
+repository and its installed dependencies.
 
 Both paths require Node.js 22.12 or newer, Git, Corepack, and an interactive
 local session. Cloudflare operations use Wrangler browser authorization. Credentials are
@@ -100,10 +101,10 @@ repository-owned management engine.
 
 ## Safety model
 
-- The repository-owned `yarn manage` engine is the only supported interface
-  for microfeed Cloudflare mutations. Use it directly from a clone or through
-  `npx @microfeed/cli manage`; do not replace it with improvised Wrangler or
-  REST commands.
+- The repository-owned management engine is the only supported interface for
+  microfeed Cloudflare mutations. Use it through `npx @microfeed/cli manage`,
+  or through `yarn manage` when working in a Git-cloned microfeed source
+  repository; do not replace it with improvised Wrangler or REST commands.
 - Initialization validates the selected account and checks Worker, Pages, D1,
   and, unless `--no-r2` is used, R2 name collisions before creating resources.
 - Existing D1 or R2 resources require explicit reuse approval. Resources
@@ -128,9 +129,9 @@ repository-owned management engine.
 
 | Command | Purpose | External effect |
 | --- | --- | --- |
-| `accounts` | Authorize and list Cloudflare accounts | Read-only discovery; may update local Wrangler login profiles and the repository binding |
+| `accounts` | Authorize and list Cloudflare accounts | Read-only discovery; may update local Wrangler login profiles and the management-workspace binding |
 | `init` | Initialize production, preview, or local installation | Creates or updates Cloudflare resources, or local-only state |
-| `connect` | Save an existing compatible Worker in this clone | Reads Cloudflare; writes local state only |
+| `connect` | Save an existing compatible Worker in local management state | Reads Cloudflare; writes local state only |
 | `deploy` | Check, migrate, deploy, verify, or prepare a local release | Updates Worker code and D1 migrations, or only local state with `--local` |
 | `dev` | Run a selected site locally | Starts a local server and changes local simulation data |
 | `theme` | Initialize, install, and manage immutable theme versions | Creates local authoring repositories, writes theme rows to D1 and optional assets to R2, or changes active state through the Worker |
@@ -151,19 +152,21 @@ repository-owned management engine.
 
 Use `--instance <name>` whenever the target is not already the active saved
 site. `MICROFEED_INSTANCE` supplies the same selection for commands that accept
-an instance. Use `yarn manage instances` to review choices and `yarn manage use
-<name>` to change the default.
+an instance. Use `npx @microfeed/cli manage instances` to review choices and
+`npx @microfeed/cli manage use <name>` to change the default.
 
 ### Selecting a Cloudflare account
 
-Use `yarn manage accounts` first. Commands that operate on a saved deployment
-automatically require its recorded account. Supplying `--account-id <id>` is an
-additional exact-account assertion; it cannot override saved ownership.
+Use `npx @microfeed/cli manage accounts` first. Commands that operate on a
+saved deployment automatically require its recorded account. Supplying
+`--account-id <id>` is an additional exact-account assertion; it cannot
+override saved ownership.
 
 To keep separate Cloudflare logins on the same computer, use
-`yarn manage accounts --profile <name>`. The named Wrangler profile is local to
-your computer and does not need to be globally unique. It is separate from the
-microfeed site/Worker name, which should be globally distinctive.
+`npx @microfeed/cli manage accounts --profile <name>`. The named Wrangler
+profile is local to your computer and does not need to be globally unique. It
+is separate from the microfeed site/Worker name, which should be globally
+distinctive.
 
 ### Production, preview, and local data
 
@@ -187,12 +190,12 @@ keeps the automatic state, and prints the exact `deploy --enable-r2` command.
 
 ## Command reference
 
-## `yarn manage accounts`
+## `npx @microfeed/cli manage accounts`
 
 **Purpose:** Authorize Cloudflare and list available accounts.
 
-**Changes:** Read-only Cloudflare discovery; may update local Wrangler login profiles
-and the repository binding.
+**Changes:** Read-only Cloudflare discovery; may update local Wrangler login
+profiles and their binding to the management workspace.
 
 Authorize Cloudflare and list every account available to the active Wrangler
 login. This command never creates or changes a Worker, D1 database, R2 bucket,
@@ -204,35 +207,36 @@ and other Cloudflare resources. One login profile may have access to one or
 more Cloudflare accounts.
 
 The output lists every locally stored profile, marks the one active for this
-local repository, and prints an exact `yarn manage accounts --profile <name>`
-command for each other named profile. The displayed email and Cloudflare
-accounts belong only to the active profile; inactive profiles remain stored
-but are not queried. Wrangler's `default` profile is a fallback login rather
-than a named profile selected by this option.
+management workspace, and prints an exact
+`npx @microfeed/cli manage accounts --profile <name>` command for each other
+named profile. The displayed email and Cloudflare accounts belong only to the
+active profile; inactive profiles remain stored but are not queried. Wrangler's
+`default` profile is a fallback login rather than a named profile selected by
+this option.
 
 Use `--profile <name>` to create or select a named Wrangler browser login and
-bind it to this local Git copy of the repository. If the profile does not yet
-exist, the command opens Cloudflare authorization to create it. If it already
-exists, the command selects it without changing its credentials. Add
-`--reauthorize` to replace that named profile's authorization deliberately.
+bind it to the local management workspace. If the profile does not yet exist,
+the command opens Cloudflare authorization to create it. If it already exists,
+the command selects it without changing its credentials. Add `--reauthorize`
+to replace that named profile's authorization deliberately.
 Wrangler profile names accept ASCII letters, numbers, hyphens, and underscores;
 `default` and `staging` are reserved. Wrangler currently labels named profiles
 as a beta feature.
 
 ```console
-yarn manage accounts [--json] [--profile <name>] [--reauthorize]
+npx @microfeed/cli manage accounts [--json] [--profile <name>] [--reauthorize]
 ```
 
 | Option | Meaning |
 | --- | --- |
 | `--json` | Print the login, active profile, all profiles with active markers, and `{name, id}` accounts as JSON. |
-| `--profile <name>` | Create or select a named Wrangler browser login and bind it to this local repository. |
+| `--profile <name>` | Create or select a named Wrangler browser login and bind it to the local management workspace. |
 | `--reauthorize` | Force fresh browser authorization, for example when the desired account is missing. |
 
 Browser authorization rejection, missing permissions, zero accounts, or an unavailable browser
 callback fail before resource creation.
 
-## `yarn manage init`
+## `npx @microfeed/cli manage init`
 
 **Purpose:** Initialize or resume a production, preview, or local installation.
 
@@ -256,7 +260,7 @@ activates only the Default fallback. A resumed run installs any missing
 packages without changing an already selected theme.
 
 ```console
-yarn manage init [--instance <name>] [--preview|--local] [options]
+npx @microfeed/cli manage init [--instance <name>] [--preview|--local] [options]
 ```
 
 | Option | Meaning |
@@ -281,16 +285,16 @@ yarn manage init [--instance <name>] [--preview|--local] [options]
 Examples:
 
 ```console
-yarn manage init
-yarn manage init --preview
-yarn manage init --local
-yarn manage init --no-r2 --r2-name future-media
+npx @microfeed/cli manage init
+npx @microfeed/cli manage init --preview
+npx @microfeed/cli manage init --local
+npx @microfeed/cli manage init --no-r2 --r2-name future-media
 ```
 
 `--no-r2` works for both Cloudflare and local-only initialization. It creates a
 content-only instance where D1 publishing and external URLs continue to work.
 It never detaches an already configured bucket. Enable the saved bucket later
-with `yarn manage deploy --enable-r2`.
+with `npx @microfeed/cli manage deploy --enable-r2`.
 
 Without `--no-r2`, only Cloudflare's documented R2 subscription-required
 response (`10042`, `NotEntitled`) is safely deferrable. The Worker is deployed
@@ -310,8 +314,9 @@ duplicate creation and unrelated-resource overwrite.
 
 On a newly created Cloudflare account, its first Worker deployment may report
 that `workers.dev` is not ready while Cloudflare finishes preparing the
-account. Wait a few minutes, then rerun the same `yarn manage init` command.
-The saved initialization resumes without duplicating completed work.
+account. Wait a few minutes, then rerun the same
+`npx @microfeed/cli manage init` command. The saved initialization resumes
+without duplicating completed work.
 
 microfeed enables the free `workers.dev` address, so Worker names are checked
 against its Cloudflare naming rules: 1–63 ASCII letters, numbers, or hyphens,
@@ -322,10 +327,11 @@ project with the same name. Explicit invalid names are rejected before
 Cloudflare authorization. D1 database and R2 bucket names are validated
 separately before resource creation.
 
-If a same-named Worker exists but this clone has no saved state for it, `init`
-stops without overwriting it. Use the exact `yarn manage connect --worker
-<name> --instance <name>` command printed by the error when that Worker is an
-existing microfeed installation. Otherwise, choose a different project name.
+If a same-named Worker exists but the current local management state has no
+saved connection for it, `init` stops without overwriting it. Use the exact
+`npx @microfeed/cli manage connect --worker <name> --instance <name>` command
+printed by the error when that Worker is an existing microfeed installation.
+Otherwise, choose a different project name.
 
 If resource provisioning or the first-password handoff is incomplete, `init`
 resumes only the unfinished work and preserves every recorded resource. When
@@ -333,22 +339,23 @@ the installation and dashboard login are already ready, it stops without
 changing anything and points to `deploy`, `status`, `domain`, and `auth` for
 later management.
 
-## `yarn manage connect`
+## `npx @microfeed/cli manage connect`
 
-**Purpose:** Connect an existing Cloudflare microfeed to this clone.
+**Purpose:** Connect local management state to an existing Cloudflare
+microfeed.
 
 **Changes:** Reads Cloudflare and writes local connection state; does not change
 Cloudflare.
 
 Discover an existing compatible microfeed Worker, including a content-only
 Worker identified by its D1 binding and saved R2 variables, verify its public
-identity, and save it in this clone. Cloudflare is not changed. Connected D1
+identity, and save it in local management state. Cloudflare is not changed. Connected D1
 and any ready R2 resource are marked reused and preserved by later destruction.
 Use `--preview` only after production is connected; it recovers the preview's
 independent Worker and webhook Queue identity under the same saved instance.
 
 ```console
-yarn manage connect [--preview] [--account-id <id>] [--worker <name>] [--instance <name>]
+npx @microfeed/cli manage connect [--preview] [--account-id <id>] [--worker <name>] [--instance <name>]
 ```
 
 | Option | Meaning |
@@ -359,7 +366,7 @@ yarn manage connect [--preview] [--account-id <id>] [--worker <name>] [--instanc
 | `--preview` | Connect the preview Worker after its production instance is connected under the same local name. |
 | `--yes` | Run without selection prompts; requires `--worker` when several matches exist. |
 
-## `yarn manage deploy`
+## `npx @microfeed/cli manage deploy`
 
 **Purpose:** Check, migrate, deploy, and verify a saved installation.
 
@@ -394,7 +401,7 @@ local data, performs the same preparation against local D1, and does not deploy
 or start a server.
 
 ```console
-yarn manage deploy [--instance <name>] [--preview|--local] [--enable-r2] [--enable-webhooks|--disable-webhooks]
+npx @microfeed/cli manage deploy [--instance <name>] [--preview|--local] [--enable-r2] [--enable-webhooks|--disable-webhooks]
 ```
 
 | Option | Meaning |
@@ -409,10 +416,11 @@ yarn manage deploy [--instance <name>] [--preview|--local] [--enable-r2] [--enab
 | `--reuse-r2` | Explicitly approve reuse if the saved bucket name already exists during Cloudflare enablement. `--enable-r2` alone never approves reuse. |
 | `--yes` | Run without optional prompts. Pending R2 remains automatic and content-only unless `--enable-r2` is supplied. |
 
-`deploy` only operates on instances with configuration saved in this clone. If
-the microfeed already exists on Cloudflare, run `yarn manage connect --instance
-<name>` first and select its Worker. If it does not exist yet, run `yarn manage
-init --instance <name>` instead.
+`deploy` only operates on instances with locally saved configuration. If the
+microfeed already exists on Cloudflare, run
+`npx @microfeed/cli manage connect --instance <name>` first and select its
+Worker. If it does not exist yet, run
+`npx @microfeed/cli manage init --instance <name>` instead.
 
 An ordinary deployment does not probe or prompt when media storage is already
 ready or explicitly disabled. For automatic pending setup, `NotEntitled`
@@ -475,8 +483,9 @@ schedules; confirmed destruction removes the exact Queue even when disabled.
 **Changes:** Starts a local server and changes only isolated local D1/R2
 simulation data.
 
-Run the selected site locally after applying local migrations. Even when the
-site is connected to Cloudflare, development uses isolated local D1 and R2
+Run this from a Git-cloned microfeed source repository after `yarn install`.
+The command starts the selected site after applying local migrations. Even when
+the site is connected to Cloudflare, development uses isolated local D1 and R2
 simulations.
 
 ```console
@@ -497,7 +506,7 @@ Cloudflare permission, incurs no Cloudflare Queue or Worker charge, and does
 not change whether preview or production webhooks are enabled. The original
 generated configuration is restored when the development server exits.
 
-## `yarn manage theme`
+## `npx @microfeed/cli manage theme`
 
 **Purpose:** Initialize, install, and manage versioned themes.
 
@@ -509,7 +518,7 @@ Start a new authoring repository from the theme the selected instance is
 actually using:
 
 ```console
-yarn manage theme init ~/microfeed-themes/my-theme --instance <instance-name>
+npx @microfeed/cli manage theme init ~/microfeed-themes/my-theme --instance <instance-name>
 ```
 
 `init` resolves the same effective selection as the live site: a valid active
@@ -536,7 +545,7 @@ version control.
 The generated repository also contains the `develop-microfeed-theme` coding
 agent skill. It exports the rendered theme package, not the build sources of
 the original project. To use microfeed's complete Tailwind/Vite starter, copy
-or clone `themes/default` from the microfeed repository instead.
+`themes/default` from a Git-cloned microfeed source repository instead.
 
 Use `init` to derive a new `local.<name>@0.1.0` identity from the site's
 effective active, imported, or fallback appearance. Use `export` when you want
@@ -544,10 +553,10 @@ an exact installed immutable version and need to preserve its current package
 ID and version:
 
 ```console
-yarn manage theme export --active --instance personal --git --json
+npx @microfeed/cli manage theme export --active --instance personal --git --json
 
 # Or export one explicit immutable version.
-yarn manage theme export <theme-id> --instance personal \
+npx @microfeed/cli manage theme export <theme-id> --instance personal \
   --output .microfeed/themes/example-theme-1.0.0 --git
 ```
 
@@ -600,13 +609,13 @@ current microfeed checkout. The compatibility alias `default` continues to
 resolve to `bundled:default`:
 
 ```console
-yarn manage theme install bundled:default --instance <instance-name>
-yarn manage theme install bundled:podcast --instance <instance-name>
-yarn manage theme install bundled:blog --instance <instance-name>
-yarn manage theme install bundled:photo --instance <instance-name>
-yarn manage theme install bundled:video --instance <instance-name>
-yarn manage theme install bundled:curation --instance <instance-name>
-yarn manage theme install bundled:changelog --instance <instance-name>
+npx @microfeed/cli manage theme install bundled:default --instance <instance-name>
+npx @microfeed/cli manage theme install bundled:podcast --instance <instance-name>
+npx @microfeed/cli manage theme install bundled:blog --instance <instance-name>
+npx @microfeed/cli manage theme install bundled:photo --instance <instance-name>
+npx @microfeed/cli manage theme install bundled:video --instance <instance-name>
+npx @microfeed/cli manage theme install bundled:curation --instance <instance-name>
+npx @microfeed/cli manage theme install bundled:changelog --instance <instance-name>
 ```
 
 The registered keys are `default`, `podcast`, `blog`, `photo`, `video`,
@@ -630,7 +639,7 @@ Worker consumes the grant atomically, updates theme state, and purges the
 `THEME_CURRENT` cache tag. The CLI never needs an Admin password.
 
 ```console
-yarn manage theme <init|install|list|update|activate|deactivate|rollback|export|delete> \
+npx @microfeed/cli manage theme <init|install|list|update|activate|deactivate|rollback|export|delete> \
   [directory|source|theme-id] [options]
 ```
 
@@ -656,40 +665,40 @@ Common examples:
 
 ```console
 # Start a new repository from this instance's effective active theme.
-yarn manage theme init ~/microfeed-themes/my-theme --instance personal
+npx @microfeed/cli manage theme init ~/microfeed-themes/my-theme --instance personal
 
 # Set public package metadata immediately.
-yarn manage theme init ~/microfeed-themes/my-theme --instance personal \
+npx @microfeed/cli manage theme init ~/microfeed-themes/my-theme --instance personal \
   --package-id example.my-theme --name "My theme" --author "Your name"
 
 # Install an inactive GitHub version.
-yarn manage theme install https://github.com/example/microfeed-theme \
+npx @microfeed/cli manage theme install https://github.com/example/microfeed-theme \
   --instance personal
 
 # Reinstall the current Default Built-in release as an inactive version.
-yarn manage theme install bundled:default --instance personal
+npx @microfeed/cli manage theme install bundled:default --instance personal
 
 # Install the current Podcast showcase release as an inactive version.
-yarn manage theme install bundled:podcast --instance personal
+npx @microfeed/cli manage theme install bundled:podcast --instance personal
 
 # Install the Link Digest release, whose search results open original links.
-yarn manage theme install bundled:curation --instance personal
+npx @microfeed/cli manage theme install bundled:curation --instance personal
 
 # Exercise a local checkout without changing the deployed site.
-yarn manage theme install ~/microfeed-themes/my-theme --local --instance personal
+npx @microfeed/cli manage theme install ~/microfeed-themes/my-theme --local --instance personal
 
 # Inspect and activate an installed version.
-yarn manage theme list --instance personal
-yarn manage theme activate <theme-id> --instance personal
+npx @microfeed/cli manage theme list --instance personal
+npx @microfeed/cli manage theme activate <theme-id> --instance personal
 
 # Return to the previous theme, or deactivate to the bundled default fallback.
-yarn manage theme rollback --instance personal
-yarn manage theme deactivate --instance personal
+npx @microfeed/cli manage theme rollback --instance personal
+npx @microfeed/cli manage theme deactivate --instance personal
 
 # Export one exact installed version as a Git-ready standalone repository, or delete it.
-yarn manage theme export --active --instance personal --git --json
-yarn manage theme export <theme-id> --instance personal --git
-yarn manage theme delete <theme-id> --instance personal --confirm <theme-id>
+npx @microfeed/cli manage theme export --active --instance personal --git --json
+npx @microfeed/cli manage theme export <theme-id> --instance personal --git
+npx @microfeed/cli manage theme delete <theme-id> --instance personal --confirm <theme-id>
 ```
 
 The unique key is `(packageId, version)`. Reinstalling the same checksum is a
@@ -716,7 +725,7 @@ Delete an inactive Custom version to free a slot; if Admin installation reaches
 the limit, its draft remains available. `theme list` selects only package and
 source metadata, not the full theme bundles.
 
-## `yarn manage snapshot`
+## `npx @microfeed/cli manage snapshot`
 
 **Purpose:** Create, download, validate, and restore migration-safe portable snapshots.
 
@@ -741,7 +750,7 @@ indicator visible. Its brief status message changes as D1, migrations, R2, and
 verification work advances, then ends with a green success or red failure mark.
 
 ```console
-yarn manage snapshot <create|pull|restore> [options]
+npx @microfeed/cli manage snapshot <create|pull|restore> [options]
 ```
 
 | Option | Meaning |
@@ -760,7 +769,7 @@ yarn manage snapshot <create|pull|restore> [options]
 #### 1. Back up a production instance into one `.tar.gz` file
 
 ```console
-yarn manage snapshot create \
+npx @microfeed/cli manage snapshot create \
   --instance my-podcast-domain-com \
   --output my-podcast-domain-com-backup.tar.gz
 ```
@@ -770,7 +779,7 @@ yarn manage snapshot create \
 ```console
 # No separate .tar.gz download is required first. This command creates a
 # temporary snapshot, restores it into the new local instance, then removes it.
-yarn manage snapshot pull \
+npx @microfeed/cli manage snapshot pull \
   --instance my-podcast-domain-com \
   --local-instance my-podcast-production-copy
 ```
@@ -782,7 +791,7 @@ downloaded snapshot.
 
 ```console
 # The local instance name must be new.
-yarn manage snapshot restore \
+npx @microfeed/cli manage snapshot restore \
   --file my-podcast-domain-com-backup.tar.gz \
   --local \
   --instance my-podcast-archive-copy
@@ -792,7 +801,7 @@ If the snapshot has no administrator account, the completed restore prints the
 exact next step for creating the local dashboard login:
 
 ```console
-yarn manage auth setup \
+npx @microfeed/cli manage auth setup \
   --instance my-podcast-archive-copy
 ```
 
@@ -800,16 +809,16 @@ yarn manage auth setup \
 
 ```console
 # First initialize a fresh remote target with new, nonreused D1 and R2 resources.
-yarn manage init --instance restored-podcast-domain-com
+npx @microfeed/cli manage init --instance restored-podcast-domain-com
 
 # Validate the archive and target without changing Cloudflare data.
-yarn manage snapshot restore \
+npx @microfeed/cli manage snapshot restore \
   --file my-podcast-domain-com-backup.tar.gz \
   --instance restored-podcast-domain-com \
   --dry-run
 
 # Then restore by confirming the exact target instance name.
-yarn manage snapshot restore \
+npx @microfeed/cli manage snapshot restore \
   --file my-podcast-domain-com-backup.tar.gz \
   --instance restored-podcast-domain-com \
   --confirm restored-podcast-domain-com
@@ -819,20 +828,20 @@ yarn manage snapshot restore \
 
 ```console
 # A local .tar.gz handoff is currently required. Download the source first.
-yarn manage snapshot create \
+npx @microfeed/cli manage snapshot create \
   --instance my-podcast-domain-com \
   --output my-podcast-domain-com-backup.tar.gz
 
 # Initialize a fresh target with new, nonreused D1 and R2 resources.
-yarn manage init --instance new-podcast-domain-com
+npx @microfeed/cli manage init --instance new-podcast-domain-com
 
 # Validate the archive and target, then perform the confirmed restore.
-yarn manage snapshot restore \
+npx @microfeed/cli manage snapshot restore \
   --file my-podcast-domain-com-backup.tar.gz \
   --instance new-podcast-domain-com \
   --dry-run
 
-yarn manage snapshot restore \
+npx @microfeed/cli manage snapshot restore \
   --file my-podcast-domain-com-backup.tar.gz \
   --instance new-podcast-domain-com \
   --confirm new-podcast-domain-com
@@ -903,9 +912,9 @@ migration, index, or R2 difference is rejected.
 A successful repair or refresh saves the fingerprint in the local instance
 configuration; the later restore refuses to start if the target changes again.
 It changes no Cloudflare data or D1/R2 ownership flags, and resources already
-marked reused remain protected from `yarn manage destroy`. The dry run never
-imports the snapshot. An incomplete initialization still must be finished
-before restore, while a nonempty or mismatched target is rejected.
+marked reused remain protected from `npx @microfeed/cli manage destroy`. The
+dry run never imports the snapshot. An incomplete initialization still must be
+finished before restore, while a nonempty or mismatched target is rejected.
 
 After an interrupted restore has finished uploading media, rerunning
 `--dry-run` also compares the current R2 inventory with the archive and reports
@@ -931,20 +940,21 @@ normal deployment disables that address again after a successful restore. This
 keeps restore control independent of custom-domain DNS and Access settings.
 
 If the snapshot contains no administrator account, successful local and remote
-restore completion prints the exact `yarn manage auth setup --instance <name>`
-command. Running it asks for the administrator email when needed and creates a
-private one-time browser link for choosing the first password.
+restore completion prints the exact
+`npx @microfeed/cli manage auth setup --instance <name>` command. Running it
+asks for the administrator email when needed and creates a private one-time
+browser link for choosing the first password.
 
 Snapshots include password hashes and possibly private media. They are
 unencrypted and created with owner-only (`0600`) permissions. Store and encrypt
 them according to your backup policy.
 
 Cloudflare snapshot create, pull, and remote restore require a ready production
-R2 bucket and binding. Run `yarn manage deploy --enable-r2` first for a
-content-only installation. Preview initialization is blocked by the same
+R2 bucket and binding. Run `npx @microfeed/cli manage deploy --enable-r2` first
+for a content-only installation. Preview initialization is blocked by the same
 production-R2 requirement.
 
-## `yarn manage status`
+## `npx @microfeed/cli manage status`
 
 **Purpose:** Verify Cloudflare resources, the public site, and dashboard protection.
 
@@ -968,7 +978,7 @@ time. Cloudflare Analytics is operational telemetry rather than a billing
 invoice, so reconcile cost alerts with the account's Queues dashboard.
 
 ```console
-yarn manage status [--instance <name>] [--preview]
+npx @microfeed/cli manage status [--instance <name>] [--preview]
 ```
 
 | Option | Meaning |
@@ -980,7 +990,7 @@ yarn manage status [--instance <name>] [--preview]
 This command is read-only. Missing resources or unsafe protection produce a
 non-zero result with recovery guidance.
 
-## `yarn manage destroy`
+## `npx @microfeed/cli manage destroy`
 
 **Purpose:** Inspect and safely remove a saved Cloudflare deployment.
 
@@ -994,8 +1004,8 @@ address, local folder, actions, and inspection links. If a Queue consumer is
 attached, the plan includes its Worker name and consumer ID.
 
 ```console
-yarn manage destroy --instance <name> --dry-run
-yarn manage destroy --instance <name> --confirm <name>
+npx @microfeed/cli manage destroy --instance <name> --dry-run
+npx @microfeed/cli manage destroy --instance <name> --confirm <name>
 ```
 
 | Option | Meaning |
@@ -1019,7 +1029,7 @@ not the environment-specific Queue. Completed steps are recorded and local
 state is removed last. Rerun the same confirmed command to resume a partial
 removal.
 
-## `yarn manage migrate-pages`
+## `npx @microfeed/cli manage migrate-pages`
 
 **Purpose:** Create a side-by-side Worker migration from Cloudflare Pages.
 
@@ -1031,7 +1041,7 @@ reusing the existing D1 database and R2 bucket. The command does not modify or
 delete Pages; traffic cutover remains manual.
 
 ```console
-yarn manage migrate-pages [--pages-name <name>] [--project-name <name>] [options]
+npx @microfeed/cli manage migrate-pages [--pages-name <name>] [--project-name <name>] [options]
 ```
 
 | Option | Meaning |
@@ -1051,7 +1061,7 @@ yarn manage migrate-pages [--pages-name <name>] [--project-name <name>] [options
 `--preview` is rejected because the new migration Worker is already deployed
 side by side.
 
-## `yarn manage domain`
+## `npx @microfeed/cli manage domain`
 
 **Purpose:** Configure and verify a production custom domain.
 
@@ -1063,7 +1073,7 @@ its workers.dev URL. If the hostname remains attached to a recorded Pages
 project, the command stops and links to the manual Pages detachment screen.
 
 ```console
-yarn manage domain [--instance <name>] [--hostname <hostname>]
+npx @microfeed/cli manage domain [--instance <name>] [--hostname <hostname>]
 ```
 
 | Option | Meaning |
@@ -1075,7 +1085,7 @@ yarn manage domain [--instance <name>] [--hostname <hostname>]
 
 A pending browser password link is replaced with one using the final hostname.
 
-## `yarn manage access`
+## `npx @microfeed/cli manage access`
 
 **Purpose:** Guide and verify optional Cloudflare Access protection.
 
@@ -1088,7 +1098,7 @@ CLI can then verify that the dashboard is intercepted while public routes stay
 available.
 
 ```console
-yarn manage access [--instance <name>] [--preview] [--open]
+npx @microfeed/cli manage access [--instance <name>] [--preview] [--open]
 ```
 
 | Option | Meaning |
@@ -1099,7 +1109,7 @@ yarn manage access [--instance <name>] [--preview] [--open]
 | `--open` | Open the Cloudflare Access application page immediately. |
 | `--yes` | Print instructions without interactive opening or verification prompts. |
 
-## `yarn manage auth`
+## `npx @microfeed/cli manage auth`
 
 **Purpose:** Set up or change the built-in dashboard login and path.
 
@@ -1113,10 +1123,10 @@ When you are already signed in and know the current password, use the
 dashboard's [**Account settings**](/manage/domains-and-access/#change-your-built-in-login)
 for a routine email or password change. Use this command for setup,
 forgotten-password recovery, dashboard-path changes, disabling login, or
-administration from the connected clone.
+administration of the selected saved site.
 
 ```console
-yarn manage auth <setup|reset-password|change-email|change-path|disable> [options]
+npx @microfeed/cli manage auth <setup|reset-password|change-email|change-path|disable> [options]
 ```
 
 | Action | Effect |
@@ -1127,9 +1137,9 @@ yarn manage auth <setup|reset-password|change-email|change-path|disable> [option
 | `change-path` | Redeploy at a new dashboard path; the old path returns 404. |
 | `disable` | Disable built-in protection after a high-visibility warning and immediately revoke the owner's app authorizations and credentials. Locally, the development dashboard opens without login; remotely, the dashboard may become public. |
 
-Without an action, `yarn manage auth` prints its subcommand usage, options, and
-examples. It does not select an instance, inspect authentication state, or
-change anything. Choose `setup`, `reset-password`, `change-email`,
+Without an action, `npx @microfeed/cli manage auth` prints its subcommand usage,
+options, and examples. It does not select an instance, inspect authentication
+state, or change anything. Choose `setup`, `reset-password`, `change-email`,
 `change-path`, or `disable` explicitly.
 
 After an action is selected, the CLI shows a **Dashboard login target** summary
@@ -1174,14 +1184,14 @@ instance whose type cannot be inferred yet.
 Local examples:
 
 ```console
-yarn manage auth change-email \
+npx @microfeed/cli manage auth change-email \
   --instance microfeed-org-local \
   --owner-email new-owner@example.com
 
-yarn manage auth reset-password \
+npx @microfeed/cli manage auth reset-password \
   --instance microfeed-org-local
 
-yarn manage auth disable \
+npx @microfeed/cli manage auth disable \
   --instance microfeed-org-local
 ```
 
@@ -1190,7 +1200,7 @@ Local disable shows a warning unless `--yes` is supplied and does not query or
 modify feed content or R2 data. Both actions revoke app authorizations and credentials in
 the selected D1 database.
 
-## `yarn manage config`
+## `npx @microfeed/cli manage config`
 
 **Purpose:** Validate saved state and generate a local Wrangler configuration.
 
@@ -1202,7 +1212,7 @@ without deployment or a development server. With `--local`, missing local-only
 state and development secrets may be initialized.
 
 ```console
-yarn manage config [--instance <name>] [--preview|--local]
+npx @microfeed/cli manage config [--instance <name>] [--preview|--local]
 ```
 
 | Option | Meaning |
@@ -1211,20 +1221,20 @@ yarn manage config [--instance <name>] [--preview|--local]
 | `--preview` | Generate preview configuration. |
 | `--local` | Generate the local view and ensure local development values exist. |
 
-## `yarn manage instances`
+## `npx @microfeed/cli manage instances`
 
 **Purpose:** List local, managed, and connectable microfeed installations.
 
 **Changes:** Reads local saved state and available Cloudflare Workers; does not
 change Cloudflare.
 
-List local-only sites, Cloudflare sites managed by this clone, and compatible
-Cloudflare Workers available to connect. Output is grouped by account and
+List local-only sites, Cloudflare sites in local management state, and
+compatible Cloudflare Workers available to connect. Output is grouped by account and
 includes each media-storage state and ready-to-run `connect` commands. No
 Cloudflare resources are changed.
 
 ```console
-yarn manage instances [--account-id <id>] [--json]
+npx @microfeed/cli manage instances [--account-id <id>] [--json]
 ```
 
 | Option | Meaning |
@@ -1232,17 +1242,17 @@ yarn manage instances [--account-id <id>] [--json]
 | `--account-id <id>` | Limit Cloudflare discovery to one available account. |
 | `--json` | Print machine-readable `local`, `accounts`, and discovery `messages` groups. |
 
-## `yarn manage use`
+## `npx @microfeed/cli manage use`
 
 **Purpose:** Select the default saved site.
 
-**Changes:** Changes only the active-instance pointer in local repository state.
+**Changes:** Changes only the active-instance pointer in local management state.
 
 Set the active saved site used when later commands omit `--instance`. This
-changes only local repository state.
+changes only local management state.
 
 ```console
-yarn manage use <name>
+npx @microfeed/cli manage use <name>
 ```
 
 | Option | Meaning |
@@ -1252,10 +1262,10 @@ yarn manage use <name>
 ## Built-in help
 
 ```console
-yarn manage
-yarn manage help
-yarn manage help destroy
-yarn manage destroy --help
+npx @microfeed/cli manage
+npx @microfeed/cli manage help
+npx @microfeed/cli manage help destroy
+npx @microfeed/cli manage destroy --help
 ```
 
 Top-level help lists every command. Command help is generated from the same

--- a/docs/manage/backups-and-migrations.md
+++ b/docs/manage/backups-and-migrations.md
@@ -28,7 +28,7 @@ not overwritten. Store the archive like private site data; it can contain
 unpublished content and media.
 
 App-access connections, temporary CLI credentials, and dashboard sessions are
-intentionally not portable. Run `yarn microfeed login <restored-site-url>`
+intentionally not portable. Run `npx @microfeed/cli login <restored-site-url>`
 before managing restored content.
 
 ## Test a production snapshot locally
@@ -49,7 +49,7 @@ target must be a newly initialized, unchanged deployment. First run the exact
 restore with `--dry-run`, inspect the source and target, then use
 `--confirm <target-instance-name>` only when every identifier matches.
 
-See [the canonical snapshot reference](/manage-cli/#yarn-manage-snapshot) for
+See [the canonical snapshot reference](/manage-cli/#npx-microfeedcli-manage-snapshot) for
 eligibility checks, resumable maintenance state, and all options.
 
 ## Migrate an older Pages installation
@@ -70,4 +70,4 @@ Verify the new Worker at its temporary address before moving the custom domain.
 You can move the domain back to Pages if you need to reverse the traffic
 switch; the shared data remains in D1 and R2.
 
-See [the canonical migrate-pages reference](/manage-cli/#yarn-manage-migrate-pages) for all options.
+See [the canonical migrate-pages reference](/manage-cli/#npx-microfeedcli-manage-migrate-pages) for all options.

--- a/docs/manage/index.md
+++ b/docs/manage/index.md
@@ -3,11 +3,12 @@ title: Manage your site
 description: Update, inspect, protect, back up, migrate, and safely remove a microfeed instance.
 ---
 
-Run management commands through `npx @microfeed/cli manage`, or from a local
-microfeed repository clone with `yarn manage`. The launcher keeps its saved
-instance mapping in the platform microfeed configuration directory; a clone
-uses its ignored `.microfeed/` directory. Cloudflare resources and content
-remain in your Cloudflare account.
+Run management commands through `npx @microfeed/cli manage` from any folder.
+If you have a Git-cloned microfeed source repository with dependencies
+installed, `yarn manage` is a shortcut to its local version. The published
+launcher keeps saved instance mappings in the platform microfeed configuration
+directory; the source repository uses its ignored `.microfeed/` directory.
+Cloudflare resources and content remain in your Cloudflare account.
 
 An **instance name** is only the short local label used to select a saved site.
 If the Cloudflare terms below are unfamiliar, start with
@@ -43,6 +44,5 @@ use named API keys and do not reuse the dashboard password or Cloudflare login.
 - Create a snapshot before a high-risk content migration.
 
 The [management CLI reference](/manage-cli/) is authoritative if this
-task-oriented guide and an option listing ever appear to differ. Its
-`yarn manage` examples document the same engine for people already inside a
-clone; the clone-free prefix is `npx @microfeed/cli manage`.
+task-oriented guide and an option listing ever appear to differ. Its examples
+use the recommended `npx @microfeed/cli manage` prefix.

--- a/docs/manage/multiple-instances.md
+++ b/docs/manage/multiple-instances.md
@@ -1,6 +1,6 @@
 ---
 title: Multiple instances
-description: Manage several production, preview, or local microfeed sites from one clone-free launcher.
+description: Manage several production, preview, or local microfeed sites from one published launcher.
 ---
 
 An instance name is the local label that selects one site’s saved configuration.

--- a/docs/manage/remove.md
+++ b/docs/manage/remove.md
@@ -47,4 +47,4 @@ the same management command so its saved journal can report or resume the
 unfinished steps.
 
 For the complete contract, read
-[the `destroy` reference](/manage-cli/#yarn-manage-destroy).
+[the `destroy` reference](/manage-cli/#npx-microfeedcli-manage-destroy).

--- a/docs/manage/update.md
+++ b/docs/manage/update.md
@@ -3,8 +3,9 @@ title: Update microfeed
 description: Bring a connected production instance to the latest source and verify the deployment.
 ---
 
-Use the clone-free launcher or update from a repository clone connected to the
-intended site.
+Use the published launcher from any folder. If you already have a Git-cloned
+microfeed source repository connected to the intended site, you may instead
+use its local `yarn manage` shortcut.
 
 ## Recommended: ask your coding agent
 
@@ -12,21 +13,21 @@ Open a local coding agent and use a prompt that names the saved site or Worker
 when you know it:
 
 ```text
-Run `npx @microfeed/cli manage` and follow every instruction it prints. Connect
-to the microfeed Worker <worker-name> if it is not already saved, deploy the
-latest release, and continue until `status` verifies the site.
+Update the microfeed site <site-url> to the latest release. Start by running
+`npx @microfeed/cli manage`, connect the existing site if needed, deploy the
+update, and continue until `status` verifies the site.
 ```
 
 The launcher obtains the exact release in a private cache. The agent discovers
 saved and compatible existing sites, asks before choosing among candidates,
-connects only if needed, deploys through the same `yarn manage` engine, and
+connects only if needed, deploys through the same management engine, and
 runs a status check. Complete any Cloudflare browser handoffs it requests.
 
-## Manual update from a clone
+## Update from a Git-cloned source repository
 
 First run `git status` and protect any local work. Then fetch and inspect
-upstream changes using your normal Git workflow. Once the clone contains the
-version you intend to run:
+upstream changes using your normal Git workflow. Once the source repository
+contains the version you intend to run:
 
 ```console
 yarn install --immutable
@@ -39,7 +40,7 @@ yarn manage status
 Worker, tags the deployed version with the source commit, deploys, reconciles
 data written during the version switch, and verifies it.
 
-## If this clone is not connected
+## If the source repository is not connected
 
 Do not initialize over an existing Worker. Connect first:
 
@@ -54,5 +55,5 @@ microfeed Worker and saves local connection state.
 
 If deployment stops, read the final error before retrying. The CLI keeps saved
 state for resumable resource changes. If the site still serves the previous
-version, run `yarn manage status` and resolve the reported account, resource, or
-migration problem before another deploy.
+version, run `npx @microfeed/cli manage status` and resolve the reported
+account, resource, or migration problem before another deploy.

--- a/docs/microfeed-cli.md
+++ b/docs/microfeed-cli.md
@@ -5,9 +5,8 @@ description: Canonical commands, options, authentication behavior, output, and s
 
 This is the canonical capability reference for the official
 [`@microfeed/cli` package](https://www.npmjs.com/package/@microfeed/cli),
-including the `yarn microfeed` command available inside a microfeed clone. For
-a shorter workflow, start with
-[Manage content with the microfeed CLI](/automation/cli/).
+including its content commands and `manage` launcher. For a shorter workflow,
+start with [Manage content with the microfeed CLI](/automation/cli/).
 
 This page is intentionally exhaustive. You do not need to read it from top to
 bottom before publishing; use the contents list or built-in `--help` to jump to
@@ -21,23 +20,24 @@ the command you need.
 - [Authentication and safety](#authentication-and-safety)
 - [Command summary](#command-summary)
 - [Global options](#global-options)
-- [`login`](#yarn-microfeed-login)
-- [`logout`](#yarn-microfeed-logout)
-- [`instances`](#yarn-microfeed-instances)
-- [`item`](#yarn-microfeed-item)
-- [`item list`](#yarn-microfeed-item-list)
-- [`item search`](#yarn-microfeed-item-search)
-- [`item get`](#yarn-microfeed-item-get)
-- [`item create`](#yarn-microfeed-item-create)
-- [`item update`](#yarn-microfeed-item-update)
-- [`item delete`](#yarn-microfeed-item-delete)
-- [`media`](#yarn-microfeed-media)
-- [`media upload`](#yarn-microfeed-media-upload)
-- [`webhook`](#yarn-microfeed-webhook)
-- [`webhook scaffold`](#yarn-microfeed-webhook-scaffold)
-- [`webhook listen`](#yarn-microfeed-webhook-listen)
-- [`webhook sample`](#yarn-microfeed-webhook-sample)
-- [`api`](#yarn-microfeed-api)
+- [`manage`](#npx-microfeedcli-manage)
+- [`login`](#npx-microfeedcli-login)
+- [`logout`](#npx-microfeedcli-logout)
+- [`instances`](#npx-microfeedcli-instances)
+- [`item`](#npx-microfeedcli-item)
+- [`item list`](#npx-microfeedcli-item-list)
+- [`item search`](#npx-microfeedcli-item-search)
+- [`item get`](#npx-microfeedcli-item-get)
+- [`item create`](#npx-microfeedcli-item-create)
+- [`item update`](#npx-microfeedcli-item-update)
+- [`item delete`](#npx-microfeedcli-item-delete)
+- [`media`](#npx-microfeedcli-media)
+- [`media upload`](#npx-microfeedcli-media-upload)
+- [`webhook`](#npx-microfeedcli-webhook)
+- [`webhook scaffold`](#npx-microfeedcli-webhook-scaffold)
+- [`webhook listen`](#npx-microfeedcli-webhook-listen)
+- [`webhook sample`](#npx-microfeedcli-webhook-sample)
+- [`api`](#npx-microfeedcli-api)
 - [Output and errors](#output-and-errors)
 - [Saved instances and credentials](#saved-instances-and-credentials)
 - [Environment variables](#environment-variables)
@@ -45,23 +45,25 @@ the command you need.
 
 ## Run the CLI
 
-`@microfeed/cli` requires Node.js 22.12 or newer. Choose the invocation that
-matches where you are working.
+`@microfeed/cli` requires Node.js 22.12 or newer. The recommended invocation
+works from any folder and does not require global installation or a copy of
+microfeed's source code.
 
 | Context | Command | Installation behavior |
 | --- | --- | --- |
-| Inside a microfeed clone | `yarn microfeed …` | Uses the local workspace after the repository's normal `yarn install`. It does not require a CLI build, registry download, or global installation. |
-| Another Yarn project | `yarn add -D @microfeed/cli`, then `yarn microfeed …` | Uses the project-local package and binary. |
-| One-off use | `yarn dlx @microfeed/cli …` | Downloads a temporary package for this run. |
+| Recommended from any folder | `npx @microfeed/cli …` | Downloads the package when needed and reuses npm's cache. |
+| Git-cloned microfeed source repository after `yarn install` | `yarn microfeed …` | Shortcut to that source repository's local CLI version. |
 | Global installation | `npm install --global @microfeed/cli`, then `microfeed …` | Installs one shared executable for regular use across directories. |
 
-The examples below use `yarn microfeed`. Replace that prefix with
-`yarn dlx @microfeed/cli` or `microfeed` when using one of the other modes.
+The examples below use the recommended `npx @microfeed/cli` prefix. If you are
+already working in a Git-cloned microfeed source repository whose dependencies
+are installed, you may replace it with `yarn microfeed` to test that local
+version.
 
 ## Deploy or administer a site
 
-Ask a local coding agent to run the clone-free launcher when you do not have a
-microfeed repository open:
+Ask a local coding agent to run the published launcher from any folder; you do
+not need to Git-clone or open the microfeed source repository:
 
 ```console
 npx @microfeed/cli manage
@@ -84,7 +86,7 @@ npx @microfeed/cli manage status --instance <instance-name>
 ```
 
 Saved deployment state is stored separately from the replaceable source cache.
-The [`yarn manage` reference](/manage-cli/) documents every forwarded command,
+The [management CLI reference](/manage-cli/) documents every forwarded command,
 side effect, confirmation, and recovery path.
 
 To install the command globally and confirm it is available:
@@ -101,8 +103,8 @@ directories.
 
 ## Agent skill
 
-Inside a microfeed clone, repository guidance routes coding agents to the
-canonical `manage-microfeed-content` skill at
+Inside a Git-cloned microfeed source repository, repository guidance routes
+coding agents to the canonical `manage-microfeed-content` skill at
 `.agents/skills/manage-microfeed-content/`. Claude Code enters through the
 root `CLAUDE.md` bridge; compatible agent hosts can discover the skill directly.
 The published npm tarball contains the identical skill at
@@ -162,7 +164,7 @@ For every authenticated REST request, the CLI:
 
 | Command | Purpose | Local or remote change |
 | --- | --- | --- |
-| `manage [command]` | Prepare a clone-free deployment workspace, print the coding-agent handoff, or forward a repository management command. | The bare command updates only the private cache. Forwarded commands retain the effects and safeguards documented in the [`yarn manage` reference](/manage-cli/). |
+| `manage [command]` | Prepare a private deployment workspace, print the coding-agent handoff, or forward a management command without requiring the source repository in the current folder. | The bare command updates only the private cache. Forwarded commands retain the effects and safeguards documented in the [management CLI reference](/manage-cli/). |
 | `login <site-url>` | Authorize the official public CLI client in a browser and save an instance for this computer connection. | Creates or replaces a local encrypted saved instance after browser consent. |
 | `logout` | Revoke this computer's selected credential family and remove its saved instance locally. | Leaves the server-side connection listed as Inactive until the owner revokes it. |
 | `instances list` | List saved instances and the current selection. | Read-only. |
@@ -193,7 +195,13 @@ Global options may appear before or after a command and its arguments.
 When `MICROFEED_API_KEY` is set, `--instance` selects its site URL from a saved
 instance; it does not cause the saved browser credential to be used.
 
-## `yarn microfeed login`
+## `npx @microfeed/cli manage`
+
+Deploy and administer microfeed through the published launcher. See the
+[management CLI reference](/manage-cli/) for every command, option, side
+effect, and safety contract.
+
+## `npx @microfeed/cli login`
 
 **Purpose:** Verify and authorize a microfeed site, then save it as the current
 instance.
@@ -203,7 +211,7 @@ saved instance and makes it current. It does not expose a credential in terminal
 output.
 
 ```console
-yarn microfeed login <site-url> [--instance <name>] [--connection-name <computer-name>]
+npx @microfeed/cli login <site-url> [--instance <name>] [--connection-name <computer-name>]
 ```
 
 | Option | Meaning |
@@ -239,7 +247,7 @@ operating the CLI, it pauses and asks the owner to complete that browser step.
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed login https://feed.example.com \
+npx @microfeed/cli login https://feed.example.com \
   --instance <instance-name> \
   --connection-name "Home Mac"
 ```
@@ -248,7 +256,7 @@ With `--json`, success returns the saved `name`, canonical `siteUrl`, verified
 `instanceId`, and non-secret `connectionName`. It never returns the connection
 ID or a credential.
 
-## `yarn microfeed logout`
+## `npx @microfeed/cli logout`
 
 **Purpose:** Revoke this computer's selected credential family and remove its
 saved instance locally.
@@ -258,7 +266,7 @@ refresh token exists, then deletes the saved instance locally. If it was
 current, the alphabetically first remaining instance becomes current.
 
 ```console
-yarn microfeed logout [--instance <name>]
+npx @microfeed/cli logout [--instance <name>]
 ```
 
 If revocation cannot be delivered, logout still removes the saved instance.
@@ -270,11 +278,11 @@ connections together.
 Use `instances remove` instead when local credentials are unreadable or when
 you intentionally want a local-only removal.
 
-## `yarn microfeed instances`
+## `npx @microfeed/cli instances`
 
 Manage locally saved instances.
 
-## `yarn microfeed instances list`
+## `npx @microfeed/cli instances list`
 
 **Purpose:** List instance names, site URLs, instance IDs in JSON output, and
 the current selection.
@@ -282,24 +290,24 @@ the current selection.
 **Changes:** None.
 
 ```console
-yarn microfeed instances list [--json]
+npx @microfeed/cli instances list [--json]
 ```
 
 Human-readable output marks the current instance with `*`. JSON output returns
 an `instances` array whose entries contain `name`, `siteUrl`, `instanceId`,
 `connectionName`, and `current`.
 
-## `yarn microfeed instances use`
+## `npx @microfeed/cli instances use`
 
 **Purpose:** Select the default saved instance for later commands.
 
 **Changes:** Updates only the local current-instance pointer.
 
 ```console
-yarn microfeed instances use <name> [--json]
+npx @microfeed/cli instances use <name> [--json]
 ```
 
-## `yarn microfeed instances remove`
+## `npx @microfeed/cli instances remove`
 
 **Purpose:** Remove a saved instance locally without decrypting or revoking its
 CLI credentials.
@@ -307,13 +315,13 @@ CLI credentials.
 **Changes:** Deletes the saved instance locally. It does not contact the site.
 
 ```console
-yarn microfeed instances remove <name> [--json]
+npx @microfeed/cli instances remove <name> [--json]
 ```
 
 Use `logout` for the normal revoke-and-remove workflow. Use `remove` for local
 cleanup or recovery when the keychain entry is unavailable.
 
-## `yarn microfeed item`
+## `npx @microfeed/cli item`
 
 List, search, read, create, update, or delete content items. An `<item-id>` is
 the stable ID returned by `item list`, `item search`, or `item get`, such as
@@ -323,17 +331,17 @@ they reject mixed input forms. Delete is permanent and requires an exact
 item-ID confirmation.
 
 ```console
-yarn microfeed item <list|search|get|create|update|delete> [arguments] [options]
+npx @microfeed/cli item <list|search|get|create|update|delete> [arguments] [options]
 ```
 
-## `yarn microfeed item list`
+## `npx @microfeed/cli item list`
 
 **Purpose:** Read a page from `GET /api/v1/feed/`.
 
 **Changes:** None.
 
 ```console
-yarn microfeed item list [options]
+npx @microfeed/cli item list [options]
 ```
 
 | Option | Meaning |
@@ -348,9 +356,9 @@ yarn microfeed item list [options]
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item list --instance <instance-name> --limit 25 --json
+npx @microfeed/cli item list --instance <instance-name> --limit 25 --json
 
-yarn microfeed item list --instance <instance-name> \
+npx @microfeed/cli item list --instance <instance-name> \
   --summary \
   --fields id,title,status \
   --json
@@ -363,14 +371,14 @@ Allowed projected fields are `id`, `title`, `status`, `date_published`,
 field or `_microfeed.status`; it omits channel metadata and unrequested item
 content while retaining pagination.
 
-## `yarn microfeed item search`
+## `npx @microfeed/cli item search`
 
 **Purpose:** Search items and Pages through `GET /api/v1/search/`.
 
 **Changes:** None.
 
 ```console
-yarn microfeed item search <query> [options]
+npx @microfeed/cli item search <query> [options]
 ```
 
 The query contains 1–200 characters. Unquoted terms use implicit AND matching,
@@ -393,21 +401,21 @@ Search only titles for `hello`:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item search hello --fields title --instance <instance-name> --json
+npx @microfeed/cli item search hello --fields title --instance <instance-name> --json
 ```
 
 Search both items and Pages:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item search hello --types items,pages --instance <instance-name> --json
+npx @microfeed/cli item search hello --types items,pages --instance <instance-name> --json
 ```
 
 Keep the shell's outer quotes separate from the exact phrase quotes that the
 search API receives:
 
 ```console
-yarn microfeed item search '"season finale"' \
+npx @microfeed/cli item search '"season finale"' \
   --fields title,content \
   --status published,unlisted \
   --json
@@ -418,14 +426,14 @@ Without `--json`, the response body is formatted on standard output. With
 `body`, including `items`, safe highlight segments, and an optional
 `next_cursor`.
 
-## `yarn microfeed item get`
+## `npx @microfeed/cli item get`
 
 **Purpose:** Read one item by ID or an item-page slug ending in its ID.
 
 **Changes:** None.
 
 ```console
-yarn microfeed item get <item-id> [--unwrap] [--fields <fields>]
+npx @microfeed/cli item get <item-id> [--unwrap] [--fields <fields>]
 ```
 
 | Option | Meaning |
@@ -435,9 +443,9 @@ yarn microfeed item get <item-id> [--unwrap] [--fields <fields>]
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item get 0HGJLSML3P1 --instance <instance-name> --json
+npx @microfeed/cli item get 0HGJLSML3P1 --instance <instance-name> --json
 
-yarn microfeed item get 0HGJLSML3P1 \
+npx @microfeed/cli item get 0HGJLSML3P1 \
   --unwrap \
   --fields id,title,status \
   --instance <instance-name> \
@@ -512,14 +520,14 @@ To reference already-hosted media with JSON input, use one attachment:
 
 Use `category: "external_url"` for a linked web page rather than a file.
 
-## `yarn microfeed item create`
+## `npx @microfeed/cli item create`
 
 **Purpose:** Create an item with `POST /api/v1/items/`.
 
 **Changes:** Creates remote content.
 
 ```console
-yarn microfeed item create [item flags | --input <file|->] \
+npx @microfeed/cli item create [item flags | --input <file|->] \
   [--validate-only | [--idempotency-key <key>] [--verify]]
 ```
 
@@ -531,41 +539,41 @@ yarn microfeed item create [item flags | --input <file|->] \
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item create \
+npx @microfeed/cli item create \
   --instance <instance-name> \
   --title "Release notes" \
   --content-html "<p>What changed.</p>" \
   --status published \
   --json
 
-yarn microfeed item create \
+npx @microfeed/cli item create \
   --instance <instance-name> \
   --input item.json \
   --validate-only \
   --json
 
-yarn microfeed item create \
+npx @microfeed/cli item create \
   --instance <instance-name> \
   --input item.json \
   --idempotency-key 8ca861ab-0383-4f10-bbc2-8c80d8ef29dc \
   --verify \
   --json
 
-yarn microfeed item create \
+npx @microfeed/cli item create \
   --instance <instance-name> \
   --title "Episode 1" \
   --attachment-file ./episode.mp3 \
   --status published \
   --json
 
-yarn microfeed item create \
+npx @microfeed/cli item create \
   --instance <instance-name> \
   --title "Full-resolution photo" \
   --attachment-file ./original.png \
   --status unlisted \
   --json
 
-yarn microfeed item create \
+npx @microfeed/cli item create \
   --instance <instance-name> \
   --title "Photo update" \
   --image-file ./cover.png \
@@ -595,42 +603,42 @@ the normal `{body, headers, ok, status}` envelope with the item itself in
 `body`. If read-back fails, the CLI reports the created ID and exits nonzero so
 an agent can inspect or retry verification without creating a duplicate.
 
-## `yarn microfeed item update`
+## `npx @microfeed/cli item update`
 
 **Purpose:** Replace or update an item with `PUT /api/v1/items/{item-id}/`.
 
 **Changes:** Changes remote content.
 
 ```console
-yarn microfeed item update <item-id> [item flags | --input <file|->]
+npx @microfeed/cli item update <item-id> [item flags | --input <file|->]
 ```
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item update 0HGJLSML3P1 \
+npx @microfeed/cli item update 0HGJLSML3P1 \
   --instance <instance-name> \
   --input - \
   --json < item.json
 
-yarn microfeed item update 0HGJLSML3P1 \
+npx @microfeed/cli item update 0HGJLSML3P1 \
   --instance <instance-name> \
   --attachment-file ./episode.mp3 \
   --json
 
-yarn microfeed item update 0HGJLSML3P1 \
+npx @microfeed/cli item update 0HGJLSML3P1 \
   --instance <instance-name> \
   --image-file ./cover.png \
   --json
 ```
 
-## `yarn microfeed item delete`
+## `npx @microfeed/cli item delete`
 
 **Purpose:** Permanently delete one item.
 
 **Changes:** Deletes remote content after exact-ID confirmation.
 
 ```console
-yarn microfeed item delete <item-id> [--confirm <item-id>]
+npx @microfeed/cli item delete <item-id> [--confirm <item-id>]
 ```
 
 | Option | Meaning |
@@ -643,7 +651,7 @@ exactly equal the positional ID. There is no generic `--yes` option.
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item delete 0HGJLSML3P1 \
+npx @microfeed/cli item delete 0HGJLSML3P1 \
   --instance <instance-name> \
   --confirm 0HGJLSML3P1 \
   --json
@@ -653,20 +661,20 @@ Before an agent runs this command, it must report the selected saved-instance
 name and exact item ID, explain that deletion is permanent, and receive
 approval.
 
-## `yarn microfeed media`
+## `npx @microfeed/cli media`
 
 Upload standalone media for rich content or later use by another documented
 API field.
 
 ```console
-yarn microfeed media upload <file> [--item-id <item-id>]
+npx @microfeed/cli media upload <file> [--item-id <item-id>]
 ```
 
 The upload creates a remote media object and returns its permanent URL. It does
 not edit an item. Use `item --help` when you instead want to set item cover art
 or the main RSS enclosure.
 
-## `yarn microfeed media upload`
+## `npx @microfeed/cli media upload`
 
 **Purpose:** Upload one supported local file and return permanent, safe media
 metadata.
@@ -676,7 +684,7 @@ an item, and an object that is never referenced remains stored because the CLI
 has no media-delete command.
 
 ```console
-yarn microfeed media upload <file> \
+npx @microfeed/cli media upload <file> \
   [--item-id <item-id>] \
   [--instance <name>] \
   [--json]
@@ -698,7 +706,7 @@ For an inline rich-text image, upload first:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed media upload ./diagram.png --instance <instance-name> --json
+npx @microfeed/cli media upload ./diagram.png --instance <instance-name> --json
 ```
 
 ```json
@@ -721,7 +729,7 @@ JSON input:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed item update 0HGJLSML3P1 \
+npx @microfeed/cli item update 0HGJLSML3P1 \
   --instance <instance-name> \
   --input item.json \
   --json
@@ -736,27 +744,27 @@ For non-image media, supply the target item:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed media upload ./episode.mp3 \
+npx @microfeed/cli media upload ./episode.mp3 \
   --item-id 0HGJLSML3P1 \
   --instance <instance-name> \
   --json
 ```
 
-## `yarn microfeed webhook`
+## `npx @microfeed/cli webhook`
 
 Create a local receiver project, inspect an exact OpenAPI example, or receive
 signed webhook deliveries during local development. The CLI does not create a
 microfeed endpoint or provide a public relay.
 
 ```console
-yarn microfeed webhook <scaffold|listen|sample> [arguments] [options]
+npx @microfeed/cli webhook <scaffold|listen|sample> [arguments] [options]
 ```
 
 Use `scaffold` to create code you can extend, `listen` to inspect or forward
 signed deliveries without a project, `sample` to discover an unsigned exact
 payload, and Admin Event Explorer to send a signed, budgeted, retryable test.
 
-## `yarn microfeed webhook scaffold`
+## `npx @microfeed/cli webhook scaffold`
 
 **Purpose:** Copy one complete, offline webhook receiver starter into a new
 local directory.
@@ -767,7 +775,7 @@ performs no authentication. The destination must not already exist; there is
 no overwrite or force option.
 
 ```console
-yarn microfeed webhook scaffold <directory> \
+npx @microfeed/cli webhook scaffold <directory> \
   [--language javascript|python] \
   [--json]
 ```
@@ -791,14 +799,13 @@ store it in `MICROFEED_WEBHOOK_SECRET` through the generated `.env.example`;
 the signing secret is the endpoint authentication, so a second passcode is
 unnecessary.
 
-Inside a microfeed clone, use `.microfeed/webhooks/<endpoint-name>/` as the
-destination. The clone ignores `.microfeed/`, just as it does for local theme
-and instance work, so the development receiver and populated secret files are
-not checked into microfeed. Move a production-hardened receiver into its own
-repository before deploying it. Relative scaffold destinations resolve from
-Yarn's project root. Therefore the root `yarn microfeed` command creates
-`<microfeed-root>/.microfeed/webhooks/endpoint1`, never
-`<microfeed-root>/packages/cli/.microfeed/webhooks/endpoint1`.
+Inside a Git-cloned microfeed source repository, use
+`.microfeed/webhooks/<endpoint-name>/` as the destination. That source
+repository ignores `.microfeed/`, just as it does for local theme and instance
+work, so the development receiver and populated secret files are not checked
+in. Move a production-hardened receiver into its own repository before
+deploying it. Run the following commands from the source repository root;
+`yarn microfeed` is available there as a shortcut to its local CLI version.
 
 ```console
 yarn microfeed webhook scaffold .microfeed/webhooks/endpoint1 \
@@ -813,7 +820,7 @@ install and run with `MICROFEED_WEBHOOK_SECRET` before sending an Event
 Explorer test. The same templates supply Admin quickstart code and
 the OpenAPI webhook operation's JavaScript and Python `x-codeSamples`.
 
-## `yarn microfeed webhook listen`
+## `npx @microfeed/cli webhook listen`
 
 **Purpose:** Start a development receiver, verify Standard Webhooks signatures
 against exact request bytes, print each event, and optionally make the
@@ -825,7 +832,7 @@ temporary Cloudflare Quick Tunnel subprocess and may, with explicit approval,
 download one verified `cloudflared` executable into a versioned microfeed cache.
 
 ```console
-yarn microfeed webhook listen \
+npx @microfeed/cli webhook listen \
   [--secret-file <path>] \
   [--forward-to <url>] \
   [--port <1-65535>] \
@@ -853,7 +860,7 @@ To receive a signed test from a deployed instance without deploying a receiver,
 run:
 
 ```console
-yarn microfeed webhook listen --tunnel
+npx @microfeed/cli webhook listen --tunnel
 ```
 
 Plain `webhook listen` remains loopback-only. Tunnel mode first looks for
@@ -888,14 +895,14 @@ timeout. A duplicate delivery ID is marked in human or NDJSON output but is
 still forwarded so the target's own deduplication can be tested.
 
 ```console
-yarn microfeed webhook listen
+npx @microfeed/cli webhook listen
 
-yarn microfeed webhook listen --tunnel
+npx @microfeed/cli webhook listen --tunnel
 
 MICROFEED_WEBHOOK_SECRET=whsec_... \
-  yarn microfeed webhook listen --json
+  npx @microfeed/cli webhook listen --json
 
-yarn microfeed webhook listen \
+npx @microfeed/cli webhook listen \
   --secret-file .webhook-secret \
   --forward-to http://127.0.0.1:3000/hooks/microfeed
 ```
@@ -904,7 +911,7 @@ See [Test webhooks without code](/webhooks/testing/) for the local and deployed
 signed-testing workflows. See [Webhooks and integrations](/webhooks/) for
 enablement, endpoint creation, and safe shutdown.
 
-## `yarn microfeed webhook sample`
+## `npx @microfeed/cli webhook sample`
 
 **Purpose:** Print the exact named example published by one instance's
 generated OpenAPI webhook operation.
@@ -913,7 +920,7 @@ generated OpenAPI webhook operation.
 documentation and writes the example to standard output.
 
 ```console
-yarn microfeed webhook sample <event> [--instance <name>] [--json]
+npx @microfeed/cli webhook sample <event> [--instance <name>] [--json]
 ```
 
 Use an exact event type such as `item.published`,
@@ -931,17 +938,17 @@ side effects.
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed webhook sample item.published
-yarn microfeed webhook sample page.navigation_updated --instance <instance-name> --json
+npx @microfeed/cli webhook sample item.published
+npx @microfeed/cli webhook sample page.navigation_updated --instance <instance-name> --json
 MICROFEED_URL=http://127.0.0.1:4321 \
-  yarn microfeed webhook sample webhook.test --json
+  npx @microfeed/cli webhook sample webhook.test --json
 ```
 
 If the contract is unavailable, enable **Publish API docs** in **Admin → API →
 API Settings**, or inspect the same canonical examples in **Admin → Webhooks →
 Event explorer**.
 
-## `yarn microfeed api`
+## `npx @microfeed/cli api`
 
 **Purpose:** Call a documented REST operation while the CLI selects, injects,
 and refreshes credentials.
@@ -949,7 +956,7 @@ and refreshes credentials.
 **Changes:** Depend on the HTTP method and API endpoint.
 
 ```console
-yarn microfeed api <method> </api/v1/path> \
+npx @microfeed/cli api <method> </api/v1/path> \
   [--input <file|->] \
   [--header <name:value>]…
 ```
@@ -972,11 +979,11 @@ Quote paths containing `?` or `&` so the shell passes them as one argument.
 
 ```console
 # Replace <instance-name> with a saved instance name.
-yarn microfeed api GET "/api/v1/feed/?limit=3" \
+npx @microfeed/cli api GET "/api/v1/feed/?limit=3" \
   --instance <instance-name> \
   --json
 
-yarn microfeed api POST /api/v1/items/ \
+npx @microfeed/cli api POST /api/v1/items/ \
   --instance <instance-name> \
   --input item.json \
   --header "Content-Type: application/json" \
@@ -1085,17 +1092,17 @@ generated example, or agent conversation.
 
 ```console
 npx @microfeed/cli manage --help
-yarn microfeed --help
-yarn microfeed help
-yarn microfeed login --help
-yarn microfeed instances use -h
-yarn microfeed item create --help
-yarn microfeed help item delete
-yarn microfeed webhook scaffold --help
-yarn microfeed webhook sample --help
-yarn microfeed media upload --help
-yarn microfeed webhook listen --help
-yarn microfeed api --help
+npx @microfeed/cli --help
+npx @microfeed/cli help
+npx @microfeed/cli login --help
+npx @microfeed/cli instances use -h
+npx @microfeed/cli item create --help
+npx @microfeed/cli help item delete
+npx @microfeed/cli webhook scaffold --help
+npx @microfeed/cli webhook sample --help
+npx @microfeed/cli media upload --help
+npx @microfeed/cli webhook listen --help
+npx @microfeed/cli api --help
 ```
 
 Top-level help defines inputs such as `<site-url>`, `<name>`, `<item-id>`, and

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -82,10 +82,12 @@ A publishing mode in which software consumes RSS, JSON Feed, or the API while a
 different website or app presents the content. microfeed can hide its generated
 web pages without deleting the content.
 
-**Git clone**
-A local copy of this repository containing the source code and project-owned
-`yarn manage` tool. It is optional for people using the clone-free
-`npx @microfeed/cli manage` launcher.
+**Git-cloned microfeed source repository**
+An optional local copy of microfeed's source code created with `git clone
+https://github.com/microfeed/microfeed.git`. After dependencies are installed,
+it provides `yarn manage` and `yarn microfeed` as shortcuts to the source
+repository's local CLI versions. The recommended published commands do not
+require this source repository.
 
 **Instance**
 The locally saved connection to one production, preview, or local microfeed
@@ -161,8 +163,9 @@ producing production side effects.
 
 **Wrangler**
 Cloudflare’s command-line tool. microfeed invokes it behind
-`npx @microfeed/cli manage`, or `yarn manage` inside a clone; people and agents
-should not replace management workflows with improvised Wrangler commands.
+`npx @microfeed/cli manage`, or behind `yarn manage` inside a Git-cloned
+microfeed source repository; people and agents should not replace management
+workflows with improvised Wrangler commands.
 
 **workers.dev address**
 The free Cloudflare-provided web address for a Worker. A microfeed site can use

--- a/docs/start-here/after-deploy.md
+++ b/docs/start-here/after-deploy.md
@@ -7,9 +7,10 @@ Use this checklist after deployment completes.
 
 ## Confirm the site is healthy
 
-Run `npx @microfeed/cli manage status`, or `yarn manage status` from the same
-repository clone. Confirm the displayed hosted application, database,
-media-storage state, and dashboard protection match what you expected.
+Run `npx @microfeed/cli manage status`. Confirm the displayed hosted
+application, database, media-storage state, and dashboard protection match what
+you expected. If you deployed from a Git-cloned microfeed source repository,
+`yarn manage status` runs its local version of the same check.
 
 Open these public addresses:
 
@@ -35,19 +36,21 @@ and JSON feeds. You can publish it yourself in the Admin dashboard. To publish
 with a coding agent, first [enable API access and connect the
 CLI](/automation/cli/), then ask the agent to use the official
 [`@microfeed/cli`](https://www.npmjs.com/package/@microfeed/cli). Inside a
-clone, the agent should run `yarn microfeed`; elsewhere it can use the
-published package. You remain responsible for browser authorization and
-approval of destructive actions. Delete or unpublish the test when finished.
+Git-cloned microfeed source repository with installed dependencies, the agent
+may use `yarn microfeed` as a shortcut; otherwise it should run the published
+`npx @microfeed/cli` command. You remain responsible for browser authorization
+and approval of destructive actions. Delete or unpublish the test when finished.
 
 Next: [compare the dashboard and agent publishing workflows](/dashboard/publish/).
 
 ## Save the local connection
 
-The clone-free launcher stores instance connections in the platform microfeed
-configuration directory, separately from its replaceable cache. A repository
-clone instead uses its ignored `.microfeed/` directory. Keep either workspace
-on a trusted computer; the read-only `connect` workflow can reconnect to an
-existing compatible microfeed Worker when local state is unavailable.
+The published launcher stores instance connections in the platform microfeed
+configuration directory, separately from its replaceable source cache. A
+Git-cloned microfeed source repository instead uses its ignored `.microfeed/`
+directory. Keep either workspace on a trusted computer; the read-only
+`connect` workflow can reconnect to an existing compatible microfeed Worker
+when local state is unavailable.
 
 ## Optional next steps
 

--- a/docs/start-here/ai-agent.md
+++ b/docs/start-here/ai-agent.md
@@ -5,8 +5,9 @@ description: The recommended three-step route to a new microfeed site.
 
 Use a local coding agent that can run terminal commands and open browser pages.
 The published launcher prepares an exact microfeed release in a private cache,
-then directs the agent to the same guarded `yarn manage` engine available to
-people. You do not need to clone or open the source repository.
+then directs the agent to the same guarded management engine available in the
+microfeed source repository. You do not need to Git-clone or open that source
+repository yourself.
 
 ## 1. Open a local coding agent
 
@@ -23,8 +24,8 @@ recovery step when one is unavailable.
 Paste this prompt:
 
 ```text
-Run `npx @microfeed/cli manage` and follow every instruction it prints until
-`status` verifies the deployment.
+Deploy microfeed to Cloudflare. Start by running `npx @microfeed/cli manage`,
+then follow its instructions until deployment is verified.
 ```
 
 The first run downloads the exact release matching `@microfeed/cli`, creates a

--- a/docs/start-here/concepts.md
+++ b/docs/start-here/concepts.md
@@ -9,8 +9,9 @@ dashboard to publish content, while coding agents can use the official
 the public site or subscribe to its feeds.
 
 You do not need to operate these Cloudflare services separately during normal
-use. The clone-free `npx @microfeed/cli manage` launcher creates, connects,
-updates, and checks them as one microfeed site.
+use. Run `npx @microfeed/cli manage` from any folder to create, connect, update,
+and check them as one microfeed site without first Git-cloning microfeed's
+source repository yourself.
 
 ## The important words
 
@@ -34,15 +35,16 @@ for uploaded images, audio, video, documents, and packaged theme assets. It is
 optional: a content-only installation can publish text and link to files hosted
 elsewhere without enabling R2.
 
-**Repository clone** is an optional local copy of microfeed’s source code. It
-includes the project-owned `yarn manage` command for contributors and people
-who prefer the manual deployment workflow. A clone is not required when using
-the published management launcher.
+**Git-cloned microfeed source repository** is an optional local copy created
+with `git clone https://github.com/microfeed/microfeed.git`. After its
+dependencies are installed, it provides `yarn manage` and `yarn microfeed` as
+shortcuts to the repository's local CLI versions. You do not need this source
+repository when using the published `npx` commands.
 
 **Instance** is the short local name that selects one saved microfeed site. The
 name is not a Cloudflare login or website address. The launcher can remember
-several instances without putting state in your current folder; a repository
-clone keeps its own instance state instead.
+several instances without putting state in your current folder; a Git-cloned
+microfeed source repository keeps its own instance state instead.
 
 **Admin dashboard** is the private management area where you create items,
 upload media, and customize the channel. It is separate from the public site.
@@ -83,12 +85,12 @@ API docs are enabled.
 ## What the local management tool changes
 
 `npx @microfeed/cli manage` prepares the matching microfeed release in a private
-cache and runs the same guarded management engine used by `yarn manage` inside
-a clone. It checks for name collisions, applies database migrations, builds the
-application, deploys it, and verifies the result. Launcher connection details
-live in the platform microfeed configuration directory, separate from the
-replaceable source cache.
+cache and runs the same guarded management engine available through `yarn
+manage` inside a Git-cloned microfeed source repository. It checks for name
+collisions, applies database migrations, builds the application, deploys it,
+and verifies the result. Launcher connection details live in the platform
+microfeed configuration directory, separate from the replaceable source cache.
 
 For exact behavior and safety rules, use the
-[management CLI reference](/manage-cli/). Its `yarn manage` examples map to the
-clone-free `npx @microfeed/cli manage` prefix.
+[management CLI reference](/manage-cli/). Its examples use the recommended
+`npx @microfeed/cli manage` prefix.

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -28,8 +28,8 @@ You need:
 2. Ask the agent:
 
    ```text frame="terminal" wrap
-   Run `npx @microfeed/cli manage` and follow every instruction it prints
-   until `status` verifies the deployment.
+   Deploy microfeed to Cloudflare. Start by running `npx @microfeed/cli manage`,
+   then follow its instructions until deployment is verified.
    ```
 
 3. Stay nearby while the agent works. The first command downloads the exact
@@ -66,6 +66,7 @@ For screenshots, browser handoffs, and recovery steps, continue to
 
 ## Prefer to use the terminal yourself?
 
-Follow [Deploy manually](./manual/) to clone the repository and run the same
-guided `yarn manage` workflow without an agent. If Worker, D1, or R2 are unfamiliar terms, read
-[How microfeed works](./concepts/) before installing.
+Follow [Deploy manually](./manual/) to run the same guided
+`npx @microfeed/cli manage` workflow without an agent or a copy of the
+microfeed source code. If Worker, D1, or R2 are unfamiliar terms, read [How
+microfeed works](./concepts/) before installing.

--- a/docs/start-here/manual.md
+++ b/docs/start-here/manual.md
@@ -1,29 +1,23 @@
 ---
 title: Deploy manually
-description: Install microfeed by running the guided yarn manage commands yourself.
+description: Install microfeed by running the guided management commands yourself.
 ---
 
 This path uses the terminal directly. The prompts explain the available choices
 and the CLI stops before unsafe collisions or ambiguous account selection.
 You do not need prior Cloudflare command-line experience.
 
-## 1. Install the project
+## 1. Prepare your computer
 
-```console
-git clone https://github.com/microfeed/microfeed.git
-cd microfeed
-corepack enable
-yarn install --immutable
-```
-
-`corepack enable` makes the repository’s declared Yarn version available.
-Expected result: dependency installation completes without changing
-`yarn.lock`.
+Install Node.js 22.12 or newer with npm, plus Git and Corepack. You do not need
+to download or Git-clone the microfeed source repository yourself. The
+published launcher checks these prerequisites and prepares the matching release
+in a private operating-system cache.
 
 ## 2. Discover your Cloudflare account
 
 ```console
-yarn manage accounts
+npx @microfeed/cli manage accounts
 ```
 
 Your browser may open for Cloudflare authorization. If the command lists more
@@ -33,7 +27,7 @@ only on list position.
 ## 3. Initialize the site
 
 ```console
-yarn manage init
+npx @microfeed/cli manage init
 ```
 
 Follow the prompts for the Cloudflare account, distinctive site name,
@@ -52,15 +46,23 @@ shared document.
 ## 5. Check the deployment
 
 ```console
-yarn manage status
+npx @microfeed/cli manage status
 ```
 
 Expected result: a verified hosted application and dashboard status, plus the
 exact D1 and R2 resources attached to the saved instance.
 
 :::tip[Need every option?]
-The [`yarn manage` reference](/manage-cli/) is the canonical contract for all
+The [management CLI reference](/manage-cli/) is the canonical contract for all
 commands, options, side effects, and safeguards.
 :::
+
+## Shortcut from the source repository
+
+If you already have a Git-cloned microfeed source repository and have run
+`yarn install`, you can replace the `npx @microfeed/cli manage` prefix above
+with `yarn manage`. This runs that source repository's local version of the
+same management engine; a Git-cloned microfeed source repository is not
+required for deployment.
 
 Next: [complete the post-deployment checklist](../after-deploy/).

--- a/docs/theme-kit-cli.md
+++ b/docs/theme-kit-cli.md
@@ -9,7 +9,7 @@ It creates, validates, tests, and previews a theme package on your computer. It
 does not deploy microfeed, install a theme into an instance, or activate a live
 theme.
 
-Use [`npx @microfeed/cli manage theme`](/manage-cli/#yarn-manage-theme) from any
+Use [`npx @microfeed/cli manage theme`](/manage-cli/#npx-microfeedcli-manage-theme) from any
 folder for instance operations such as export, install, update, activation,
 rollback, and deletion. See [Build and release a theme](/themes/) for the
 authoring workflow, [Theme contract and rendering](/themes/contract/) for the

--- a/docs/themes/index.md
+++ b/docs/themes/index.md
@@ -170,7 +170,7 @@ package ID and version for different content. Delete only inactive versions
 that are no longer needed.
 
 See the canonical [management CLI theme
-reference](/manage-cli/#yarn-manage-theme) for source selection, local and
+reference](/manage-cli/#npx-microfeedcli-manage-theme) for source selection, local and
 preview environments, update, rollback, export, and deletion behavior.
 
 ## Verify the release

--- a/docs/webhooks/endpoints.md
+++ b/docs/webhooks/endpoints.md
@@ -10,11 +10,12 @@ slow effects happen after acceptance.
 
 ## Start from a runnable receiver
 
-Inside a microfeed clone, scaffold a local JavaScript inspector under the
-ignored `.microfeed/` workspace:
+From any folder, scaffold a local JavaScript inspector. If you are working in
+a Git-cloned microfeed source repository, its ignored `.microfeed/` workspace
+is a convenient destination:
 
 ```console
-yarn microfeed webhook scaffold .microfeed/webhooks/endpoint1 \
+npx @microfeed/cli webhook scaffold .microfeed/webhooks/endpoint1 \
   --language javascript
 ```
 
@@ -141,7 +142,7 @@ Headers, preview generated or current content, and send a signed test. From a
 terminal, print the same unsigned example with:
 
 ```console
-yarn microfeed webhook sample item.published --json
+npx @microfeed/cli webhook sample item.published --json
 ```
 
 Before creating a receiver project, follow [Test webhooks without code](../testing/)

--- a/docs/webhooks/index.md
+++ b/docs/webhooks/index.md
@@ -49,16 +49,18 @@ its installed microfeed version and event catalog exactly.
 
 ### Local development
 
-Plain `npx @microfeed/cli manage dev` automatically starts Wrangler's isolated Queue simulation,
-consumer, maintenance trigger, and local signing-secret encryption. It creates
-no Cloudflare resources, requests no Cloudflare permissions, and incurs no
-Cloudflare Queue or Worker charges. `npx @microfeed/cli manage dev --enable-webhooks` is accepted as
-an explicit alias, but the flag is not required and does not change preview or
-production. To omit Queue and Cron simulation for one run, use:
+From a Git-cloned microfeed source repository with dependencies installed,
+plain `yarn manage dev` automatically starts Wrangler's isolated Queue
+simulation, consumer, maintenance trigger, and local signing-secret encryption.
+It creates no Cloudflare resources, requests no Cloudflare permissions, and
+incurs no Cloudflare Queue or Worker charges. The explicit
+`yarn manage dev --enable-webhooks` form is also accepted, but the flag is not
+required and does not change preview or production. To omit Queue and Cron
+simulation for one run, use:
 
 ```console
 # Replace <instance-name> with a saved instance name.
-npx @microfeed/cli manage dev --disable-webhooks --instance <instance-name>
+yarn manage dev --disable-webhooks --instance <instance-name>
 ```
 
 This local-only flag does not change the next local run or either deployed
@@ -91,10 +93,9 @@ saved instance name. Expand only the environment you intend to change.
 <summary>Production coding-agent prompt</summary>
 
 ```text
-Run `npx @microfeed/cli manage` and follow every instruction it prints to
-enable production webhooks for my existing microfeed instance
-"<instance-name>". Confirm the exact instance and production environment, then
-run:
+Enable production webhooks for my existing microfeed instance
+"<instance-name>". Start by running `npx @microfeed/cli manage`, then follow its
+instructions. Confirm the exact instance and production environment, then run:
 
 npx @microfeed/cli manage deploy --enable-webhooks --instance <instance-name>
 
@@ -111,8 +112,8 @@ dashboard password.
 <summary>Preview coding-agent prompt</summary>
 
 ```text
-Run `npx @microfeed/cli manage` and follow every instruction it prints to
-enable preview webhooks for my existing microfeed instance "<instance-name>".
+Enable preview webhooks for my existing microfeed instance "<instance-name>".
+Start by running `npx @microfeed/cli manage`, then follow its instructions.
 Confirm the exact instance and preview environment, then run:
 
 npx @microfeed/cli manage deploy --preview --enable-webhooks --instance <instance-name>
@@ -188,7 +189,8 @@ deletion.
 
 ## Create and test an endpoint
 
-For the shortest local path:
+For the shortest local path, work from a Git-cloned microfeed source repository
+after `yarn install`:
 
 1. Scaffold a JavaScript or Python receiver under the ignored `.microfeed/`
    workspace:
@@ -221,7 +223,7 @@ before deploying real actions.
 To inspect signed deliveries without creating a receiver project, follow [Test
 webhooks without code](./testing/). It covers the loopback-only `webhook listen`
 workflow for a local site and the temporary `--tunnel` workflow for a deployed
-site. Use `yarn microfeed webhook sample <event> --json` to read an unsigned
+site. Use `npx @microfeed/cli webhook sample <event> --json` to read an unsigned
 exact example from the instance's OpenAPI contract.
 
 ## Authentication and limits

--- a/docs/webhooks/operations.md
+++ b/docs/webhooks/operations.md
@@ -108,7 +108,7 @@ telemetry. The Cloudflare Queues dashboard is the final place to inspect Queue
 health and billing-related usage.
 
 The deployment contract owns reconciliation, retention, and Worker binding
-details. See the [management CLI deploy reference](/manage-cli/#yarn-manage-deploy)
+details. See the [management CLI deploy reference](/manage-cli/#npx-microfeedcli-manage-deploy)
 when diagnosing provisioning or maintenance behavior instead of depending on
 those implementation details in a receiver.
 

--- a/docs/webhooks/testing.md
+++ b/docs/webhooks/testing.md
@@ -14,16 +14,18 @@ does not create or edit that endpoint for you.
 
 ## Choose a listener mode
 
-- **Local development:** Run `npx @microfeed/cli webhook listen` and register
+- **Local development:** From the Git-cloned microfeed source repository, run
+  `yarn microfeed webhook listen` and register
   `http://127.0.0.1:8978/webhook`. The endpoint is reachable only from this
   computer.
 - **Deployed preview or production:** Run `npx @microfeed/cli webhook listen
   --tunnel` and register the random HTTPS URL printed by the CLI. The endpoint
   is public only while the command runs.
 
-Run either command from any folder. Event
-Explorer sends are real signed deliveries that use the normal Queue, retry
-policy, delivery history, and daily budget. Previewing an event does not send a
+Run the local-development command from the microfeed source repository after
+`yarn install`. The deployed-site command works from any folder. Event Explorer
+sends are real signed deliveries that use the normal Queue, retry policy,
+delivery history, and daily budget. Previewing an event does not send a
 delivery.
 
 ## Test a local development site
@@ -31,10 +33,10 @@ delivery.
 Plain `webhook listen` starts a loopback-only receiver. It does not expose your
 computer to the internet or require `cloudflared`.
 
-1. From any folder, start the listener:
+1. From the Git-cloned microfeed source repository, start the listener:
 
    ```console
-   npx @microfeed/cli webhook listen
+   yarn microfeed webhook listen
    ```
 
 2. Open the local site's **Admin → Webhooks → Endpoints** page, choose **Add
@@ -97,7 +99,7 @@ for the production architecture.
 
 ## Use listener options
 
-The [`webhook listen` CLI reference](/microfeed-cli/#yarn-microfeed-webhook-listen)
+The [`webhook listen` CLI reference](/microfeed-cli/#npx-microfeedcli-webhook-listen)
 documents every option, including `--secret-file`, `--forward-to`, `--json`,
 `--install-cloudflared`, and `--cloudflared-path`. Use those options when you
 need non-interactive secret input, machine-readable output, forwarding to a


### PR DESCRIPTION
## Summary

- Make the published `npx @microfeed/cli` commands the recommended path throughout the README and documentation, including one consistent deployment prompt.
- Define a Git-cloned microfeed source repository explicitly and present `yarn microfeed` and `yarn manage` as its local-version shortcuts.
- Prefer repository-local Yarn commands for microfeed source development while retaining published `npx` commands for deployment, administration, snapshots, themes, and deployed-site workflows.
- Add `manage` to the `@microfeed/cli` command reference and update navigation labels, headings, and internal reference links.

## Related issue

N/A.

## Testing

- [x] `yarn docs:check`
- [x] `git diff --check`
- [x] `yarn check`

## Screenshots

N/A — documentation-only command and prose changes; no screenshots requested.

## Risks

Low. Runtime and CLI behavior are unchanged. Command-reference heading anchors changed to match the recommended invocation; all repository links and generated documentation were verified by the documentation build.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed. N/A: no runtime behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
