### PR TITLE
Fix npm package CLI invocation handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microfeed",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "type": "module",
   "license": "AGPL-3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/cli",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Deploy microfeed and manage content on its sites",
   "keywords": [
     "microfeed",

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,5 +1,26 @@
 import {CliError} from "./errors.js";
 
+export const NPX_CLI_INVOCATION = "npx @microfeed/cli";
+export const YARN_CLI_INVOCATION = "yarn microfeed";
+
+export type CliInvocation =
+  | typeof NPX_CLI_INVOCATION
+  | typeof YARN_CLI_INVOCATION;
+
+type CliInvocationEnvironment = Readonly<Record<string, string | undefined>>;
+
+export function detectCliInvocation(
+  environment: CliInvocationEnvironment = process.env,
+): CliInvocation {
+  const npmExecutable = environment.npm_execpath ?? "";
+  if (environment.npm_lifecycle_event === "npx" ||
+      (environment.npm_command === "exec" &&
+        /(?:^|[/\\])(?:npm|npx)-cli\.js$/u.test(npmExecutable))) {
+    return NPX_CLI_INVOCATION;
+  }
+  return YARN_CLI_INVOCATION;
+}
+
 export interface CliHelpOption {
   description: string;
   syntax: string;
@@ -635,19 +656,34 @@ function referenceUrl(path?: readonly string[]): string {
   return `https://docs.microfeed.org/microfeed-cli/${anchor}`;
 }
 
-export function renderCliHelp(path?: readonly string[]): string {
+function renderInvocation(
+  lines: string[],
+  invocation: CliInvocation,
+): string {
+  return lines.map((line) =>
+    line.replace(
+      /yarn microfeed|npx @microfeed\/cli/gu,
+      invocation,
+    )
+  ).join("\n");
+}
+
+export function renderCliHelp(
+  path?: readonly string[],
+  invocation = detectCliInvocation(),
+): string {
   if (path?.length) {
     const topic = helpTopic(path);
     if (!topic) {
       throw new CliError(
-        `Unknown help topic: ${topicKey(path)}. Run \`yarn microfeed help\` to list commands.`,
+        `Unknown help topic: ${topicKey(path)}. Run \`${invocation} help\` to list commands.`,
       );
     }
     const subcommands = topic.subcommands?.map(({description, name}) => ({
       description,
       syntax: name,
     })) ?? [];
-    return [
+    return renderInvocation([
       topic.usage,
       "",
       topic.summary,
@@ -666,7 +702,7 @@ export function renderCliHelp(path?: readonly string[]): string {
       "",
       `Complete reference: ${referenceUrl(topic.path)}`,
       "",
-    ].join("\n");
+    ], invocation);
   }
 
   const commands = [
@@ -678,7 +714,7 @@ export function renderCliHelp(path?: readonly string[]): string {
     {syntax: "media", description: "Upload standalone media for rich content or later API use."},
     {syntax: "api", description: "Call one relative /api/v1/ REST operation."},
   ];
-  return [
+  return renderInvocation([
     "microfeed — deploy sites and manage their content",
     "",
     "Usage:",
@@ -731,5 +767,5 @@ export function renderCliHelp(path?: readonly string[]): string {
     "",
     `Complete reference: ${referenceUrl()}`,
     "",
-  ].join("\n");
+  ], invocation);
 }

--- a/packages/theme-kit/package.json
+++ b/packages/theme-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microfeed/theme-kit",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Author, validate, test, and preview microfeed themes.",
   "keywords": [
     "microfeed",

--- a/packages/theme-kit/src/cli.ts
+++ b/packages/theme-kit/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import {realpathSync} from "node:fs";
 import {cp, mkdir, readFile, readdir, writeFile} from "node:fs/promises";
 import {createServer} from "node:http";
 import path from "node:path";
@@ -528,7 +529,17 @@ async function main(): Promise<void> {
   throw new Error(`Unknown command: ${command}\n\n${renderThemeKitHelp()}`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+function isDirectInvocation(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) ===
+      realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return import.meta.url === pathToFileURL(process.argv[1]).href;
+  }
+}
+
+if (isDirectInvocation()) {
   main().catch((error: unknown) => {
     const diagnostics = error instanceof ThemeValidationError ? error.diagnostics : [error instanceof Error ? error.message : String(error)];
     const json = process.argv.includes("--json");

--- a/scripts/check-cli-package.ts
+++ b/scripts/check-cli-package.ts
@@ -14,7 +14,11 @@ import {spawnSync} from "node:child_process";
 import {pathToFileURL} from "node:url";
 
 import {x as extractTar} from "tar";
-import {CLI_HELP_TOPICS, renderCliHelp} from "../packages/cli/src/help";
+import {
+  CLI_HELP_TOPICS,
+  NPX_CLI_INVOCATION,
+  renderCliHelp,
+} from "../packages/cli/src/help";
 import {HELP} from "../packages/cli/src/index";
 
 const require = createRequire(import.meta.url);
@@ -298,8 +302,22 @@ try {
     "manage",
     "--help",
   ], npmConsumer);
-  if (npxManageHelp !== expectedManageHelp) {
+  const expectedNpxManageHelp = renderCliHelp(
+    ["manage"],
+    NPX_CLI_INVOCATION,
+  );
+  if (npxManageHelp !== expectedNpxManageHelp) {
     throw new Error("The npx @microfeed/cli management help diverged.");
+  }
+
+  const npxHelp = run(process.execPath, [npmJavaScript("npx"),
+    "--no-install",
+    "microfeed",
+    "--help",
+  ], npmConsumer);
+  const expectedNpxHelp = renderCliHelp(undefined, NPX_CLI_INVOCATION);
+  if (npxHelp !== expectedNpxHelp) {
+    throw new Error("The npx @microfeed/cli help uses the wrong launcher.");
   }
 
   const runtimeManifest = JSON.parse(await readFile(path.join(

--- a/scripts/check-theme-kit-package.ts
+++ b/scripts/check-theme-kit-package.ts
@@ -1,4 +1,4 @@
-import {mkdir, mkdtemp, readFile, rm, writeFile} from "node:fs/promises";
+import {mkdir, mkdtemp, readFile, rm, symlink, writeFile} from "node:fs/promises";
 import {tmpdir} from "node:os";
 import {createRequire} from "node:module";
 import path from "node:path";
@@ -120,7 +120,31 @@ try {
     packageManager: "yarn@4.18.0",
     private: true,
   }), "utf8");
+  await writeFile(
+    path.join(consumer, ".yarnrc.yml"),
+    "nodeLinker: node-modules\n",
+    "utf8",
+  );
   runYarn(["install"], consumer);
+  if (process.platform !== "win32") {
+    const npmBinDirectory = path.join(temporary, "npm-bin");
+    const npmBin = path.join(npmBinDirectory, "microfeed-theme");
+    await mkdir(npmBinDirectory);
+    await symlink(
+      path.relative(
+        npmBinDirectory,
+        path.join(
+          consumer,
+          "node_modules/@microfeed/theme-kit/dist/cli.js",
+        ),
+      ),
+      npmBin,
+    );
+    const npmBinVersion = run(npmBin, ["--version"], temporary);
+    if (npmBinVersion.trim() !== rootPackage.version) {
+      throw new Error("The npm-style theme-kit executable reports a stale version.");
+    }
+  }
   const help = runYarn(["theme-kit", "--help"], consumer);
   if (!help.includes("theme-kit <command>") ||
       !help.includes("fixture pull <url>") ||
@@ -203,7 +227,7 @@ try {
     throw new Error("The compatibility theme-kit executable reports a stale version.");
   }
   process.stdout.write(
-    "Workspace, packed, project-local, library, scaffold, and yarn dlx theme-kit behavior match.\n",
+    "Workspace, packed, npm-style, project-local, library, scaffold, and yarn dlx theme-kit behavior match.\n",
   );
 } finally {
   await rm(temporary, {force: true, recursive: true});

--- a/tests/unit/cli/help.test.ts
+++ b/tests/unit/cli/help.test.ts
@@ -4,7 +4,10 @@ import {globalOptions} from "../../../packages/cli/src/arguments";
 import {loginCommand} from "../../../packages/cli/src/commands";
 import {
   CLI_HELP_TOPICS,
+  detectCliInvocation,
+  NPX_CLI_INVOCATION,
   renderCliHelp,
+  YARN_CLI_INVOCATION,
 } from "../../../packages/cli/src/help";
 import {HELP, run} from "../../../packages/cli/src/index";
 
@@ -31,6 +34,31 @@ describe("microfeed CLI help", () => {
     expect(HELP).toContain("https://docs.microfeed.org/microfeed-cli/");
     expect(HELP).not.toContain("<origin>");
     expect(HELP).not.toContain("<profile>");
+  });
+
+  it("renders copyable commands for the active package launcher", () => {
+    expect(detectCliInvocation({
+      npm_command: "exec",
+      npm_execpath: "/usr/local/lib/node_modules/npm/bin/npm-cli.js",
+    })).toBe(NPX_CLI_INVOCATION);
+    expect(detectCliInvocation({
+      npm_execpath: "/tmp/yarn",
+    })).toBe(YARN_CLI_INVOCATION);
+
+    const npxHelp = renderCliHelp(undefined, NPX_CLI_INVOCATION);
+    expect(npxHelp).toContain("npx @microfeed/cli login --help");
+    expect(npxHelp).toContain("npx @microfeed/cli item create --help");
+    expect(npxHelp).not.toContain(YARN_CLI_INVOCATION);
+
+    const yarnManageHelp = renderCliHelp(["manage"], YARN_CLI_INVOCATION);
+    expect(yarnManageHelp).toContain("yarn microfeed manage init");
+    expect(yarnManageHelp).not.toContain(NPX_CLI_INVOCATION);
+
+    for (const topic of CLI_HELP_TOPICS) {
+      const topicHelp = renderCliHelp(topic.path, NPX_CLI_INVOCATION);
+      expect(topicHelp).toContain(NPX_CLI_INVOCATION);
+      expect(topicHelp).not.toContain(YARN_CLI_INVOCATION);
+    }
   });
 
   it("distinguishes media attachments from item cover images", () => {
@@ -127,13 +155,19 @@ describe("microfeed CLI help", () => {
   it("renders comprehensive help for every command and subcommand", () => {
     for (const topic of CLI_HELP_TOPICS) {
       const help = renderCliHelp(topic.path);
-      expect(help).toContain(topic.usage);
+      expect(help).toContain(
+        topic.usage.replaceAll(NPX_CLI_INVOCATION, YARN_CLI_INVOCATION),
+      );
       expect(help).toContain(topic.summary);
       expect(help).toContain("-h, --help");
       expect(help).toContain("Examples:");
       expect(help).toContain("https://docs.microfeed.org/microfeed-cli/");
       for (const {syntax} of topic.options) expect(help).toContain(syntax);
-      for (const example of topic.examples) expect(help).toContain(example);
+      for (const example of topic.examples) {
+        expect(help).toContain(
+          example.replaceAll(NPX_CLI_INVOCATION, YARN_CLI_INVOCATION),
+        );
+      }
     }
   });
 

--- a/tests/unit/default-theme.test.ts
+++ b/tests/unit/default-theme.test.ts
@@ -234,7 +234,7 @@ describe("bundled theme packages", () => {
       expect(url).toMatch(/^https:\/\/upload\.wikimedia\.org\//u);
       expect(url).not.toContain("example.test");
     }
-    expect(application.version).toBe("1.0.10");
+    expect(application.version).toBe("1.0.11");
   });
 
   it("renders subscription methods without broken or duplicated image text", async () => {


### PR DESCRIPTION
## Summary

- resolve the theme-kit executable entrypoint through symlinks so npm and npx-installed bins run normally
- render @microfeed/cli help examples for the active launcher: npx @microfeed/cli under npm exec and yarn microfeed under Yarn
- synchronize the application, CLI, and theme-kit versions at 1.0.11

## Related issue

None.

## Testing

- [x] yarn check
- [x] packed theme-kit check executes an npm-style POSIX bin symlink
- [x] packed CLI check installs with npm and verifies npx help output

## Screenshots

N/A — command-line behavior only.

## Risks

Low. Launcher selection uses npm lifecycle and executable metadata, with the existing Yarn form as the fallback. Packed-package checks cover both npm/npx and Yarn invocation paths.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation remains accurate; this corrects runtime help examples without changing commands.
- [x] No secrets, private configuration, production data, or generated files are included.