### PR TITLE
Handle globally installed CLI help

### DIFF
--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -1,9 +1,11 @@
 import {CliError} from "./errors.js";
 
+export const GLOBAL_CLI_INVOCATION = "microfeed";
 export const NPX_CLI_INVOCATION = "npx @microfeed/cli";
 export const YARN_CLI_INVOCATION = "yarn microfeed";
 
 export type CliInvocation =
+  | typeof GLOBAL_CLI_INVOCATION
   | typeof NPX_CLI_INVOCATION
   | typeof YARN_CLI_INVOCATION;
 
@@ -18,7 +20,12 @@ export function detectCliInvocation(
         /(?:^|[/\\])(?:npm|npx)-cli\.js$/u.test(npmExecutable))) {
     return NPX_CLI_INVOCATION;
   }
-  return YARN_CLI_INVOCATION;
+  const packageManager = environment.npm_config_user_agent ?? "";
+  if (/^yarn\//u.test(packageManager) ||
+      /(?:^|[/\\])yarn(?:-[^/\\]+)?(?:\.c?js)?$/u.test(npmExecutable)) {
+    return YARN_CLI_INVOCATION;
+  }
+  return GLOBAL_CLI_INVOCATION;
 }
 
 export interface CliHelpOption {

--- a/scripts/check-cli-package.ts
+++ b/scripts/check-cli-package.ts
@@ -16,6 +16,7 @@ import {pathToFileURL} from "node:url";
 import {x as extractTar} from "tar";
 import {
   CLI_HELP_TOPICS,
+  GLOBAL_CLI_INVOCATION,
   NPX_CLI_INVOCATION,
   renderCliHelp,
 } from "../packages/cli/src/help";
@@ -28,6 +29,7 @@ function npmJavaScript(binary: "npm" | "npx"): string {
   const filename = `${binary}-cli.js`;
   const searchDirectories = [
     path.dirname(process.execPath),
+    path.resolve(path.dirname(process.execPath), "..", "lib"),
     ...(process.env.PATH ?? "").split(path.delimiter),
   ].filter(Boolean);
   for (const directory of searchDirectories) {
@@ -320,6 +322,20 @@ try {
     throw new Error("The npx @microfeed/cli help uses the wrong launcher.");
   }
 
+  const globalHelp = run(process.execPath, [
+    path.join(temporary, "package", "dist", "index.js"),
+    "--help",
+  ], temporary, {
+    npm_command: "",
+    npm_execpath: "",
+    npm_lifecycle_event: "",
+    npm_config_user_agent: "",
+  });
+  const expectedGlobalHelp = renderCliHelp(undefined, GLOBAL_CLI_INVOCATION);
+  if (globalHelp !== expectedGlobalHelp) {
+    throw new Error("The globally installed microfeed help uses the wrong launcher.");
+  }
+
   const runtimeManifest = JSON.parse(await readFile(path.join(
     temporary,
     "package/dist/manage-runtime-manifest.json",
@@ -431,7 +447,7 @@ try {
     throw new Error("The packed Python webhook starter file set is incomplete.");
   }
   process.stdout.write(
-    "Workspace, project-local, packed, npx, and yarn dlx @microfeed/cli behavior match.\n",
+    "Workspace, project-local, packed, global, npx, and yarn dlx @microfeed/cli behavior match.\n",
   );
 } finally {
   await rm(temporary, {force: true, recursive: true});

--- a/tests/unit/cli/help.test.ts
+++ b/tests/unit/cli/help.test.ts
@@ -5,6 +5,7 @@ import {loginCommand} from "../../../packages/cli/src/commands";
 import {
   CLI_HELP_TOPICS,
   detectCliInvocation,
+  GLOBAL_CLI_INVOCATION,
   NPX_CLI_INVOCATION,
   renderCliHelp,
   YARN_CLI_INVOCATION,
@@ -44,11 +45,21 @@ describe("microfeed CLI help", () => {
     expect(detectCliInvocation({
       npm_execpath: "/tmp/yarn",
     })).toBe(YARN_CLI_INVOCATION);
+    expect(detectCliInvocation({
+      npm_config_user_agent: "yarn/4.18.0 npm/? node/v24.20.0 darwin arm64",
+    })).toBe(YARN_CLI_INVOCATION);
+    expect(detectCliInvocation({})).toBe(GLOBAL_CLI_INVOCATION);
 
     const npxHelp = renderCliHelp(undefined, NPX_CLI_INVOCATION);
     expect(npxHelp).toContain("npx @microfeed/cli login --help");
     expect(npxHelp).toContain("npx @microfeed/cli item create --help");
     expect(npxHelp).not.toContain(YARN_CLI_INVOCATION);
+
+    const globalHelp = renderCliHelp(undefined, GLOBAL_CLI_INVOCATION);
+    expect(globalHelp).toContain("microfeed login --help");
+    expect(globalHelp).toContain("microfeed item create --help");
+    expect(globalHelp).not.toContain(NPX_CLI_INVOCATION);
+    expect(globalHelp).not.toContain(YARN_CLI_INVOCATION);
 
     const yarnManageHelp = renderCliHelp(["manage"], YARN_CLI_INVOCATION);
     expect(yarnManageHelp).toContain("yarn microfeed manage init");


### PR DESCRIPTION
## Summary

- treat a package-manager-free invocation as the globally installed `microfeed` command
- keep explicit launcher detection for `npx @microfeed/cli` and repository or project-local `yarn microfeed` usage
- verify generated help through unit tests and the packed CLI check, including the standard npm location used by Volta

## Related issue

None.

## Testing

- [x] `yarn vitest run tests/unit/cli/help.test.ts`
- [x] `yarn cli:check`
- [x] `git diff --check`
- [x] `yarn check`

## Screenshots

N/A — command-line help behavior only.

## Risks

Low. The launcher is selected only for rendered command examples. The already-published npm package `1.0.11` is immutable, so publishing this fix will require a later patch version.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed.
- [x] Documentation remains accurate; generated help now reflects the actual launcher.
- [x] No secrets, private configuration, production data, or generated files are included.