### PR TITLE
Bundle deployment runtime with published CLI

### DIFF
--- a/.agents/skills/deploy-microfeed/SKILL.md
+++ b/.agents/skills/deploy-microfeed/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-microfeed
-description: Deploy and administer microfeed through the clone-free @microfeed/cli launcher or the project-owned yarn manage CLI. Use when a user asks a coding agent to operate a local or Cloudflare instance, including accounts, initialization, connection, development, deployment, themes, snapshots, status, destruction, Pages migration, domains, Access, built-in authentication, configuration, or instance selection.
+description: Deploy and administer microfeed through the source-code-free @microfeed/cli launcher or the project-owned yarn manage CLI. Use when a user asks a coding agent to operate a local or Cloudflare instance, including accounts, initialization, connection, development, deployment, themes, snapshots, status, destruction, Pages migration, domains, Access, built-in authentication, configuration, or instance selection.
 ---
 
 # Deploy microfeed
@@ -18,7 +18,7 @@ side-effect contract; keep this skill focused on agent sequencing and safety.
 
 microfeed supports one deployment engine. A person may run `yarn manage` from
 a trusted clone, or a local coding agent may use `npx @microfeed/cli manage` to
-download the exact release into a private cache and forward commands to that
+copy the exact bundled release into a private cache and forward commands to that
 engine. Do not offer Cloudflare repository imports, Workers Builds, deploy
 buttons, GitHub Actions, raw Wrangler deploys, or API-token deployment as
 alternatives. If a user asks for a dashboard-only or hosted deployment,
@@ -53,9 +53,10 @@ Choose one command prefix for the session:
 - In a user-managed clone, inspect `git status --short` before deploying. If
   the working tree is dirty, identify that the current files will be built and
   obtain explicit approval to deploy them. Do not modify, discard, or stash
-  the changes. The clone-free launcher instead verifies a clean exact release
-  tag before every forwarded command and recreates only its private source
-  cache when that verification fails; never edit the launcher cache.
+  the changes. The published launcher instead verifies the file manifest for
+  the exact release bundled with `@microfeed/cli` before every forwarded
+  command and recreates only its private source cache when verification fails;
+  never edit the launcher cache.
 - Treat changes to `package.json`, `yarn.lock`, `.yarn/`, `manage-cli/`,
   `wrangler.jsonc`, `wrangler.template.jsonc`, `astro.config.ts`, or this skill
   as security-sensitive because deployment executes or trusts them. Inspect
@@ -205,18 +206,20 @@ never recreate, rename, adopt, purge, resume, or delete the Queue outside
 
 ## Prepared-workspace workflow
 
-1. When the clone-free launcher handed off this skill, use its printed cached
+1. When the published launcher handed off this skill, use its printed cached
    repository and reference paths and keep using the public `npx` command
-   prefix. The launcher has already verified the exact release tag, checked
-   that its source is clean, and run `yarn install --immutable`; do not edit the
+   prefix. The launcher has already verified the bundled release source and run
+   `yarn install --immutable` with its pinned Yarn runtime; do not edit the
    cached source or run a second checkout. In a user-managed clone, confirm the
    repository root contains `package.json`, `yarn.lock`, and
    `manage-cli/index.ts`.
-2. Require Node.js 22.12 or newer with npm, plus Git and Corepack. The
-   clone-free launcher checks these prerequisites itself and creates a private
-   Yarn shim without changing the global installation. In a user-managed clone,
-   check the tools directly and obtain approval before a command writes outside
-   the workspace.
+2. Require Node.js 22.12 or newer with npm for the public `npx` invocation.
+   Ordinary deployment through the published launcher does not require Git or
+   Corepack. Git is command-specific for installing or updating a theme from
+   GitHub, initializing a theme repository unless `--no-git` is passed, and
+   `theme export --git`. In a user-managed clone, check its normal development
+   tools directly and obtain approval before a command writes outside the
+   workspace.
 3. In a user-managed clone, before any command receives OAuth input, obtain
    network approval and run `yarn install --immutable --check-cache`. This must
    revalidate the locked packages and relink local dependencies even when
@@ -339,7 +342,7 @@ never recreate, rename, adopt, purge, resume, or delete the Queue outside
 
 ## Existing installations
 
-With clone-free launcher state, start with `accounts --json`; when several
+With published-launcher state, start with `accounts --json`; when several
 accounts are available, show their names and ID suffixes and ask the user to
 select one. Then run `instances --account-id <account-id> --json`. Use the
 selected saved instance when one exists. Otherwise show every exact compatible

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@
   `npx @microfeed/cli manage` and `npx @microfeed/cli manage dev`.
 - Do not use or recommend Cloudflare repository imports, Workers Builds,
   deploy buttons, GitHub Actions, or API-token deployment. People and agents
-  can use the clone-free launcher without creating a local source checkout.
+  can use the published launcher without creating a local source checkout.
 - Treat `docs/manage-cli.md` as the canonical command, option, side-effect, and
   safety reference for both people and agents. Read the relevant command
   section before using an unfamiliar or destructive option. Keep that reference

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,19 +86,19 @@ secrets.
 
 ## Prepare release metadata
 
-Set the application, published CLI, theme kit, bundled default theme, and
-compatible starter range with one command:
+Set the application, published CLI, theme kit, and compatible starter range
+with one command:
 
 ```console
 yarn version:set 1.2.3
-yarn theme:release
 ```
 
 Use an exact semantic version. The command verifies every target before it
-writes anything. `yarn theme:release` records the bundled theme's immutable
-canonical checksum and refuses to replace any released version. Private
-workspace metadata, examples, fixtures, tests, and the lockfile do not need
-patch-release edits.
+writes anything. Bundled themes have their own immutable versions; when a
+bundled theme changes, increment that theme's version and run
+`yarn theme:release` to record its canonical checksum. Private workspace
+metadata, examples, fixtures, tests, and the lockfile do not need patch-release
+edits.
 
 ## Open a pull request
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ Deploy microfeed to Cloudflare. Start by running `npx @microfeed/cli manage`,
 then follow its instructions until deployment is verified.
 ```
 
-That's it. The launcher requires Node.js 22.12 or newer with npm, Git, and
-Corepack. It downloads the exact microfeed release and locked dependencies into
-a private cache instead of creating source files in your current folder. The
+That's it. The launcher requires Node.js 22.12 or newer with npm. It carries
+the exact microfeed release and Yarn runtime, verifies and copies that source
+into a private cache, and installs its locked dependencies without requiring
+Git or Corepack. It does not create source files in your current folder. The
 first setup may use about 1.3 GB and take several minutes; later runs reuse it.
 The agent guides the setup, runs the deployment, and verifies the finished
 site. You only step in for Cloudflare browser authorization, choices that

--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -51,13 +51,12 @@ Git-clone or open the microfeed source repository:
 npx @microfeed/cli manage
 ```
 
-The launcher downloads the exact tagged release matching the installed CLI
-into a private operating-system cache, verifies that source before every
-forwarded command, installs its locked dependencies with a cache-local Yarn
-shim, and prints the deployment skill and reference paths for the agent. It
-stores saved deployment state separately under the microfeed configuration
-directory. The first setup may use about 1.3 GB and take several minutes;
-later commands reuse it.
+The launcher carries the exact release matching the installed CLI and a pinned
+Yarn runtime. It verifies and copies that source into a private operating-system
+cache, installs its locked dependencies, and prints the deployment skill and
+reference paths for the agent. It stores saved deployment state separately
+under the microfeed configuration directory. The first setup may use about
+1.3 GB and take several minutes; later commands reuse it.
 
 Coding agents do not generally discover skills inside npm or cache directories
 automatically. The launcher therefore prints both cached file paths explicitly
@@ -90,10 +89,12 @@ The `dev` section instead prioritizes `yarn manage dev` from a Git-cloned
 microfeed source repository because local source development requires that
 repository and its installed dependencies.
 
-Both paths require Node.js 22.12 or newer, Git, Corepack, and an interactive
-local session. Cloudflare operations use Wrangler browser authorization. Credentials are
-managed by Wrangler; do not paste Cloudflare tokens into command arguments or
-agent conversations.
+Both paths require Node.js 22.12 or newer and an interactive local session.
+The published `npx` path also requires npm, but it does not require Git or
+Corepack. A Git-cloned source repository uses its normal Corepack and Yarn
+development setup. Cloudflare operations use Wrangler browser authorization.
+Credentials are managed by Wrangler; do not paste Cloudflare tokens into
+command arguments or agent conversations.
 
 Cloudflare repository imports, Workers Builds, deploy buttons, GitHub Actions,
 and API-token deployment are not supported. Both invocations use the same

--- a/docs/manage/update.md
+++ b/docs/manage/update.md
@@ -18,7 +18,8 @@ Update the microfeed site <site-url> to the latest release. Start by running
 update, and continue until `status` verifies the site.
 ```
 
-The launcher obtains the exact release in a private cache. The agent discovers
+The launcher verifies and copies its exact bundled release into a private
+cache. The agent discovers
 saved and compatible existing sites, asks before choosing among candidates,
 connects only if needed, deploys through the same management engine, and
 runs a status check. Complete any Cloudflare browser handoffs it requests.

--- a/docs/microfeed-cli.md
+++ b/docs/microfeed-cli.md
@@ -69,12 +69,13 @@ not need to Git-clone or open the microfeed source repository:
 npx @microfeed/cli manage
 ```
 
-The launcher also requires Git and Corepack. It downloads the exact tagged
-microfeed release matching the CLI into a persistent private cache, verifies
-the checkout, installs its locked dependencies, and prints the exact
-deployment skill and management-reference paths for the agent. It does not
-write source files into the current project. The initial workspace may use
-about 1.3 GB and take several minutes to prepare; later commands reuse it.
+The launcher carries the exact microfeed release matching the CLI and a pinned
+Yarn runtime. It verifies and copies that source into a persistent private
+cache, installs its locked dependencies without Git or Corepack, and prints
+the exact deployment skill and management-reference paths for the agent. It
+does not write source files into the current project. The initial workspace
+may use about 1.3 GB and take several minutes to prepare; later commands reuse
+it.
 
 Pass any repository management command and options after `manage`; arguments
 such as `--instance` and `--json` are forwarded unchanged:

--- a/docs/start-here/ai-agent.md
+++ b/docs/start-here/ai-agent.md
@@ -15,9 +15,9 @@ Open OpenAI Codex, Claude Code, Cursor, or another coding agent that can run
 terminal commands on your computer and complete a browser handoff. The current
 folder does not need to contain source code.
 
-Your computer needs Node.js 22.12 or newer with npm, plus Git and Corepack. The
-launcher checks these tools before downloading anything and prints a specific
-recovery step when one is unavailable.
+Your computer needs Node.js 22.12 or newer with npm. The published launcher
+includes its own Yarn runtime and deployment source, so ordinary deployment
+does not require Git or Corepack.
 
 ## 2. Give the agent one command
 
@@ -28,10 +28,11 @@ Deploy microfeed to Cloudflare. Start by running `npx @microfeed/cli manage`,
 then follow its instructions until deployment is verified.
 ```
 
-The first run downloads the exact release matching `@microfeed/cli`, creates a
-private Yarn launcher, and installs the locked dependencies in your operating
-system cache. This may use about 1.3 GB and take several minutes, depending on
-your connection and computer. Later commands reuse that workspace, while saved
+The first run verifies and copies the exact release bundled with
+`@microfeed/cli`, then installs the locked dependencies in your operating
+system cache with the included Yarn runtime. This may use about 1.3 GB and take
+several minutes, depending on your connection and computer. Later commands
+reuse that workspace, while saved
 deployment state lives separately so a cache refresh cannot erase your site
 connections.
 

--- a/docs/start-here/concepts.md
+++ b/docs/start-here/concepts.md
@@ -84,12 +84,13 @@ API docs are enabled.
 
 ## What the local management tool changes
 
-`npx @microfeed/cli manage` prepares the matching microfeed release in a private
-cache and runs the same guarded management engine available through `yarn
-manage` inside a Git-cloned microfeed source repository. It checks for name
-collisions, applies database migrations, builds the application, deploys it,
-and verifies the result. Launcher connection details live in the platform
-microfeed configuration directory, separate from the replaceable source cache.
+`npx @microfeed/cli manage` verifies and copies its bundled microfeed release
+into a private cache, then runs the same guarded management engine available
+through `yarn manage` inside a Git-cloned microfeed source repository. It
+checks for name collisions, applies database migrations, builds the
+application, deploys it, and verifies the result. Launcher connection details
+live in the platform microfeed configuration directory, separate from the
+replaceable source cache.
 
 For exact behavior and safety rules, use the
 [management CLI reference](/manage-cli/). Its examples use the recommended

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -14,8 +14,8 @@ You need:
 - A [Cloudflare account](https://dash.cloudflare.com/sign-up). Cloudflare’s
   included usage is enough for many personal and small sites; usage above the
   published limits may require a paid plan.
-- A computer with [Git](https://git-scm.com/downloads),
-  [Node.js 22.12 or newer](https://nodejs.org/), npm, and Corepack installed.
+- A computer with [Node.js 22.12 or newer](https://nodejs.org/) and npm.
+  Ordinary deployment does not require Git or Corepack.
 - A local coding agent such as OpenAI Codex, Claude Code, or Cursor that can run
   terminal commands in a folder on your computer.
 - An email address for the private dashboard login.
@@ -32,9 +32,10 @@ You need:
    then follow its instructions until deployment is verified.
    ```
 
-3. Stay nearby while the agent works. The first command downloads the exact
-   microfeed release and its dependencies into a private cache; it does not
-   create source files in your current folder. Cloudflare opens a browser page
+3. Stay nearby while the agent works. The first command copies the exact
+   release bundled with the CLI into a private cache and installs its
+   dependencies; it does not create source files in your current folder.
+   Cloudflare opens a browser page
    for you to sign in, and the agent may ask you to select an account or
    approve an important choice. Never paste a Cloudflare token or dashboard
    password into the conversation.

--- a/docs/start-here/manual.md
+++ b/docs/start-here/manual.md
@@ -9,10 +9,10 @@ You do not need prior Cloudflare command-line experience.
 
 ## 1. Prepare your computer
 
-Install Node.js 22.12 or newer with npm, plus Git and Corepack. You do not need
-to download or Git-clone the microfeed source repository yourself. The
-published launcher checks these prerequisites and prepares the matching release
-in a private operating-system cache.
+Install Node.js 22.12 or newer with npm. You do not need Git, Corepack, or a
+Git-cloned copy of the microfeed source repository. The published launcher
+carries a pinned Yarn runtime and prepares its matching release in a private
+operating-system cache.
 
 ## 2. Discover your Cloudflare account
 

--- a/manage-cli/lib/process.ts
+++ b/manage-cli/lib/process.ts
@@ -1,4 +1,5 @@
 import {spawn} from "node:child_process";
+import {readFile} from "node:fs/promises";
 import path from "node:path";
 import {fileURLToPath} from "node:url";
 
@@ -83,8 +84,14 @@ export function runYarnScript(
   script: string,
   options: RunOptions = {},
 ): Promise<CommandResult> {
-  const executable = process.platform === "win32" ? "yarn.cmd" : "yarn";
-  return runner(executable, [script], {
+  const yarnJavaScript = (
+    options.env?.MICROFEED_YARN_JAVASCRIPT ??
+    process.env.MICROFEED_YARN_JAVASCRIPT
+  )?.trim();
+  const executable = yarnJavaScript
+    ? process.execPath
+    : process.platform === "win32" ? "yarn.cmd" : "yarn";
+  return runner(executable, yarnJavaScript ? [yarnJavaScript, script] : [script], {
     cwd: repositoryRoot,
     ...options,
   });
@@ -94,11 +101,29 @@ const FULL_GIT_SHA = /^[0-9a-f]{40}$/u;
 
 export async function repositoryCommitSha(
   runner: CommandRunner,
+  sourceRoot = repositoryRoot,
 ): Promise<string> {
+  const markerPath = path.join(sourceRoot, ".microfeed-runtime.json");
+  try {
+    const marker = JSON.parse(await readFile(markerPath, "utf8")) as {
+      sourceCommit?: unknown;
+    };
+    if (
+      typeof marker.sourceCommit !== "string" ||
+      !FULL_GIT_SHA.test(marker.sourceCommit)
+    ) {
+      throw new Error(
+        "The packaged microfeed deployment source commit is invalid.",
+      );
+    }
+    return marker.sourceCommit;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
   const result = await runner(
     "git",
     ["rev-parse", "--verify", "HEAD"],
-    {cwd: repositoryRoot},
+    {cwd: sourceRoot},
   );
   const sha = result.stdout.trim().toLowerCase();
   if (!FULL_GIT_SHA.test(sha)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfeed",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -18,7 +18,8 @@ giving an agent a raw credential.
 ## Requirements
 
 - Node.js 22.12 or newer
-- For clone-free deployment: npm, Git, Corepack, and a Cloudflare account
+- For deployment through `npx`: npm and a Cloudflare account; Git and Corepack
+  are not required for ordinary deployment
 - For content management: a microfeed site with API access enabled and
   built-in administrator login for browser authorization
 
@@ -74,10 +75,11 @@ Run `npx @microfeed/cli manage` and follow every instruction it prints until
 `status` verifies the deployment.
 ```
 
-The launcher requires npm, Git, and Corepack. It downloads the exact tagged
-release matching the CLI into a private persistent cache, installs its locked
-dependencies, and prints the repository-owned deployment skill and reference
-for the agent. The first setup may use about 1.3 GB and take several minutes.
+The launcher carries the exact release matching the CLI and a pinned Yarn
+runtime. It verifies and copies that source into a private persistent cache,
+installs its locked dependencies without Git or Corepack, and prints the
+repository-owned deployment skill and reference for the agent. The first setup
+may use about 1.3 GB and take several minutes.
 Every later management command uses the same prefix, such as
 `npx @microfeed/cli manage status`. The source cache is replaceable; saved
 deployment state is kept separately.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/cli",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Deploy microfeed and manage content on its sites",
   "keywords": [
     "microfeed",
@@ -26,9 +26,7 @@
   },
   "files": [
     "dist",
-    "templates",
-    "README.md",
-    "LICENSE"
+    "templates"
   ],
   "engines": {
     "node": ">=22.12.0"
@@ -36,7 +34,10 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "microfeed": "node --import tsx src/index.ts",
-    "prepack": "yarn build && node scripts/copy-agent-skill.mjs"
+    "prepack": "yarn build && node scripts/copy-agent-skill.mjs && node scripts/copy-manage-runtime.mjs"
+  },
+  "dependencies": {
+    "@yarnpkg/cli-dist": "4.18.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/packages/cli/scripts/copy-manage-runtime.mjs
+++ b/packages/cli/scripts/copy-manage-runtime.mjs
@@ -1,0 +1,125 @@
+import {execFile} from "node:child_process";
+import {createHash} from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import {fileURLToPath} from "node:url";
+import {promisify} from "node:util";
+
+const run = promisify(execFile);
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const repositoryRoot = path.resolve(packageRoot, "../..");
+const runtimeDirectory = path.join(packageRoot, "dist/manage-runtime-files");
+const legacyRuntimeDirectory = path.join(packageRoot, "dist/manage-runtime");
+const manifestPath = path.join(
+  packageRoot,
+  "dist/manage-runtime-manifest.json",
+);
+
+const runtimePaths = [
+  ".agents/skills/deploy-microfeed",
+  ".yarnrc.yml",
+  "LICENSE",
+  "astro.config.ts",
+  "components.json",
+  "docs/manage-cli.md",
+  "manage-cli",
+  "migrations",
+  "package.json",
+  "packages",
+  "postcss.config.ts",
+  "public",
+  "redocly.yaml",
+  "scripts",
+  "src",
+  "tests",
+  "themes",
+  "tsconfig.json",
+  "vitest.config.ts",
+  "vitest.worker.config.ts",
+  "wrangler.jsonc",
+  "wrangler.template.jsonc",
+  "yarn.lock",
+];
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+const [{stdout: trackedOutput}, {stdout: commitOutput}] = await Promise.all([
+  run("git", ["ls-files", "-z", "--", ...runtimePaths], {
+    cwd: repositoryRoot,
+    encoding: "buffer",
+    maxBuffer: 16 * 1024 * 1024,
+  }),
+  run("git", ["rev-parse", "--verify", "HEAD"], {
+    cwd: repositoryRoot,
+    encoding: "utf8",
+  }),
+]);
+const files = trackedOutput
+  .toString("utf8")
+  .split("\0")
+  .filter(Boolean)
+  .sort();
+const sourceCommit = commitOutput.trim().toLowerCase();
+if (!/^[0-9a-f]{40}$/u.test(sourceCommit)) {
+  throw new Error("Could not determine the deployment source commit.");
+}
+if (files.length === 0) {
+  throw new Error("No tracked deployment runtime files were found.");
+}
+
+const [rootPackage, cliPackage] = await Promise.all([
+  readFile(path.join(repositoryRoot, "package.json"), "utf8").then(JSON.parse),
+  readFile(path.join(packageRoot, "package.json"), "utf8").then(JSON.parse),
+]);
+if (!rootPackage.version || rootPackage.version !== cliPackage.version) {
+  throw new Error(
+    "The application and @microfeed/cli versions must match before packing.",
+  );
+}
+
+await rm(runtimeDirectory, {force: true, recursive: true});
+await rm(legacyRuntimeDirectory, {force: true, recursive: true});
+await rm(manifestPath, {force: true});
+await mkdir(runtimeDirectory, {recursive: true});
+
+const manifestFiles = [];
+for (const relativePath of files) {
+  if (
+    path.posix.isAbsolute(relativePath) ||
+    relativePath.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(`Unsafe deployment runtime path: ${relativePath}`);
+  }
+  const source = path.join(repositoryRoot, relativePath);
+  const contents = await readFile(source);
+  const metadata = await stat(source);
+  if (!metadata.isFile()) {
+    throw new Error(`Deployment runtime entry is not a file: ${relativePath}`);
+  }
+  const digest = sha256(contents);
+  await writeFile(path.join(runtimeDirectory, digest), contents, {mode: 0o600});
+  manifestFiles.push({
+    path: relativePath,
+    sha256: digest,
+    size: metadata.size,
+  });
+}
+
+await writeFile(
+  manifestPath,
+  `${JSON.stringify({
+    files: manifestFiles,
+    schemaVersion: 1,
+    sourceCommit,
+    version: rootPackage.version,
+  }, null, 2)}\n`,
+  "utf8",
+);

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -71,8 +71,8 @@ const itemInputOptions = [
 export const CLI_HELP_TOPICS: readonly CliHelpTopic[] = [
   {
     details: [
-      "Downloads the exact tagged microfeed release into a private, persistent cache and runs its repository-owned management CLI. It never checks out source into the current project.",
-      "The launcher requires Git and Corepack in addition to Node.js and npm. Its first run installs the locked application dependencies, and the workspace may consume about 1.3 GB; later runs reuse it.",
+      "Copies the exact microfeed release bundled with @microfeed/cli into a private, persistent cache and runs its repository-owned management CLI. It never checks out source into the current project.",
+      "The published launcher includes its own Yarn runtime, so ordinary deployment requires Node.js and npm but not Git or Corepack. Its first run installs the locked application dependencies, and the workspace may consume about 1.3 GB; later runs reuse it.",
       "A bare manage command prepares the workspace and prints exact instructions for a local coding agent. Pass any management command and options after manage to forward them unchanged, including --instance and --json.",
       "Deployment state is stored separately from the replaceable source cache. Existing sites that are not yet saved can be discovered and connected through the guarded management workflow.",
       "Use only from a local interactive session that can complete Cloudflare browser authorization. Never paste a Cloudflare token, dashboard password, or private password-setup link into a command or agent conversation.",

--- a/packages/cli/src/manage.ts
+++ b/packages/cli/src/manage.ts
@@ -1,8 +1,11 @@
 import {spawn, type SpawnOptions} from "node:child_process";
+import {createHash} from "node:crypto";
+import {createRequire} from "node:module";
 import {constants as osConstants, homedir} from "node:os";
 import path from "node:path";
 import {
   chmod,
+  copyFile,
   mkdir,
   readFile,
   readdir,
@@ -11,13 +14,13 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
+import {fileURLToPath} from "node:url";
 
 import {CliError} from "./errors.js";
 
-const MICROFEED_REPOSITORY_URL =
-  "https://github.com/microfeed/microfeed.git";
 const MINIMUM_NODE_VERSION = [22, 12, 0] as const;
 const SETUP_LOCK_STALE_MS = 60 * 60 * 1_000;
+const RUNTIME_MARKER = ".microfeed-runtime.json";
 
 type StringEnvironment = Record<string, string | undefined>;
 type CommandStdio = "ignore" | "inherit" | "pipe";
@@ -49,8 +52,24 @@ export interface ManageLauncherOptions {
   output?: (value: string) => void;
   packageVersion?: string;
   platform?: NodeJS.Platform;
+  runtimeDirectory?: string;
+  runtimeManifestPath?: string;
   runner?: ManageCommandRunner;
   stateDirectory?: string;
+  yarnJavaScript?: string;
+}
+
+interface ManageRuntimeFile {
+  path: string;
+  sha256: string;
+  size: number;
+}
+
+export interface ManageRuntimeManifest {
+  files: ManageRuntimeFile[];
+  schemaVersion: 1;
+  sourceCommit: string;
+  version: string;
 }
 
 function signalExitCode(signal: NodeJS.Signals | null): number {
@@ -177,7 +196,7 @@ function requireSupportedNodeVersion(version = process.versions.node): void {
     const part = actual[index] ?? Number.NaN;
     if (!Number.isInteger(part) || part < minimum) {
       throw new CliError(
-        "Node.js 22.12.0 or newer is required for clone-free microfeed " +
+        "Node.js 22.12.0 or newer is required for source-code-free microfeed " +
           "deployment. Install a current Node.js LTS release from " +
           "https://nodejs.org/, then rerun the same command.",
       );
@@ -196,20 +215,6 @@ async function installedPackageVersion(): Promise<string> {
   return metadata.version;
 }
 
-async function requireExecutable(
-  runner: ManageCommandRunner,
-  executable: string,
-  remediation: string,
-): Promise<void> {
-  try {
-    const result = await runner(executable, ["--version"], {stdio: "pipe"});
-    if (result.exitCode === 0) return;
-  } catch {
-    // The actionable error below is the same for a missing or unusable tool.
-  }
-  throw new CliError(remediation);
-}
-
 async function pathExists(filename: string): Promise<boolean> {
   try {
     await stat(filename);
@@ -220,47 +225,125 @@ async function pathExists(filename: string): Promise<boolean> {
   }
 }
 
-async function repositoryMatchesVersion(
+function installedRuntimeDirectory(): string {
+  return fileURLToPath(new URL("./manage-runtime-files/", import.meta.url));
+}
+
+function installedRuntimeManifestPath(): string {
+  return fileURLToPath(
+    new URL("./manage-runtime-manifest.json", import.meta.url),
+  );
+}
+
+function installedYarnJavaScript(): string {
+  const require = createRequire(import.meta.url);
+  return require.resolve("@yarnpkg/cli-dist/bin/yarn.js");
+}
+
+function safeRuntimePath(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 &&
+    !path.posix.isAbsolute(value) && !value.includes("\\") &&
+    value.split("/").every((part) =>
+      part.length > 0 && part !== "." && part !== ".."
+    );
+}
+
+async function readRuntimeManifest(
+  filename: string,
+  expectedVersion: string,
+): Promise<ManageRuntimeManifest> {
+  let value: unknown;
+  try {
+    value = JSON.parse(await readFile(filename, "utf8"));
+  } catch {
+    throw new CliError(
+      "The installed @microfeed/cli deployment runtime is missing or " +
+        "damaged. Reinstall the package and rerun the same command.",
+    );
+  }
+  if (!value || typeof value !== "object") {
+    throw new CliError("The installed deployment runtime manifest is invalid.");
+  }
+  const manifest = value as Partial<ManageRuntimeManifest>;
+  const seen = new Set<string>();
+  if (
+    manifest.schemaVersion !== 1 || manifest.version !== expectedVersion ||
+    typeof manifest.sourceCommit !== "string" ||
+    !/^[0-9a-f]{40}$/u.test(manifest.sourceCommit) ||
+    !Array.isArray(manifest.files) || manifest.files.length === 0 ||
+    manifest.files.some((file) => {
+      if (!file || typeof file !== "object") return true;
+      const entry = file as Partial<ManageRuntimeFile>;
+      if (
+        !safeRuntimePath(entry.path) || seen.has(entry.path) ||
+        typeof entry.sha256 !== "string" ||
+        !/^[0-9a-f]{64}$/u.test(entry.sha256) ||
+        typeof entry.size !== "number" ||
+        !Number.isSafeInteger(entry.size) || entry.size < 0
+      ) return true;
+      seen.add(entry.path);
+      return false;
+    })
+  ) {
+    throw new CliError(
+      "The installed @microfeed/cli deployment runtime does not match this " +
+        "package version. Reinstall the package and rerun the same command.",
+    );
+  }
+  return manifest as ManageRuntimeManifest;
+}
+
+async function sha256File(filename: string): Promise<string> {
+  return createHash("sha256")
+    .update(await readFile(filename))
+    .digest("hex");
+}
+
+function manifestsMatch(
+  left: ManageRuntimeManifest,
+  right: ManageRuntimeManifest,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+async function cachedRuntimeMatches(
   repositoryDirectory: string,
-  version: string,
-  runner: ManageCommandRunner,
+  manifest: ManageRuntimeManifest,
 ): Promise<boolean> {
   try {
-    const metadata = JSON.parse(
-      await readFile(path.join(repositoryDirectory, "package.json"), "utf8"),
-    ) as {version?: unknown};
-    if (metadata.version !== version) return false;
-    const [head, release, status] = await Promise.all([
-      runner(
-        "git",
-        ["-C", repositoryDirectory, "rev-parse", "--verify", "HEAD"],
-        {stdio: "pipe"},
-      ),
-      runner(
-        "git",
-        [
-          "-C",
-          repositoryDirectory,
-          "rev-parse",
-          `refs/tags/v${version}^{commit}`,
-        ],
-        {stdio: "pipe"},
-      ),
-      runner(
-        "git",
-        [
-          "-C",
-          repositoryDirectory,
-          "status",
-          "--porcelain",
-          "--untracked-files=all",
-        ],
-        {stdio: "pipe"},
-      ),
-    ]);
-    return head.exitCode === 0 && release.exitCode === 0 &&
-      status.exitCode === 0 && status.stdout.trim() === "" &&
-      head.stdout.trim() === release.stdout.trim() && Boolean(head.stdout.trim());
+    const cachedManifest = JSON.parse(await readFile(
+      path.join(repositoryDirectory, RUNTIME_MARKER),
+      "utf8",
+    )) as ManageRuntimeManifest;
+    if (!manifestsMatch(cachedManifest, manifest)) return false;
+    for (const file of manifest.files) {
+      const filename = path.join(repositoryDirectory, file.path);
+      const metadata = await stat(filename);
+      if (
+        !metadata.isFile() || metadata.size !== file.size ||
+        await sha256File(filename) !== file.sha256
+      ) return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function packagedRuntimeMatches(
+  runtimeDirectory: string,
+  manifest: ManageRuntimeManifest,
+): Promise<boolean> {
+  try {
+    for (const file of manifest.files) {
+      const filename = path.join(runtimeDirectory, file.sha256);
+      const metadata = await stat(filename);
+      if (
+        !metadata.isFile() || metadata.size !== file.size ||
+        await sha256File(filename) !== file.sha256
+      ) return false;
+    }
+    return true;
   } catch {
     return false;
   }
@@ -269,8 +352,8 @@ async function repositoryMatchesVersion(
 async function replaceRepository(
   cacheDirectory: string,
   repositoryDirectory: string,
-  version: string,
-  runner: ManageCommandRunner,
+  runtimeDirectory: string,
+  manifest: ManageRuntimeManifest,
 ): Promise<void> {
   const candidate = path.join(
     cacheDirectory,
@@ -280,31 +363,27 @@ async function replaceRepository(
   await rm(candidate, {force: true, recursive: true});
   await rm(previous, {force: true, recursive: true});
   try {
-    const clone = await runner(
-      "git",
-      [
-        "clone",
-        "--depth",
-        "1",
-        "--single-branch",
-        "--branch",
-        `v${version}`,
-        MICROFEED_REPOSITORY_URL,
-        candidate,
-      ],
-      {stdio: "inherit"},
-    );
-    if (clone.exitCode !== 0) {
+    if (!await packagedRuntimeMatches(runtimeDirectory, manifest)) {
       throw new CliError(
-        `Could not download microfeed release v${version}. Confirm that the ` +
-          "release tag exists and that GitHub is reachable, then rerun the command.",
-        clone.exitCode,
+        "The source bundled with @microfeed/cli is damaged. Reinstall the " +
+          "package and rerun the same command.",
       );
     }
-    if (!await repositoryMatchesVersion(candidate, version, runner)) {
+    await mkdir(candidate, {recursive: true, mode: 0o700});
+    for (const file of manifest.files) {
+      const destination = path.join(candidate, file.path);
+      await mkdir(path.dirname(destination), {recursive: true});
+      await copyFile(path.join(runtimeDirectory, file.sha256), destination);
+    }
+    await writeFile(
+      path.join(candidate, RUNTIME_MARKER),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+      {mode: 0o600},
+    );
+    if (!await cachedRuntimeMatches(candidate, manifest)) {
       throw new CliError(
-        `The downloaded source did not match @microfeed/cli ${version}. ` +
-          "The deployment workspace was not replaced.",
+        "The packaged microfeed deployment runtime could not be verified. " +
+          "The cached workspace was not replaced.",
       );
     }
 
@@ -403,9 +482,11 @@ async function acquireSetupLock(
 async function prepareWorkspace(input: {
   cacheDirectory: string;
   environment: StringEnvironment;
-  packageVersion: string;
+  manifest: ManageRuntimeManifest;
   platform: NodeJS.Platform;
+  runtimeDirectory: string;
   runner: ManageCommandRunner;
+  yarnJavaScript: string;
 }): Promise<{
   environment: StringEnvironment;
   repositoryDirectory: string;
@@ -416,7 +497,6 @@ async function prepareWorkspace(input: {
     await chmod(input.cacheDirectory, 0o700);
   }
   const repositoryDirectory = path.join(input.cacheDirectory, "repository");
-  const binDirectory = path.join(input.cacheDirectory, "bin");
   const releaseLock = await acquireSetupLock(
     path.join(input.cacheDirectory, ".setup-lock"),
   );
@@ -425,53 +505,27 @@ async function prepareWorkspace(input: {
       input.cacheDirectory,
       repositoryDirectory,
     );
-    if (!await repositoryMatchesVersion(
-      repositoryDirectory,
-      input.packageVersion,
-      input.runner,
-    )) {
+    if (!await cachedRuntimeMatches(repositoryDirectory, input.manifest)) {
       await replaceRepository(
         input.cacheDirectory,
         repositoryDirectory,
-        input.packageVersion,
-        input.runner,
+        input.runtimeDirectory,
+        input.manifest,
       );
     }
 
-    await mkdir(binDirectory, {recursive: true});
     const environment: StringEnvironment = {
       ...input.environment,
-      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
-      COREPACK_HOME: path.join(input.cacheDirectory, "corepack"),
-      PATH: [binDirectory, input.environment.PATH].filter(Boolean)
-        .join(path.delimiter),
+      MICROFEED_YARN_JAVASCRIPT: input.yarnJavaScript,
     };
-    const corepack = input.platform === "win32" ? "corepack.cmd" : "corepack";
-    const enable = await input.runner(
-      corepack,
-      ["enable", "--install-directory", binDirectory, "yarn"],
-      {env: environment, stdio: "pipe"},
-    );
-    if (enable.exitCode !== 0) {
-      throw new CliError(
-        "Corepack could not create the private Yarn launcher. " +
-          (enable.stderr.trim() || enable.stdout.trim() ||
-            "Rerun after repairing Corepack."),
-        enable.exitCode,
-      );
-    }
-    const yarn = path.join(
-      binDirectory,
-      input.platform === "win32" ? "yarn.cmd" : "yarn",
-    );
     const install = await input.runner(
-      yarn,
-      ["install", "--immutable"],
+      process.execPath,
+      [input.yarnJavaScript, "install", "--immutable"],
       {cwd: repositoryDirectory, env: environment, stdio: "inherit"},
     );
     if (install.exitCode !== 0) {
       throw new CliError(
-        "The exact microfeed release was downloaded, but its locked " +
+        "The exact microfeed release was unpacked, but its locked " +
           "dependencies could not be installed. Fix the reported Yarn error " +
           "and rerun the same command.",
         install.exitCode,
@@ -546,34 +600,26 @@ export async function runManageLauncher(
     homeDirectory,
   );
   const invocationDirectory = options.invocationDirectory ?? process.cwd();
+  const runtimeDirectory = options.runtimeDirectory ??
+    installedRuntimeDirectory();
+  const runtimeManifestPath = options.runtimeManifestPath ??
+    installedRuntimeManifestPath();
+  const yarnJavaScript = options.yarnJavaScript ?? installedYarnJavaScript();
 
   requireSupportedNodeVersion();
-  await requireExecutable(
-    runner,
-    platform === "win32" ? "npm.cmd" : "npm",
-    "npm is required for clone-free microfeed deployment. Install a current " +
-      "Node.js LTS release, including npm, from https://nodejs.org/, then " +
-      "rerun the same command.",
-  );
-  await requireExecutable(
-    runner,
-    "git",
-    "Git is required for clone-free microfeed deployment. Install Git from " +
-      "https://git-scm.com/downloads, then rerun the same command.",
-  );
-  await requireExecutable(
-    runner,
-    platform === "win32" ? "corepack.cmd" : "corepack",
-    "Corepack is required for clone-free microfeed deployment. Install it " +
-      "with `npm install --global corepack`, then rerun the same command.",
+  const manifest = await readRuntimeManifest(
+    runtimeManifestPath,
+    packageVersion,
   );
 
   const workspace = await prepareWorkspace({
     cacheDirectory,
     environment,
-    packageVersion,
+    manifest,
     platform,
+    runtimeDirectory,
     runner,
+    yarnJavaScript,
   });
   if (args.length === 0) {
     (options.output ?? ((value) => process.stdout.write(value)))(

--- a/packages/theme-kit/package.json
+++ b/packages/theme-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/theme-kit",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Author, validate, test, and preview microfeed themes.",
   "keywords": [
     "microfeed",

--- a/scripts/check-cli-package.ts
+++ b/scripts/check-cli-package.ts
@@ -1,5 +1,4 @@
 import {
-  chmod,
   mkdir,
   mkdtemp,
   readFile,
@@ -10,6 +9,7 @@ import {
 import {tmpdir} from "node:os";
 import path from "node:path";
 import {spawnSync} from "node:child_process";
+import {pathToFileURL} from "node:url";
 
 import {x as extractTar} from "tar";
 import {CLI_HELP_TOPICS, renderCliHelp} from "../packages/cli/src/help";
@@ -52,11 +52,21 @@ try {
     archive,
   ]);
   await extractTar({cwd: temporary, file: archive});
+  try {
+    await readFile(path.join(
+      temporary,
+      "package/.microfeed/webhooks/endpoint1/README.md",
+    ));
+    throw new Error("The packed CLI contains a local .microfeed workspace.");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
   const packedPackage = JSON.parse(
     await readFile(path.join(temporary, "package", "package.json"), "utf8"),
   ) as {
     bin?: {microfeed?: string};
     bugs?: {url?: string};
+    dependencies?: Record<string, string>;
     homepage?: string;
     keywords?: string[];
     name?: string;
@@ -66,9 +76,10 @@ try {
   };
   if (packedPackage.name !== "@microfeed/cli" ||
       packedPackage.version !== rootPackage.version ||
-      packedPackage.bin?.microfeed !== "dist/index.js") {
+      packedPackage.bin?.microfeed !== "dist/index.js" ||
+      packedPackage.dependencies?.["@yarnpkg/cli-dist"] !== "4.18.0") {
     throw new Error(
-      "The packed CLI has a stale version or does not expose the microfeed binary.",
+      "The packed CLI has stale release metadata or deployment dependencies.",
     );
   }
   if (packedPackage.homepage !== "https://docs.microfeed.org/microfeed-cli/" ||
@@ -252,7 +263,7 @@ try {
     "--help",
   ], temporary);
   if (!dlxManageHelp.endsWith(expectedManageHelp)) {
-    throw new Error("The packed clone-free management help diverged.");
+    throw new Error("The packed source-code-free management help diverged.");
   }
 
   const npmConsumer = path.join(temporary, "npm-consumer");
@@ -276,57 +287,86 @@ try {
     throw new Error("The npx @microfeed/cli management help diverged.");
   }
 
-  if (process.platform !== "win32") {
-    const cacheRoot = path.join(temporary, "launcher-cache");
-    const manageCache = path.join(cacheRoot, "manage");
-    const repository = path.join(manageCache, "repository");
-    const cacheBin = path.join(manageCache, "bin");
-    const fakeBin = path.join(temporary, "launcher-tools");
-    await Promise.all([
-      mkdir(repository, {recursive: true}),
-      mkdir(cacheBin, {recursive: true}),
-      mkdir(fakeBin, {recursive: true}),
-    ]);
-    await writeFile(
-      path.join(repository, "package.json"),
-      `${JSON.stringify({version: rootPackage.version})}\n`,
-    );
-    const fakeTool = async (name: string, source: string): Promise<void> => {
-      const filename = path.join(fakeBin, name);
-      await writeFile(filename, `#!/usr/bin/env node\n${source}\n`, {
-        mode: 0o755,
-      });
-      await chmod(filename, 0o755);
-    };
-    await Promise.all([
-      fakeTool("npm", "process.stdout.write('10.0.0\\n');"),
-      fakeTool("corepack", "process.stdout.write('0.31.0\\n');"),
-      fakeTool("git", [
-        "const args = process.argv.slice(2);",
-        "if (args[0] === '--version') process.stdout.write('git version 2.50.0\\n');",
-        "else if (args.includes('rev-parse')) process.stdout.write('0123456789abcdef0123456789abcdef01234567\\n');",
-        "else if (!args.includes('status')) process.exitCode = 1;",
-      ].join("\n")),
-    ]);
-    const yarn = path.join(cacheBin, "yarn");
-    await writeFile(yarn, "#!/usr/bin/env node\n", {mode: 0o755});
-    await chmod(yarn, 0o755);
-    const handoff = run("npx", [
-      "--no-install",
-      "microfeed",
-      "manage",
-    ], npmConsumer, {
-      MICROFEED_CACHE_DIR: cacheRoot,
-      MICROFEED_CONFIG_DIR: path.join(temporary, "launcher-config"),
-      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
-    });
-    if (!handoff.includes(`microfeed v${rootPackage.version}`) ||
-        !handoff.includes("deploy-microfeed/SKILL.md") ||
-        !handoff.includes("docs/manage-cli.md") ||
-        !handoff.includes("npx @microfeed/cli manage accounts --json") ||
-        !handoff.includes("final status check succeeds")) {
-      throw new Error("The packed npx coding-agent handoff is incomplete.");
+  const runtimeManifest = JSON.parse(await readFile(path.join(
+    temporary,
+    "package/dist/manage-runtime-manifest.json",
+  ), "utf8")) as {
+    files?: Array<{path?: string; sha256?: string; size?: number}>;
+    schemaVersion?: number;
+    sourceCommit?: string;
+    version?: string;
+  };
+  const runtimePaths = new Set(
+    runtimeManifest.files?.map(({path: runtimePath}) => runtimePath) ?? [],
+  );
+  if (runtimeManifest.schemaVersion !== 1 ||
+      runtimeManifest.version !== rootPackage.version ||
+      !/^[0-9a-f]{40}$/u.test(runtimeManifest.sourceCommit ?? "") ||
+      !runtimePaths.has("package.json") ||
+      !runtimePaths.has("manage-cli/index.ts") ||
+      !runtimePaths.has("docs/manage-cli.md") ||
+      !runtimePaths.has(".agents/skills/deploy-microfeed/SKILL.md") ||
+      [...runtimePaths].some((runtimePath) =>
+        runtimePath?.startsWith("docs/") && runtimePath !== "docs/manage-cli.md"
+      )) {
+    throw new Error("The packed deployment runtime is incomplete or oversized.");
+  }
+  for (const file of runtimeManifest.files ?? []) {
+    if (!file.sha256 || !Number.isSafeInteger(file.size)) {
+      throw new Error("The packed deployment runtime manifest is invalid.");
     }
+    const payload = await readFile(path.join(
+      temporary,
+      "package/dist/manage-runtime-files",
+      file.sha256,
+    ));
+    if (payload.byteLength !== file.size) {
+      throw new Error(`The packed deployment source is damaged: ${file.path}`);
+    }
+  }
+  const packageEntry = runtimeManifest.files?.find(({path: runtimePath}) =>
+    runtimePath === "package.json"
+  );
+  if (!packageEntry?.sha256) {
+    throw new Error("The packed deployment source has no package metadata.");
+  }
+  const packedRuntimePackage = JSON.parse(await readFile(path.join(
+    temporary,
+    "package/dist/manage-runtime-files",
+    packageEntry.sha256,
+  ), "utf8")) as {version?: string};
+  if (packedRuntimePackage.version !== rootPackage.version) {
+    throw new Error("The packed deployment source version is stale.");
+  }
+
+  const packedManage = await import(pathToFileURL(path.join(
+    temporary,
+    "package/dist/manage.js",
+  )).href);
+  const handoffOutput: string[] = [];
+  const cacheDirectory = path.join(temporary, "launcher-cache");
+  const handoffExitCode = await packedManage.runManageLauncher([], {
+    cacheDirectory,
+    environment: {PATH: process.env.PATH},
+    output: (value: string) => handoffOutput.push(value),
+    packageVersion: rootPackage.version,
+    runner: async () => ({
+      exitCode: 0,
+      signal: null,
+      stderr: "",
+      stdout: "",
+    }),
+    stateDirectory: path.join(temporary, "launcher-config"),
+    yarnJavaScript: path.join(temporary, "fake-yarn.js"),
+  });
+  const handoff = handoffOutput.join("\n");
+  if (handoffExitCode !== 0 ||
+      !handoff.includes(`microfeed v${rootPackage.version}`) ||
+      !handoff.includes("deploy-microfeed/SKILL.md") ||
+      !handoff.includes("docs/manage-cli.md") ||
+      !handoff.includes("npx @microfeed/cli manage accounts --json") ||
+      !handoff.includes("final status check succeeds")) {
+    throw new Error("The packed coding-agent handoff is incomplete.");
   }
   const dlxScaffold = path.join(temporary, "dlx-scaffold");
   const dlxScaffoldOutput = run("yarn", [

--- a/scripts/set-version.ts
+++ b/scripts/set-version.ts
@@ -41,13 +41,6 @@ const RELEASE_VERSION_TARGETS: VersionTarget[] = [
     },
   },
   {
-    filename: "themes/default/microfeed-theme.json",
-    identity: {field: "packageId", value: "microfeed.default"},
-    update: (document, version) => {
-      document.version = version;
-    },
-  },
-  {
     filename: "packages/theme-kit/assets/starter/package.json",
     identity: {field: "name", value: "microfeed-theme"},
     update: (document, version) => {

--- a/tests/unit/cli/manage.test.ts
+++ b/tests/unit/cli/manage.test.ts
@@ -1,8 +1,10 @@
+import {createHash} from "node:crypto";
 import {
   mkdir,
   mkdtemp,
   readFile,
   readdir,
+  rename,
   rm,
   stat,
   utimes,
@@ -19,12 +21,14 @@ import {
   type ManageCommandOptions,
   type ManageCommandResult,
   type ManageCommandRunner,
+  type ManageRuntimeManifest,
   manageStateDirectory,
   runManageLauncher,
   runManageProcess,
 } from "../../../packages/cli/src/manage";
 
 const temporaryDirectories: string[] = [];
+const SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
 
 async function temporaryDirectory(name: string): Promise<string> {
   const directory = await mkdtemp(path.join(tmpdir(), name));
@@ -50,30 +54,59 @@ interface RecordedCommand {
   options: ManageCommandOptions;
 }
 
+interface RuntimeFixture {
+  runtimeDirectory: string;
+  runtimeManifestPath: string;
+  yarnJavaScript: string;
+}
+
+async function runtimeFixture(
+  root: string,
+  version = "1.2.3",
+): Promise<RuntimeFixture> {
+  const runtimeDirectory = path.join(root, "packaged-runtime");
+  const runtimeManifestPath = path.join(root, "runtime-manifest.json");
+  const yarnJavaScript = path.join(root, "yarn.js");
+  const files = new Map<string, string>([
+    [".agents/skills/deploy-microfeed/SKILL.md", "# Deploy microfeed\n"],
+    ["docs/manage-cli.md", "# Management CLI\n"],
+    ["manage-cli/index.ts", "// management entry point\n"],
+    ["package.json", `${JSON.stringify({name: "microfeed", version})}\n`],
+    ["tsconfig.json", "{}\n"],
+  ]);
+  const manifestFiles: ManageRuntimeManifest["files"] = [];
+  for (const [relativePath, contents] of files) {
+    const digest = createHash("sha256").update(contents).digest("hex");
+    await mkdir(runtimeDirectory, {recursive: true});
+    await writeFile(path.join(runtimeDirectory, digest), contents);
+    manifestFiles.push({
+      path: relativePath,
+      sha256: digest,
+      size: Buffer.byteLength(contents),
+    });
+  }
+  const manifest: ManageRuntimeManifest = {
+    files: manifestFiles,
+    schemaVersion: 1,
+    sourceCommit: SOURCE_COMMIT,
+    version,
+  };
+  await writeFile(
+    runtimeManifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  await writeFile(yarnJavaScript, "// pinned Yarn CLI\n");
+  return {runtimeDirectory, runtimeManifestPath, yarnJavaScript};
+}
+
 function workspaceRunner(
-  version: string,
   commands: RecordedCommand[],
   finalResult: ManageCommandResult = commandResult(),
 ): ManageCommandRunner {
   return async (executable, args, options = {}) => {
     commands.push({args: [...args], executable, options});
-    if (executable === "git" && args[0] === "clone") {
-      const destination = args.at(-1)!;
-      await mkdir(destination, {recursive: true});
-      await writeFile(
-        path.join(destination, "package.json"),
-        `${JSON.stringify({version})}\n`,
-      );
-      return commandResult();
-    }
-    if (executable === "git" && args.includes("rev-parse")) {
-      return commandResult({stdout: "0123456789abcdef\n"});
-    }
-    if (executable === "git" && args.includes("status")) {
-      return commandResult();
-    }
     if (executable.endsWith(`${path.sep}tsx`)) return finalResult;
-    return commandResult({stdout: `${path.basename(executable)} 1.0.0\n`});
+    return commandResult();
   };
 }
 
@@ -83,7 +116,7 @@ afterEach(async () => {
   ));
 });
 
-describe("clone-free management launcher", () => {
+describe("source-code-free management launcher", () => {
   it("uses platform cache and persistent state directories", () => {
     expect(manageCacheDirectory(
       {MICROFEED_CACHE_DIR: "/custom/cache"},
@@ -116,8 +149,9 @@ describe("clone-free management launcher", () => {
       .toContain(path.join("AppData", "Roaming", "microfeed", "manage"));
   });
 
-  it("clones the exact release and prints a complete agent handoff", async () => {
+  it("copies the exact bundled release and prints a complete agent handoff", async () => {
     const root = await temporaryDirectory("microfeed-manage-bootstrap-");
+    const fixture = await runtimeFixture(root);
     const cacheDirectory = path.join(root, "cache");
     const stateDirectory = path.join(root, "state");
     const invocationDirectory = path.join(root, "empty-caller");
@@ -132,37 +166,25 @@ describe("clone-free management launcher", () => {
       packageVersion: "1.2.3",
       platform: "linux",
       invocationDirectory,
-      runner: workspaceRunner("1.2.3", commands),
+      runner: workspaceRunner(commands),
       stateDirectory,
+      ...fixture,
     })).resolves.toBe(0);
 
-    const clone = commands.find(({args, executable}) =>
-      executable === "git" && args[0] === "clone"
+    expect(commands.some(({executable}) =>
+      executable === "git" || executable.includes("corepack")
+    )).toBe(false);
+    const install = commands.find(({args, executable}) =>
+      executable === process.execPath && args[0] === fixture.yarnJavaScript
     );
-    expect(clone?.args).toEqual([
-      "clone",
-      "--depth",
-      "1",
-      "--single-branch",
-      "--branch",
-      "v1.2.3",
-      "https://github.com/microfeed/microfeed.git",
-      expect.stringContaining(".repository-"),
+    expect(install?.args).toEqual([
+      fixture.yarnJavaScript,
+      "install",
+      "--immutable",
     ]);
-    const install = commands.find(({args}) => args[0] === "install");
-    expect(install?.args).toEqual(["install", "--immutable"]);
     expect(install?.options.cwd).toBe(path.join(cacheDirectory, "repository"));
-    const corepack = commands.find(({args, executable}) =>
-      executable === "corepack" && args[0] === "enable"
-    );
-    expect(corepack?.args).toEqual([
-      "enable",
-      "--install-directory",
-      path.join(cacheDirectory, "bin"),
-      "yarn",
-    ]);
-    expect(corepack?.options.env?.COREPACK_HOME)
-      .toBe(path.join(cacheDirectory, "corepack"));
+    expect(install?.options.env?.MICROFEED_YARN_JAVASCRIPT)
+      .toBe(fixture.yarnJavaScript);
     expect(output.join("\n")).toContain("microfeed v1.2.3");
     expect(output.join("\n")).toContain("deploy-microfeed");
     expect(output.join("\n")).toContain("docs/manage-cli.md");
@@ -173,51 +195,49 @@ describe("clone-free management launcher", () => {
     await expect(readdir(invocationDirectory)).resolves.toEqual([]);
   });
 
-  it("reuses the checkout and forwards every argument from the original directory", async () => {
+  it("reuses verified source and forwards every argument from the caller", async () => {
     const root = await temporaryDirectory("microfeed-manage-forward-");
+    const fixture = await runtimeFixture(root);
     const cacheDirectory = path.join(root, "cache");
     const stateDirectory = path.join(root, "state");
     const invocationDirectory = path.join(root, "caller");
     const commands: RecordedCommand[] = [];
-    const runner = workspaceRunner(
-      "1.2.3",
-      commands,
-      commandResult({exitCode: 17}),
-    );
+    const runner = workspaceRunner(commands, commandResult({exitCode: 17}));
     await mkdir(invocationDirectory);
 
-    await runManageLauncher([], {
+    const options = {
       cacheDirectory,
       environment: {MICROFEED_TEST_MARKER: "preserved", PATH: "/usr/bin"},
-      output: () => undefined,
       packageVersion: "1.2.3",
-      platform: "linux",
+      platform: "linux" as const,
       runner,
       stateDirectory,
-    });
+      ...fixture,
+    };
+    await runManageLauncher([], {...options, output: () => undefined});
+    await writeFile(
+      path.join(cacheDirectory, "repository", "untracked-sentinel"),
+      "preserved",
+    );
     commands.splice(0);
     await expect(runManageLauncher(
       ["deploy", "--instance", "personal", "--json"],
-      {
-        cacheDirectory,
-        environment: {MICROFEED_TEST_MARKER: "preserved", PATH: "/usr/bin"},
-        invocationDirectory,
-        packageVersion: "1.2.3",
-        platform: "linux",
-        runner,
-        stateDirectory,
-      },
+      {...options, invocationDirectory},
     )).resolves.toBe(17);
 
-    expect(commands.some(({args}) => args[0] === "clone")).toBe(false);
+    await expect(readFile(
+      path.join(cacheDirectory, "repository", "untracked-sentinel"),
+      "utf8",
+    )).resolves.toBe("preserved");
     const forwarded = commands.find(({executable}) =>
       executable.endsWith(`${path.sep}tsx`)
     );
     expect(forwarded?.options.cwd).toBe(invocationDirectory);
     expect(forwarded?.options.env?.MICROFEED_STATE_DIRECTORY)
       .toBe(stateDirectory);
-    expect(forwarded?.options.env?.PATH?.split(path.delimiter)[0])
-      .toBe(path.join(cacheDirectory, "bin"));
+    expect(forwarded?.options.env?.MICROFEED_YARN_JAVASCRIPT)
+      .toBe(fixture.yarnJavaScript);
+    expect(forwarded?.options.env?.PATH).toBe("/usr/bin");
     expect(forwarded?.options.env?.MICROFEED_TEST_MARKER).toBe("preserved");
     expect(forwarded?.options.stdio).toBe("inherit");
     expect(forwarded?.args.slice(-4)).toEqual([
@@ -234,10 +254,10 @@ describe("clone-free management launcher", () => {
 
   it("replaces only stale cached source and preserves deployment state", async () => {
     const root = await temporaryDirectory("microfeed-manage-refresh-");
+    const fixture = await runtimeFixture(root);
     const cacheDirectory = path.join(root, "cache");
     const repositoryDirectory = path.join(cacheDirectory, "repository");
     const stateDirectory = path.join(root, "state");
-    const commands: RecordedCommand[] = [];
     await mkdir(repositoryDirectory, {recursive: true});
     await mkdir(stateDirectory, {recursive: true});
     await writeFile(
@@ -252,68 +272,63 @@ describe("clone-free management launcher", () => {
       output: () => undefined,
       packageVersion: "1.2.3",
       platform: "linux",
-      runner: workspaceRunner("1.2.3", commands),
+      runner: workspaceRunner([]),
       stateDirectory,
+      ...fixture,
     });
 
     expect(JSON.parse(
       await readFile(path.join(repositoryDirectory, "package.json"), "utf8"),
-    )).toEqual({version: "1.2.3"});
+    )).toEqual({name: "microfeed", version: "1.2.3"});
     await expect(readFile(path.join(stateDirectory, "saved-instance"), "utf8"))
       .resolves.toBe("preserved");
   });
 
-  it("repairs a dirty cached checkout without touching saved state", async () => {
+  it("repairs modified cached source without touching saved state", async () => {
     const root = await temporaryDirectory("microfeed-manage-dirty-");
+    const fixture = await runtimeFixture(root);
     const cacheDirectory = path.join(root, "cache");
     const repositoryDirectory = path.join(cacheDirectory, "repository");
     const stateDirectory = path.join(root, "state");
-    const commands: RecordedCommand[] = [];
-    let statusChecks = 0;
-    const baseRunner = workspaceRunner("1.2.3", commands);
-    const runner: ManageCommandRunner = async (executable, args, options) => {
-      if (executable === "git" && args.includes("status")) {
-        statusChecks += 1;
-        if (statusChecks === 1) return commandResult({stdout: "?? changed\n"});
-      }
-      return await baseRunner(executable, args, options);
-    };
-    await mkdir(repositoryDirectory, {recursive: true});
-    await mkdir(stateDirectory, {recursive: true});
-    await writeFile(
-      path.join(repositoryDirectory, "package.json"),
-      `${JSON.stringify({version: "1.2.3"})}\n`,
-    );
-    await writeFile(path.join(stateDirectory, "saved-instance"), "preserved");
-
-    await runManageLauncher([], {
+    const options = {
       cacheDirectory,
       environment: {PATH: "/usr/bin"},
       output: () => undefined,
       packageVersion: "1.2.3",
-      platform: "linux",
-      runner,
+      platform: "linux" as const,
+      runner: workspaceRunner([]),
       stateDirectory,
-    });
+      ...fixture,
+    };
+    await runManageLauncher([], options);
+    await mkdir(stateDirectory, {recursive: true});
+    await writeFile(path.join(stateDirectory, "saved-instance"), "preserved");
+    await writeFile(path.join(repositoryDirectory, "package.json"), "changed\n");
 
-    expect(commands.some(({args}) => args[0] === "clone")).toBe(true);
+    await runManageLauncher([], options);
+
+    await expect(readFile(path.join(repositoryDirectory, "package.json"), "utf8"))
+      .resolves.toContain('"version":"1.2.3"');
     await expect(readFile(path.join(stateDirectory, "saved-instance"), "utf8"))
       .resolves.toBe("preserved");
   });
 
-  it("rejects concurrent setup and reports missing prerequisites clearly", async () => {
+  it("rejects concurrent setup and a damaged packaged runtime", async () => {
     const root = await temporaryDirectory("microfeed-manage-lock-");
+    const fixture = await runtimeFixture(root);
     const cacheDirectory = path.join(root, "cache");
     await mkdir(path.join(cacheDirectory, ".setup-lock"), {recursive: true});
-    await expect(runManageLauncher([], {
-      cacheDirectory,
+    const options = {
       environment: {PATH: "/usr/bin"},
       output: () => undefined,
       packageVersion: "1.2.3",
-      platform: "linux",
-      runner: workspaceRunner("1.2.3", []),
+      platform: "linux" as const,
+      runner: workspaceRunner([]),
       stateDirectory: path.join(root, "state"),
-    })).rejects.toThrow(/Another microfeed management command/u);
+      ...fixture,
+    };
+    await expect(runManageLauncher([], {cacheDirectory, ...options}))
+      .rejects.toThrow(/Another microfeed management command/u);
 
     const activeCache = path.join(root, "active-lock");
     const activeLock = path.join(activeCache, ".setup-lock");
@@ -326,68 +341,30 @@ describe("clone-free management launcher", () => {
     await utimes(activeLock, old, old);
     await expect(runManageLauncher([], {
       cacheDirectory: activeCache,
-      environment: {PATH: "/usr/bin"},
-      output: () => undefined,
-      packageVersion: "1.2.3",
-      platform: "linux",
-      runner: workspaceRunner("1.2.3", []),
-      stateDirectory: path.join(root, "state"),
+      ...options,
     })).rejects.toThrow(/Another microfeed management command/u);
 
-    const missingGit: ManageCommandRunner = async (executable) => {
-      if (executable === "git") {
-        throw Object.assign(new Error("spawn git ENOENT"), {code: "ENOENT"});
-      }
-      return commandResult();
-    };
+    const manifest = JSON.parse(await readFile(
+      fixture.runtimeManifestPath,
+      "utf8",
+    )) as ManageRuntimeManifest;
+    const packageEntry = manifest.files.find(({path: runtimePath}) =>
+      runtimePath === "package.json"
+    );
+    expect(packageEntry).toBeDefined();
+    await writeFile(
+      path.join(fixture.runtimeDirectory, packageEntry!.sha256),
+      "damaged\n",
+    );
     await expect(runManageLauncher([], {
-      cacheDirectory: path.join(root, "missing-git"),
-      environment: {PATH: ""},
-      output: () => undefined,
-      packageVersion: "1.2.3",
-      platform: "linux",
-      runner: missingGit,
-      stateDirectory: path.join(root, "state"),
-    })).rejects.toThrow(/Git is required/u);
-
-    const missingCorepack: ManageCommandRunner = async (executable) => {
-      if (executable === "corepack") {
-        throw Object.assign(
-          new Error("spawn corepack ENOENT"),
-          {code: "ENOENT"},
-        );
-      }
-      return commandResult();
-    };
-    await expect(runManageLauncher([], {
-      cacheDirectory: path.join(root, "missing-corepack"),
-      environment: {PATH: ""},
-      output: () => undefined,
-      packageVersion: "1.2.3",
-      platform: "linux",
-      runner: missingCorepack,
-      stateDirectory: path.join(root, "state"),
-    })).rejects.toThrow(/Corepack is required/u);
-
-    const missingNpm: ManageCommandRunner = async (executable) => {
-      if (executable === "npm") {
-        throw Object.assign(new Error("spawn npm ENOENT"), {code: "ENOENT"});
-      }
-      return commandResult();
-    };
-    await expect(runManageLauncher([], {
-      cacheDirectory: path.join(root, "missing-npm"),
-      environment: {PATH: ""},
-      output: () => undefined,
-      packageVersion: "1.2.3",
-      platform: "linux",
-      runner: missingNpm,
-      stateDirectory: path.join(root, "state"),
-    })).rejects.toThrow(/npm is required/u);
+      cacheDirectory: path.join(root, "damaged-cache"),
+      ...options,
+    })).rejects.toThrow(/source bundled with @microfeed\/cli is damaged/u);
   });
 
   it("recovers an abandoned setup lock", async () => {
     const root = await temporaryDirectory("microfeed-manage-stale-lock-");
+    const fixture = await runtimeFixture(root);
     const cacheDirectory = path.join(root, "cache");
     const lockDirectory = path.join(cacheDirectory, ".setup-lock");
     await mkdir(lockDirectory, {recursive: true});
@@ -400,39 +377,40 @@ describe("clone-free management launcher", () => {
       output: () => undefined,
       packageVersion: "1.2.3",
       platform: "linux",
-      runner: workspaceRunner("1.2.3", []),
+      runner: workspaceRunner([]),
       stateDirectory: path.join(root, "state"),
+      ...fixture,
     })).resolves.toBe(0);
   });
 
-  it("recovers an interrupted repository swap without downloading again", async () => {
+  it("recovers an interrupted repository swap without copying again", async () => {
     const root = await temporaryDirectory("microfeed-manage-swap-");
+    const fixture = await runtimeFixture(root);
     const cacheDirectory = path.join(root, "cache");
+    const repository = path.join(cacheDirectory, "repository");
     const previous = path.join(cacheDirectory, ".repository-previous");
     const abandonedCandidate = path.join(cacheDirectory, ".repository-123-456");
-    const commands: RecordedCommand[] = [];
-    await mkdir(previous, {recursive: true});
-    await mkdir(abandonedCandidate, {recursive: true});
-    await writeFile(
-      path.join(previous, "package.json"),
-      `${JSON.stringify({version: "1.2.3"})}\n`,
-    );
-
-    await runManageLauncher([], {
+    const options = {
       cacheDirectory,
       environment: {PATH: "/usr/bin"},
       output: () => undefined,
       packageVersion: "1.2.3",
-      platform: "linux",
-      runner: workspaceRunner("1.2.3", commands),
+      platform: "linux" as const,
+      runner: workspaceRunner([]),
       stateDirectory: path.join(root, "state"),
-    });
+      ...fixture,
+    };
+    await runManageLauncher([], options);
+    await rename(repository, previous);
+    await mkdir(abandonedCandidate, {recursive: true});
+    await writeFile(path.join(previous, "untracked-sentinel"), "preserved");
 
-    expect(commands.some(({args}) => args[0] === "clone")).toBe(false);
+    await runManageLauncher([], options);
+
     await expect(readFile(
-      path.join(cacheDirectory, "repository", "package.json"),
+      path.join(repository, "untracked-sentinel"),
       "utf8",
-    )).resolves.toContain('"version":"1.2.3"');
+    )).resolves.toBe("preserved");
     expect(await readdir(cacheDirectory)).not.toContain(".repository-123-456");
   });
 

--- a/tests/unit/default-theme.test.ts
+++ b/tests/unit/default-theme.test.ts
@@ -234,7 +234,7 @@ describe("bundled theme packages", () => {
       expect(url).toMatch(/^https:\/\/upload\.wikimedia\.org\//u);
       expect(url).not.toContain("example.test");
     }
-    expect(application.version).toBe("1.0.7");
+    expect(application.version).toBe("1.0.8");
   });
 
   it("renders subscription methods without broken or duplicated image text", async () => {

--- a/tests/unit/manage-cli/process.test.ts
+++ b/tests/unit/manage-cli/process.test.ts
@@ -1,12 +1,24 @@
-import {describe, expect, it, vi} from "vitest";
+import {mkdtemp, rm, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import path from "node:path";
+
+import {afterEach, describe, expect, it, vi} from "vitest";
 
 import {
   repositoryCommitSha,
   repositoryRoot,
+  runYarnScript,
 } from "../../../manage-cli/lib/process";
 import type {CommandRunner} from "../../../manage-cli/types";
 
 const COMMIT = "0123456789abcdef0123456789abcdef01234567";
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((directory) =>
+    rm(directory, {force: true, recursive: true})
+  ));
+});
 
 describe("deployment source commit", () => {
   it("resolves the trusted repository HEAD before deployment", async () => {
@@ -33,6 +45,40 @@ describe("deployment source commit", () => {
 
     await expect(repositoryCommitSha(runner)).rejects.toThrow(
       "current Git commit",
+    );
+  });
+
+  it("uses packaged release provenance without invoking Git", async () => {
+    const sourceRoot = await mkdtemp(path.join(tmpdir(), "microfeed-source-"));
+    temporaryDirectories.push(sourceRoot);
+    await writeFile(
+      path.join(sourceRoot, ".microfeed-runtime.json"),
+      `${JSON.stringify({sourceCommit: COMMIT})}\n`,
+    );
+    const runner = vi.fn<CommandRunner>();
+
+    await expect(repositoryCommitSha(runner, sourceRoot)).resolves.toBe(COMMIT);
+    expect(runner).not.toHaveBeenCalled();
+  });
+});
+
+describe("Yarn command execution", () => {
+  it("uses the Yarn bundled by the published launcher", async () => {
+    const runner = vi.fn<CommandRunner>().mockResolvedValue({
+      exitCode: 0,
+      stderr: "",
+      stdout: "",
+    });
+    await runYarnScript(runner, "build", {
+      env: {MICROFEED_YARN_JAVASCRIPT: "/private/yarn.js"},
+    });
+    expect(runner).toHaveBeenCalledWith(
+      process.execPath,
+      ["/private/yarn.js", "build"],
+      {
+        cwd: repositoryRoot,
+        env: {MICROFEED_YARN_JAVASCRIPT: "/private/yarn.js"},
+      },
     );
   });
 });

--- a/tests/unit/set-version.test.ts
+++ b/tests/unit/set-version.test.ts
@@ -58,14 +58,13 @@ afterEach(async () => {
 });
 
 describe("release version synchronization", () => {
-  it("updates published metadata and the bundled theme in one operation", async () => {
+  it("updates published metadata without rewriting the bundled theme", async () => {
     const root = await repositoryFixture();
 
     await expect(setReleaseVersion(root, "2.3.4")).resolves.toEqual([
       "package.json",
       "packages/cli/package.json",
       "packages/theme-kit/package.json",
-      "themes/default/microfeed-theme.json",
       "packages/theme-kit/assets/starter/package.json",
     ]);
 
@@ -73,10 +72,11 @@ describe("release version synchronization", () => {
       "package.json",
       "packages/cli/package.json",
       "packages/theme-kit/package.json",
-      "themes/default/microfeed-theme.json",
     ]) {
       await expect(readJson(root, filename)).resolves.toMatchObject({version: "2.3.4"});
     }
+    await expect(readJson(root, "themes/default/microfeed-theme.json"))
+      .resolves.toMatchObject({version: "1.0.0"});
     await expect(readJson(
       root,
       "packages/theme-kit/assets/starter/package.json",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,6 +2885,7 @@ __metadata:
   dependencies:
     "@napi-rs/keyring": "npm:1.3.0"
     "@types/node": "npm:^24.0.0"
+    "@yarnpkg/cli-dist": "npm:4.18.0"
     tsx: "npm:^4.20.0"
     typescript: "npm:^6.0.3"
   dependenciesMeta:
@@ -5381,6 +5382,16 @@ __metadata:
   peerDependencies:
     vue: ^3.5.0
   checksum: 10/cd7670805a2760b5ccd93855634288dbfdc41014cbeb97f1d47f057301bfa2d056f8eb86eb8b7bbd26c64633d72e4bc8713dec8467a3c21aa31c7eb7a8723440
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/cli-dist@npm:4.18.0":
+  version: 4.18.0
+  resolution: "@yarnpkg/cli-dist@npm:4.18.0"
+  bin:
+    yarn: bin/yarn.js
+    yarnpkg: bin/yarn.js
+  checksum: 10/1f027fd419dc5d436764667a57417891c552886fff9f6342c0466cfb71e82f28e78b99ac7ea94fe698a01bdee3a51ccf66d1a91a47570a347e5048d7a0c240b5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- package the exact microfeed deployment source inside `@microfeed/cli` with a versioned SHA-256 manifest
- use the packaged Yarn 4.18 runtime instead of Git and Corepack for ordinary `npx @microfeed/cli manage` deployment
- preserve the existing private cache, saved-state separation, locking, repair, signal, TTY, working-directory, and exit-code behavior
- bump the application, `@microfeed/cli`, and `@microfeed/theme-kit` to 1.0.8 while keeping independently versioned bundled themes immutable
- update launcher help, deployment guidance, documentation, package validation, and focused tests

This lets people deploy from any folder with Node.js and npm. The launcher reconstructs and verifies its matching source release in a private cache, then installs the locked application dependencies with its included Yarn runtime. Git remains command-specific for GitHub-backed theme operations.

## Related issue

N/A

## Testing

- [x] `yarn check` (116 test files, 747 tests)
- [x] `yarn cli:check`
- [x] `yarn docs:check`
- [x] `git diff --check`
- [x] deploy-microfeed skill validation

## Screenshots

N/A — no visible UI changes.

## Risks

- The CLI package is larger because it now carries the deployment source (approximately 1.9 MB compressed / 6.3 MB unpacked before dependencies).
- The first management invocation still downloads and installs the locked application dependencies and may create an approximately 1.3 GB private cache.
- Publishing must build from the intended release commit so the packaged source provenance identifies that commit.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
