### PR TITLE
Resume incomplete first deployments in CLI 1.0.10

### DIFF
--- a/docs/manage-cli.md
+++ b/docs/manage-cli.md
@@ -424,8 +424,11 @@ npx @microfeed/cli manage deploy [--instance <name>] [--preview|--local] [--enab
 `deploy` only operates on instances with locally saved configuration. If the
 microfeed already exists on Cloudflare, run
 `npx @microfeed/cli manage connect --instance <name>` first and select its
-Worker. If it does not exist yet, run
-`npx @microfeed/cli manage init --instance <name>` instead.
+Worker. For a new installation with no saved configuration, run
+`npx @microfeed/cli manage init --instance <name>` instead. When initialization
+has saved the instance but its first Worker deployment is not yet complete,
+`deploy` resumes that deployment and supplies the missing initial
+upload-signing secret automatically.
 
 An ordinary deployment does not probe or prompt when media storage is already
 ready or explicitly disabled. For automatic pending setup, `NotEntitled`

--- a/manage-cli/commands.ts
+++ b/manage-cli/commands.ts
@@ -3316,8 +3316,10 @@ export async function deployCommand(
     );
     const r2EnablePending = enabledR2Now ||
       config.completedSteps.includes("r2-enable-pending");
+    const resumeFirstDeployment =
+      !config.completedSteps.includes("worker-deployed");
     try {
-      await deployConfiguredProject(context, config, false);
+      await deployConfiguredProject(context, config, resumeFirstDeployment);
     } catch (error) {
       if (finishWebhookDisable && isCloudflareAuthenticationError(error)) {
         throw webhookAuthenticationError(error, config, "disable", true);

--- a/manage-cli/help.ts
+++ b/manage-cli/help.ts
@@ -116,6 +116,7 @@ export const CLI_COMMANDS: readonly CliCommandMetadata[] = [
     changes: "Updates a selected Cloudflare Worker, or prepares a local-only release with --local.",
     details: [
       "Deploy requires saved local instance configuration. Use connect for an existing Cloudflare microfeed or init for a new installation.",
+      "When saved initialization state has not completed its first Worker deployment, deploy resumes it and supplies the missing initial upload-signing secret.",
       "Runs type checks, focused deployment smoke tests, and a build before deploying, then verifies the public site and protected admin route. The complete repository test suite remains part of yarn check and continuous integration.",
       "Normalizes stored item plain text before deployment and reconciles it after the Worker switch; search remains unavailable if either validation pass is incomplete.",
       "Synchronizes every current Built-in theme release as inactive without changing the active or previous selection, then safely soft-deletes superseded Built-in releases unless they are active, previous, or remain referenced.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfeed",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/cli",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Deploy microfeed and manage content on its sites",
   "keywords": [
     "microfeed",

--- a/packages/theme-kit/package.json
+++ b/packages/theme-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/theme-kit",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Author, validate, test, and preview microfeed themes.",
   "keywords": [
     "microfeed",

--- a/tests/unit/default-theme.test.ts
+++ b/tests/unit/default-theme.test.ts
@@ -234,7 +234,7 @@ describe("bundled theme packages", () => {
       expect(url).toMatch(/^https:\/\/upload\.wikimedia\.org\//u);
       expect(url).not.toContain("example.test");
     }
-    expect(application.version).toBe("1.0.9");
+    expect(application.version).toBe("1.0.10");
   });
 
   it("renders subscription methods without broken or duplicated image text", async () => {

--- a/tests/unit/manage-cli/instance-management.test.ts
+++ b/tests/unit/manage-cli/instance-management.test.ts
@@ -695,6 +695,80 @@ describe("first-class local instances", () => {
     expect(runner).not.toHaveBeenCalled();
   });
 
+  it("resumes an incomplete first deployment with its upload-signing secret", async () => {
+    const {commands, config} = await freshModules();
+    await config.writeConfig({
+      ...completedRemoteConfig(),
+      adminAuthMode: "none",
+      completedSteps: ["d1-ready", "r2-ready"],
+      deploymentUrl: null,
+    });
+    let deployedSecrets: Record<string, string> | undefined;
+    const runner = vi.fn<CommandRunner>(async (_executable, args) => {
+      const command = args.join(" ");
+      if (command === "whoami --json") {
+        return commandResult(JSON.stringify({
+          accounts: [{id: "account-id", name: "Personal"}],
+          authType: "OAuth Token",
+          email: "cloudflare@example.com",
+          tokenPermissions: requiredScopes,
+        }));
+      }
+      if (command === "pages project list --json") {
+        return commandResult("[]");
+      }
+      if (command === "rev-parse --verify HEAD") {
+        return commandResult("a".repeat(40));
+      }
+      if (command.startsWith("d1 migrations apply feed-db --remote ")) {
+        return commandResult("Migrations applied");
+      }
+      if (command.startsWith("d1 execute feed-db --remote --file ")) {
+        return commandResult("Executed");
+      }
+      if (command.startsWith("d1 execute feed-db --remote --command ")) {
+        const sql = args[args.indexOf("--command") + 1] ?? "";
+        const results = sql.includes("sqlite_schema")
+          ? [{name: "site_search_exact"}, {name: "site_search_title_trigram"}]
+          : sql.includes("COUNT(*)") ? [{count: 0}] : [];
+        return commandResult(JSON.stringify([{results}]));
+      }
+      if (["types", "typecheck", "test:deploy", "build"].includes(args[0]!)) {
+        return commandResult();
+      }
+      if (args[0] === "deploy") {
+        const secretIndex = args.indexOf("--secrets-file");
+        expect(secretIndex).toBeGreaterThan(-1);
+        deployedSecrets = JSON.parse(
+          await readFile(args[secretIndex + 1]!, "utf8"),
+        ) as Record<string, string>;
+        return commandResult("https://feed.example.workers.dev");
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => Response.json({
+      instanceId: "installation-id",
+      product: "microfeed",
+    })));
+
+    await commands.deployCommand({instance: "feed"}, runner);
+
+    expect(deployedSecrets).toEqual({
+      UPLOAD_SIGNING_KEY: expect.any(String),
+    });
+    expect(deployedSecrets?.UPLOAD_SIGNING_KEY).toHaveLength(43);
+    await expect(config.readConfig(false, "feed")).resolves.toEqual(
+      expect.objectContaining({
+        completedSteps: expect.arrayContaining([
+          "upload-signing-secret-created",
+          "worker-deployed",
+          "deployment-verified",
+        ]),
+        deploymentUrl: "https://feed.example.workers.dev",
+      }),
+    );
+  });
+
   it("creates a content-only local instance and enables simulated R2 later", async () => {
     const {commands, config, theme} = await freshModules();
     const runner = vi.fn<CommandRunner>(async (_executable, args) => {


### PR DESCRIPTION
## Summary

- detect saved initialization state that has not completed its first Worker deployment
- include the initial upload-signing secret when `manage deploy` resumes that state
- add an end-to-end regression test and document the recovery behavior
- synchronize the release version to 1.0.10 for the next CLI publication

This fixes interrupted first deployments where D1 and R2 were already saved but the Worker did not yet exist. Retrying with `manage deploy` previously omitted `UPLOAD_SIGNING_KEY`, causing Wrangler to reject the first Worker deployment.

## Related issue

N/A

## Testing

- [x] `yarn check`
- [x] focused management CLI tests
- [x] CLI and theme-kit package checks

## Screenshots

N/A

## Risks

Low. The new behavior is limited to configurations without the `worker-deployed` checkpoint. Completed deployments do not regenerate or rotate the upload-signing secret.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
