### PR TITLE
Fix Windows launcher cache repair and cross-drive paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,31 @@ jobs:
         run: yarn install --immutable
       - name: Test Windows process launching
         run: yarn vitest run tests/unit/manage-cli/process.test.ts tests/unit/cli/manage.test.ts
+      - name: Test cross-drive management checks
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $mappedRoot = Join-Path $env:RUNNER_TEMP "microfeed 狀態"
+          New-Item -ItemType Directory -Force -Path $mappedRoot | Out-Null
+          if (Test-Path "M:\") {
+            throw "The M: drive required by this regression test is already in use."
+          }
+          subst M: $mappedRoot
+          if ($LASTEXITCODE -ne 0) {
+            throw "Could not create the M: drive used by this regression test."
+          }
+          try {
+            $env:MICROFEED_STATE_DIRECTORY = "M:\microfeed state"
+            yarn manage init --local --instance windows-cross-drive --admin-auth none --no-r2 --yes
+            if ($LASTEXITCODE -ne 0) {
+              throw "Local microfeed initialization failed."
+            }
+            yarn manage deploy --local --instance windows-cross-drive
+            if ($LASTEXITCODE -ne 0) {
+              throw "Cross-drive microfeed checks failed."
+            }
+          } finally {
+            subst M: /d
+          }
       - name: Test Worker runtime
         run: yarn vitest run --config vitest.worker.config.ts --testTimeout 15000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
         run: yarn install --immutable
       - name: Test Windows process launching
         run: yarn vitest run tests/unit/manage-cli/process.test.ts tests/unit/cli/manage.test.ts
-      - name: Test cross-drive management checks
+      - name: Test cross-drive local deployment
+        if: matrix.runner == 'windows-latest'
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"

--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -2,6 +2,7 @@ import {createReadStream, createWriteStream} from "node:fs";
 import {createHash, randomBytes, randomUUID} from "node:crypto";
 import {
   appendFile,
+  copyFile,
   mkdir,
   mkdtemp,
   readFile,
@@ -94,8 +95,8 @@ import {
   validateWranglerProfileName,
 } from "./lib/cloudflare";
 import {
-  filesystemPathToUrl,
   openUrl,
+  relativePathFromDirectory,
   repositoryCommitSha,
   repositoryRoot,
   runCommand,
@@ -600,31 +601,66 @@ async function runChecks(
   runner: CommandRunner,
   config: MicrofeedConfig,
 ): Promise<void> {
-  const env: NodeJS.ProcessEnv = {
-    ...process.env,
-    MICROFEED_INSTANCE: config.instanceName,
-    MICROFEED_WRANGLER_CONFIG: filesystemPathToUrl(
-      wranglerConfigPath(config),
-    ),
-  };
-  const execute = async (currentActivity: WaitActivity): Promise<void> => {
-    currentActivity.update("Generating Worker binding types");
-    await runYarnScript(runner, "types", {env});
-    currentActivity.update("Checking TypeScript and Astro");
-    await runYarnScript(runner, "typecheck", {env});
-    currentActivity.update("Running deployment smoke tests");
-    await runYarnScript(runner, "test:deploy", {env});
-    currentActivity.update("Building the Worker");
-    await runYarnScript(runner, "build", {env});
-  };
-  await withSpinner(
-    {
-      error: "Checks or build failed",
-      start: "Preparing checks and build",
-      success: "Checks and build passed",
-    },
-    execute,
+  await withFrameworkWranglerConfig(config, async (configPath) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      MICROFEED_INSTANCE: config.instanceName,
+      MICROFEED_WRANGLER_CONFIG: configPath,
+    };
+    const execute = async (currentActivity: WaitActivity): Promise<void> => {
+      currentActivity.update("Generating Worker binding types");
+      await runYarnScript(runner, "types", {env});
+      currentActivity.update("Checking TypeScript and Astro");
+      await runYarnScript(runner, "typecheck", {env});
+      currentActivity.update("Running deployment smoke tests");
+      await runYarnScript(runner, "test:deploy", {env});
+      currentActivity.update("Building the Worker");
+      await runYarnScript(runner, "build", {env});
+    };
+    await withSpinner(
+      {
+        error: "Checks or build failed",
+        start: "Preparing checks and build",
+        success: "Checks and build passed",
+      },
+      execute,
+    );
+  });
+}
+
+async function withFrameworkWranglerConfig<T>(
+  config: MicrofeedConfig,
+  callback: (configPath: string) => Promise<T>,
+): Promise<T> {
+  const sourcePath = wranglerConfigPath(config);
+  const relativePath = relativePathFromDirectory(repositoryRoot, sourcePath);
+  if (relativePath !== undefined) return await callback(relativePath);
+
+  // Astro resolves configPath as a URL, while Cloudflare's Vite plugin resolves
+  // it as a filesystem path. A repository-relative path satisfies both. When
+  // Windows stores the generated config on another drive, stage a disposable
+  // copy beside the repository because no relative path spans drive letters.
+  const stagingRoot = path.join(
+    repositoryRoot,
+    ".microfeed",
+    "framework-configs",
   );
+  await mkdir(stagingRoot, {recursive: true});
+  const stagingDirectory = await mkdtemp(path.join(stagingRoot, "wrangler-"));
+  try {
+    const stagedPath = path.join(stagingDirectory, "wrangler.jsonc");
+    await copyFile(sourcePath, stagedPath);
+    const stagedRelativePath = relativePathFromDirectory(
+      repositoryRoot,
+      stagedPath,
+    );
+    if (stagedRelativePath === undefined) {
+      throw new Error("Could not prepare a repository-relative Wrangler config.");
+    }
+    return await callback(stagedRelativePath);
+  } finally {
+    await rm(stagingDirectory, {force: true, recursive: true});
+  }
 }
 
 async function withEphemeralSecretFile<T>(
@@ -5904,23 +5940,20 @@ export async function devCommand(
       local: true,
       persistTo: localPersistencePath(config),
     });
-    await runYarnScript(runner, "dev:astro", {
-      env: {
-        ...process.env,
-        // Astro automatically backgrounds dev servers when it detects an AI
-        // agent. The management command owns this child process and must keep
-        // it attached so readiness, output, and shutdown remain coordinated.
-        ASTRO_DEV_BACKGROUND: "1",
-        MICROFEED_INSTANCE: config.instanceName,
-        MICROFEED_LOCAL_STATE: localPersistencePath(config),
-        // Astro resolves this value as a URL. A file URL preserves Windows
-        // drive letters, spaces, and non-ASCII characters even when the saved
-        // configuration and prepared repository are on different volumes.
-        MICROFEED_WRANGLER_CONFIG: filesystemPathToUrl(
-          wranglerConfigPath(config),
-        ),
-      },
-      interactive: true,
+    await withFrameworkWranglerConfig(config, async (configPath) => {
+      await runYarnScript(runner, "dev:astro", {
+        env: {
+          ...process.env,
+          // Astro automatically backgrounds dev servers when it detects an AI
+          // agent. The management command owns this child process and must keep
+          // it attached so readiness, output, and shutdown remain coordinated.
+          ASTRO_DEV_BACKGROUND: "1",
+          MICROFEED_INSTANCE: config.instanceName,
+          MICROFEED_LOCAL_STATE: localPersistencePath(config),
+          MICROFEED_WRANGLER_CONFIG: configPath,
+        },
+        interactive: true,
+      });
     });
   } finally {
     await generateWranglerConfig(config);

--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -94,6 +94,7 @@ import {
   validateWranglerProfileName,
 } from "./lib/cloudflare";
 import {
+  filesystemPathToUrl,
   openUrl,
   repositoryCommitSha,
   repositoryRoot,
@@ -602,8 +603,7 @@ async function runChecks(
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     MICROFEED_INSTANCE: config.instanceName,
-    MICROFEED_WRANGLER_CONFIG: path.relative(
-      repositoryRoot,
+    MICROFEED_WRANGLER_CONFIG: filesystemPathToUrl(
       wranglerConfigPath(config),
     ),
   };
@@ -5913,11 +5913,10 @@ export async function devCommand(
         ASTRO_DEV_BACKGROUND: "1",
         MICROFEED_INSTANCE: config.instanceName,
         MICROFEED_LOCAL_STATE: localPersistencePath(config),
-        // The Astro Cloudflare adapter resolves this value as a URL before it
-        // hands the filesystem path to Wrangler. A Windows drive-letter path
-        // is parsed as a non-file URL, so keep it relative to the project.
-        MICROFEED_WRANGLER_CONFIG: path.relative(
-          repositoryRoot,
+        // Astro resolves this value as a URL. A file URL preserves Windows
+        // drive letters, spaces, and non-ASCII characters even when the saved
+        // configuration and prepared repository are on different volumes.
+        MICROFEED_WRANGLER_CONFIG: filesystemPathToUrl(
           wranglerConfigPath(config),
         ),
       },

--- a/manage-cli/lib/process.ts
+++ b/manage-cli/lib/process.ts
@@ -2,7 +2,7 @@ import {spawn} from "node:child_process";
 import {readFile} from "node:fs/promises";
 import {createRequire} from "node:module";
 import path from "node:path";
-import {fileURLToPath, pathToFileURL} from "node:url";
+import {fileURLToPath} from "node:url";
 
 import type {
   CommandResult,
@@ -16,11 +16,15 @@ export const repositoryRoot = path.resolve(
 );
 const require = createRequire(import.meta.url);
 
-export function filesystemPathToUrl(
+export function relativePathFromDirectory(
+  directory: string,
   filename: string,
   platform: NodeJS.Platform = process.platform,
-): string {
-  return pathToFileURL(filename, {windows: platform === "win32"}).href;
+): string | undefined {
+  const platformPath = platform === "win32" ? path.win32 : path.posix;
+  const relative = platformPath.relative(directory, filename);
+  if (platformPath.isAbsolute(relative)) return undefined;
+  return relative.replaceAll(platformPath.sep, "/") || ".";
 }
 
 interface PackageBinaryMetadata {

--- a/manage-cli/lib/process.ts
+++ b/manage-cli/lib/process.ts
@@ -2,7 +2,7 @@ import {spawn} from "node:child_process";
 import {readFile} from "node:fs/promises";
 import {createRequire} from "node:module";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
+import {fileURLToPath, pathToFileURL} from "node:url";
 
 import type {
   CommandResult,
@@ -15,6 +15,13 @@ export const repositoryRoot = path.resolve(
   "../..",
 );
 const require = createRequire(import.meta.url);
+
+export function filesystemPathToUrl(
+  filename: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return pathToFileURL(filename, {windows: platform === "win32"}).href;
+}
 
 interface PackageBinaryMetadata {
   bin?: string | Record<string, string>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfeed",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/cli",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Deploy microfeed and manage content on its sites",
   "keywords": [
     "microfeed",

--- a/packages/cli/src/manage.ts
+++ b/packages/cli/src/manage.ts
@@ -21,6 +21,13 @@ import {CliError} from "./errors.js";
 const MINIMUM_NODE_VERSION = [22, 12, 0] as const;
 const SETUP_LOCK_STALE_MS = 60 * 60 * 1_000;
 const RUNTIME_MARKER = ".microfeed-runtime.json";
+const REQUIRED_WORKSPACE_BINARIES = [
+  {binaryName: "tsx", packageName: "tsx"},
+  {binaryName: "wrangler", packageName: "wrangler"},
+  {binaryName: "astro", packageName: "astro"},
+  {binaryName: "tsc", packageName: "typescript"},
+  {binaryName: "vitest", packageName: "vitest"},
+] as const;
 
 type StringEnvironment = Record<string, string | undefined>;
 type CommandStdio = "ignore" | "inherit" | "pipe";
@@ -65,6 +72,10 @@ interface ManageRuntimeFile {
   path: string;
   sha256: string;
   size: number;
+}
+
+interface PackageBinaryMetadata {
+  bin?: string | Record<string, string>;
 }
 
 export interface ManageRuntimeManifest {
@@ -258,17 +269,87 @@ function installedYarnJavaScript(): string {
   return require.resolve("@yarnpkg/cli-dist/bin/yarn.js");
 }
 
-function installedTsxJavaScript(repositoryDirectory: string): string {
-  const require = createRequire(path.join(repositoryDirectory, "package.json"));
-  return require.resolve("tsx/cli");
-}
-
 function safeRuntimePath(value: unknown): value is string {
   return typeof value === "string" && value.length > 0 &&
     !path.posix.isAbsolute(value) && !value.includes("\\") &&
     value.split("/").every((part) =>
       part.length > 0 && part !== "." && part !== ".."
     );
+}
+
+async function workspacePackageBinaryJavaScript(
+  repositoryDirectory: string,
+  packageName: string,
+  binaryName: string,
+): Promise<string> {
+  const require = createRequire(path.join(repositoryDirectory, "package.json"));
+  const metadataPath = require.resolve(`${packageName}/package.json`);
+  const metadata = JSON.parse(
+    await readFile(metadataPath, "utf8"),
+  ) as PackageBinaryMetadata;
+  const binary = typeof metadata.bin === "string"
+    ? metadata.bin
+    : metadata.bin?.[binaryName];
+  if (!binary) {
+    throw new Error(
+      `${packageName} does not provide its ${binaryName} JavaScript entry point.`,
+    );
+  }
+  const filename = path.resolve(path.dirname(metadataPath), binary);
+  const file = await stat(filename);
+  if (!file.isFile()) {
+    throw new Error(
+      `${packageName} ${binaryName} entry point is not a regular file: ${filename}`,
+    );
+  }
+  return filename;
+}
+
+async function verifyWorkspaceDependencies(
+  repositoryDirectory: string,
+): Promise<string> {
+  let tsxJavaScript: string | undefined;
+  for (const {binaryName, packageName} of REQUIRED_WORKSPACE_BINARIES) {
+    let filename: string;
+    try {
+      filename = await workspacePackageBinaryJavaScript(
+        repositoryDirectory,
+        packageName,
+        binaryName,
+      );
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`${packageName}/${binaryName}: ${detail}`);
+    }
+    if (packageName === "tsx") tsxJavaScript = filename;
+  }
+  if (!tsxJavaScript) {
+    throw new Error("tsx/tsx: the required JavaScript entry point is missing.");
+  }
+  return tsxJavaScript;
+}
+
+async function installWorkspaceDependencies(input: {
+  checkCache?: boolean;
+  environment: StringEnvironment;
+  repositoryDirectory: string;
+  runner: ManageCommandRunner;
+  yarnJavaScript: string;
+}): Promise<ManageCommandResult> {
+  return await input.runner(
+    process.execPath,
+    [
+      input.yarnJavaScript,
+      "install",
+      "--immutable",
+      ...(input.checkCache ? ["--check-cache"] : []),
+    ],
+    {
+      cwd: input.repositoryDirectory,
+      env: input.environment,
+      stdio: "inherit",
+    },
+  );
 }
 
 async function readRuntimeManifest(
@@ -541,11 +622,12 @@ async function prepareWorkspace(input: {
       ...input.environment,
       MICROFEED_YARN_JAVASCRIPT: input.yarnJavaScript,
     };
-    const install = await input.runner(
-      process.execPath,
-      [input.yarnJavaScript, "install", "--immutable"],
-      {cwd: repositoryDirectory, env: environment, stdio: "inherit"},
-    );
+    const install = await installWorkspaceDependencies({
+      environment,
+      repositoryDirectory,
+      runner: input.runner,
+      yarnJavaScript: input.yarnJavaScript,
+    });
     if (install.exitCode !== 0) {
       throw new CliError(
         "The exact microfeed release was unpacked, but its locked " +
@@ -554,11 +636,50 @@ async function prepareWorkspace(input: {
         install.exitCode,
       );
     }
+    let tsxJavaScript = input.tsxJavaScript;
+    if (!tsxJavaScript) {
+      try {
+        tsxJavaScript = await verifyWorkspaceDependencies(repositoryDirectory);
+      } catch {
+        await rm(path.join(repositoryDirectory, "node_modules"), {
+          force: true,
+          recursive: true,
+        });
+        await rm(path.join(repositoryDirectory, ".yarn", "install-state.gz"), {
+          force: true,
+        });
+        const repair = await installWorkspaceDependencies({
+          checkCache: true,
+          environment,
+          repositoryDirectory,
+          runner: input.runner,
+          yarnJavaScript: input.yarnJavaScript,
+        });
+        if (repair.exitCode !== 0) {
+          throw new CliError(
+            "The private microfeed deployment workspace dependencies were " +
+              "incomplete and could not be repaired. Fix the reported Yarn " +
+              "error and rerun the same command.",
+            repair.exitCode,
+          );
+        }
+        try {
+          tsxJavaScript = await verifyWorkspaceDependencies(repositoryDirectory);
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          throw new CliError(
+            "The private microfeed deployment workspace remains incomplete " +
+              `after a clean reinstall (${detail}). Check whether Windows ` +
+              "Security or antivirus software quarantined that file, then " +
+              "rerun the same command.",
+          );
+        }
+      }
+    }
     return {
       environment,
       repositoryDirectory,
-      tsxJavaScript: input.tsxJavaScript ??
-        installedTsxJavaScript(repositoryDirectory),
+      tsxJavaScript,
     };
   } finally {
     await releaseLock();

--- a/packages/theme-kit/package.json
+++ b/packages/theme-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/theme-kit",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Author, validate, test, and preview microfeed themes.",
   "keywords": [
     "microfeed",

--- a/tests/unit/cli/manage.test.ts
+++ b/tests/unit/cli/manage.test.ts
@@ -108,6 +108,40 @@ async function runtimeFixture(
   };
 }
 
+async function installWorkspaceBinaryFixtures(
+  repositoryDirectory: string,
+  omittedPackage?: string,
+): Promise<void> {
+  const binaries = [
+    {binaryName: "tsx", packageName: "tsx"},
+    {binaryName: "wrangler", packageName: "wrangler"},
+    {binaryName: "astro", packageName: "astro"},
+    {binaryName: "tsc", packageName: "typescript"},
+    {binaryName: "vitest", packageName: "vitest"},
+  ];
+  for (const {binaryName, packageName} of binaries) {
+    if (packageName === omittedPackage) continue;
+    const packageDirectory = path.join(
+      repositoryDirectory,
+      "node_modules",
+      ...packageName.split("/"),
+    );
+    const binary = `./bin/${binaryName}.js`;
+    await mkdir(path.join(packageDirectory, "bin"), {recursive: true});
+    await writeFile(
+      path.join(packageDirectory, "package.json"),
+      `${JSON.stringify({
+        bin: packageName === "tsx" ? binary : {[binaryName]: binary},
+        name: packageName,
+      })}\n`,
+    );
+    await writeFile(
+      path.join(packageDirectory, "bin", `${binaryName}.js`),
+      "// package binary fixture\n",
+    );
+  }
+}
+
 function workspaceRunner(
   commands: RecordedCommand[],
   finalResult: ManageCommandResult = commandResult(),
@@ -230,6 +264,88 @@ describe("source-code-free management launcher", () => {
     );
     expect(output.join("\n")).toContain("Do not stop");
     await expect(readdir(invocationDirectory)).resolves.toEqual([]);
+  });
+
+  it("repairs an incomplete private dependency tree without touching saved state", async () => {
+    const root = await temporaryDirectory("microfeed-manage-dependency-repair-");
+    const fixture = await runtimeFixture(root);
+    const cacheDirectory = path.join(root, "cache");
+    const stateDirectory = path.join(root, "state");
+    const commands: RecordedCommand[] = [];
+    let installCount = 0;
+    await mkdir(stateDirectory, {recursive: true});
+    await writeFile(path.join(stateDirectory, "saved-instance"), "preserved");
+    const runner: ManageCommandRunner = async (executable, args, options = {}) => {
+      commands.push({args: [...args], executable, options});
+      if (args[0] === fixture.yarnJavaScript && args[1] === "install") {
+        installCount += 1;
+        await installWorkspaceBinaryFixtures(
+          options.cwd!,
+          installCount === 1 ? "wrangler" : undefined,
+        );
+      }
+      return commandResult();
+    };
+
+    await expect(runManageLauncher([], {
+      cacheDirectory,
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner,
+      stateDirectory,
+      runtimeDirectory: fixture.runtimeDirectory,
+      runtimeManifestPath: fixture.runtimeManifestPath,
+      yarnJavaScript: fixture.yarnJavaScript,
+    })).resolves.toBe(0);
+
+    const installs = commands.filter(({args}) =>
+      args[0] === fixture.yarnJavaScript && args[1] === "install"
+    );
+    expect(installs.map(({args}) => args)).toEqual([
+      [fixture.yarnJavaScript, "install", "--immutable"],
+      [fixture.yarnJavaScript, "install", "--immutable", "--check-cache"],
+    ]);
+    expect((await stat(path.join(
+      cacheDirectory,
+      "repository",
+      "node_modules",
+      "wrangler",
+      "bin",
+      "wrangler.js",
+    ))).isFile()).toBe(true);
+    await expect(readFile(path.join(stateDirectory, "saved-instance"), "utf8"))
+      .resolves.toBe("preserved");
+  });
+
+  it("reports a dependency file that remains missing after one clean repair", async () => {
+    const root = await temporaryDirectory("microfeed-manage-dependency-damaged-");
+    const fixture = await runtimeFixture(root);
+    const commands: RecordedCommand[] = [];
+    const runner: ManageCommandRunner = async (executable, args, options = {}) => {
+      commands.push({args: [...args], executable, options});
+      if (args[0] === fixture.yarnJavaScript && args[1] === "install") {
+        await installWorkspaceBinaryFixtures(options.cwd!, "wrangler");
+      }
+      return commandResult();
+    };
+
+    await expect(runManageLauncher([], {
+      cacheDirectory: path.join(root, "cache"),
+      environment: {PATH: "/usr/bin"},
+      output: () => undefined,
+      packageVersion: "1.2.3",
+      platform: "linux",
+      runner,
+      stateDirectory: path.join(root, "state"),
+      runtimeDirectory: fixture.runtimeDirectory,
+      runtimeManifestPath: fixture.runtimeManifestPath,
+      yarnJavaScript: fixture.yarnJavaScript,
+    })).rejects.toThrow(
+      /remains incomplete[\s\S]*wrangler\/wrangler[\s\S]*Windows Security/u,
+    );
+    expect(commands.filter(({args}) => args[1] === "install")).toHaveLength(2);
   });
 
   it("reuses verified source and forwards every argument from the caller", async () => {

--- a/tests/unit/default-theme.test.ts
+++ b/tests/unit/default-theme.test.ts
@@ -234,7 +234,7 @@ describe("bundled theme packages", () => {
       expect(url).toMatch(/^https:\/\/upload\.wikimedia\.org\//u);
       expect(url).not.toContain("example.test");
     }
-    expect(application.version).toBe("1.0.8");
+    expect(application.version).toBe("1.0.9");
   });
 
   it("renders subscription methods without broken or duplicated image text", async () => {

--- a/tests/unit/manage-cli/instance-management.test.ts
+++ b/tests/unit/manage-cli/instance-management.test.ts
@@ -465,8 +465,11 @@ describe("first-class local instances", () => {
       }),
       interactive: true,
     });
+    expect(path.isAbsolute(
+      devCall?.[2]?.env?.MICROFEED_WRANGLER_CONFIG ?? "",
+    )).toBe(false);
     expect(devCall?.[2]?.env?.MICROFEED_WRANGLER_CONFIG)
-      .toMatch(/^file:\/\//u);
+      .not.toMatch(/^file:/u);
   });
 
   it("changes the local login email and resets its password safely", async () => {
@@ -779,7 +782,8 @@ describe("first-class local instances", () => {
         /^yarn(?:\.cmd|\.js)?$/u.test(path.basename(executable))
       )
       .every(([, , options]) =>
-        options?.env?.MICROFEED_WRANGLER_CONFIG?.startsWith("file://")
+        !path.isAbsolute(options?.env?.MICROFEED_WRANGLER_CONFIG ?? "") &&
+        !options?.env?.MICROFEED_WRANGLER_CONFIG?.startsWith("file:")
       )).toBe(true);
   });
 

--- a/tests/unit/manage-cli/instance-management.test.ts
+++ b/tests/unit/manage-cli/instance-management.test.ts
@@ -465,9 +465,8 @@ describe("first-class local instances", () => {
       }),
       interactive: true,
     });
-    expect(path.isAbsolute(
-      devCall?.[2]?.env?.MICROFEED_WRANGLER_CONFIG ?? "",
-    )).toBe(false);
+    expect(devCall?.[2]?.env?.MICROFEED_WRANGLER_CONFIG)
+      .toMatch(/^file:\/\//u);
   });
 
   it("changes the local login email and resets its password safely", async () => {
@@ -775,6 +774,13 @@ describe("first-class local instances", () => {
       "build",
     ]);
     expect(yarnScripts).not.toContain("test");
+    expect(runner.mock.calls
+      .filter(([executable]) =>
+        /^yarn(?:\.cmd|\.js)?$/u.test(path.basename(executable))
+      )
+      .every(([, , options]) =>
+        options?.env?.MICROFEED_WRANGLER_CONFIG?.startsWith("file://")
+      )).toBe(true);
   });
 
   it("simulates webhooks automatically in dev without changing deployment opt-in", async () => {

--- a/tests/unit/manage-cli/process.test.ts
+++ b/tests/unit/manage-cli/process.test.ts
@@ -1,10 +1,12 @@
 import {mkdtemp, rm, writeFile} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import path from "node:path";
+import {fileURLToPath} from "node:url";
 
 import {afterEach, describe, expect, it, vi} from "vitest";
 
 import {
+  filesystemPathToUrl,
   repositoryCommitSha,
   repositoryRoot,
   runCommand,
@@ -61,6 +63,38 @@ describe("deployment source commit", () => {
 
     await expect(repositoryCommitSha(runner, sourceRoot)).resolves.toBe(COMMIT);
     expect(runner).not.toHaveBeenCalled();
+  });
+});
+
+describe("filesystem URL conversion", () => {
+  it("preserves Windows drive letters, spaces, and non-ASCII paths", () => {
+    expect(filesystemPathToUrl(
+      "C:\\Users\\系統預設\\AppData\\Roaming\\microfeed config\\wrangler.jsonc",
+      "win32",
+    )).toBe(
+      "file:///C:/Users/%E7%B3%BB%E7%B5%B1%E9%A0%90%E8%A8%AD/AppData/" +
+        "Roaming/microfeed%20config/wrangler.jsonc",
+    );
+  });
+
+  it("keeps a cross-drive Wrangler configuration independent of the repository", () => {
+    const repository = "E:\\microfeed-cli-cache\\manage\\repository";
+    const configuration =
+      "C:\\Users\\person\\AppData\\Roaming\\microfeed\\manage\\wrangler.jsonc";
+
+    expect(path.win32.isAbsolute(path.win32.relative(
+      repository,
+      configuration,
+    ))).toBe(true);
+    expect(filesystemPathToUrl(configuration, "win32"))
+      .toBe("file:///C:/Users/person/AppData/Roaming/microfeed/manage/wrangler.jsonc");
+    expect(fileURLToPath(
+      new URL(
+        filesystemPathToUrl(configuration, "win32"),
+        "file:///E:/microfeed-cli-cache/manage/repository/",
+      ),
+      {windows: true},
+    )).toBe(configuration);
   });
 });
 

--- a/tests/unit/manage-cli/process.test.ts
+++ b/tests/unit/manage-cli/process.test.ts
@@ -1,12 +1,11 @@
 import {mkdtemp, rm, writeFile} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import path from "node:path";
-import {fileURLToPath} from "node:url";
 
 import {afterEach, describe, expect, it, vi} from "vitest";
 
 import {
-  filesystemPathToUrl,
+  relativePathFromDirectory,
   repositoryCommitSha,
   repositoryRoot,
   runCommand,
@@ -66,18 +65,16 @@ describe("deployment source commit", () => {
   });
 });
 
-describe("filesystem URL conversion", () => {
-  it("preserves Windows drive letters, spaces, and non-ASCII paths", () => {
-    expect(filesystemPathToUrl(
+describe("framework-compatible filesystem paths", () => {
+  it("preserves spaces and non-ASCII segments on one Windows drive", () => {
+    expect(relativePathFromDirectory(
+      "C:\\microfeed\\repository",
       "C:\\Users\\系統預設\\AppData\\Roaming\\microfeed config\\wrangler.jsonc",
       "win32",
-    )).toBe(
-      "file:///C:/Users/%E7%B3%BB%E7%B5%B1%E9%A0%90%E8%A8%AD/AppData/" +
-        "Roaming/microfeed%20config/wrangler.jsonc",
-    );
+    )).toBe("../../Users/系統預設/AppData/Roaming/microfeed config/wrangler.jsonc");
   });
 
-  it("keeps a cross-drive Wrangler configuration independent of the repository", () => {
+  it("identifies a Windows path that requires repository-local staging", () => {
     const repository = "E:\\microfeed-cli-cache\\manage\\repository";
     const configuration =
       "C:\\Users\\person\\AppData\\Roaming\\microfeed\\manage\\wrangler.jsonc";
@@ -86,15 +83,8 @@ describe("filesystem URL conversion", () => {
       repository,
       configuration,
     ))).toBe(true);
-    expect(filesystemPathToUrl(configuration, "win32"))
-      .toBe("file:///C:/Users/person/AppData/Roaming/microfeed/manage/wrangler.jsonc");
-    expect(fileURLToPath(
-      new URL(
-        filesystemPathToUrl(configuration, "win32"),
-        "file:///E:/microfeed-cli-cache/manage/repository/",
-      ),
-      {windows: true},
-    )).toBe(configuration);
+    expect(relativePathFromDirectory(repository, configuration, "win32"))
+      .toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- pass same-drive generated Wrangler configs as normalized repository-relative paths that both Astro's URL resolver and Cloudflare's Vite plugin filesystem resolver accept
- stage a short-lived copy beside the repository when Windows stores saved state on another drive, then remove it after checks, builds, or local development exit
- verify critical binaries after the launcher installs its private workspace, then perform one clean Yarn cache-checked repair when an entry point such as `wrangler.js` is missing
- cover Unicode and cross-drive behavior with focused tests on both Windows CI runners and a full cross-drive local deployment on `windows-latest`
- prepare the application, `@microfeed/cli`, and `@microfeed/theme-kit` release metadata for v1.0.9

This fixes deployments where the source-code-free launcher prepares its repository on one Windows drive while saved microfeed state lives on another, as well as incomplete private dependency trees that previously failed later with `MODULE_NOT_FOUND`.

## Related issue

N/A

## Testing

- [x] `yarn check`
- [x] `yarn vitest run tests/unit/cli/manage.test.ts tests/unit/manage-cli/process.test.ts tests/unit/manage-cli/instance-management.test.ts` (50 tests)
- [x] `git diff --check`

## Screenshots

N/A — command-line launcher behavior only.

## Risks

Cross-drive checks create only a temporary generated Wrangler config under the ignored repository-local `.microfeed/framework-configs` directory; the file is removed in a `finally` block. The dependency repair removes only the launcher-owned cached `node_modules` tree and Yarn install-state file before reinstalling. Saved instance configuration and deployment state remain separate and are covered by regression tests. The focused Windows tests run on both CI runners; the full cross-drive deployment runs on `windows-latest` to avoid duplicating several minutes of application checks and builds under x64 emulation on Windows ARM.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
