### PR TITLE
Add full-screen previews to docs images

### DIFF
--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
         },
       ],
       components: {
+        Footer: "./src/components/Footer.astro",
         PageTitle: "./src/components/PageTitle.astro",
         SocialIcons: "./src/components/GitHubRepoButtons.astro",
       },

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -1,0 +1,7 @@
+---
+import StarlightFooter from "@astrojs/starlight/components/Footer.astro";
+import ImageLightbox from "./ImageLightbox.astro";
+---
+
+<StarlightFooter />
+<ImageLightbox />

--- a/docs/src/components/ImageLightbox.astro
+++ b/docs/src/components/ImageLightbox.astro
@@ -1,0 +1,116 @@
+<dialog
+  aria-label="Image preview"
+  class="docs-image-lightbox"
+  data-docs-image-lightbox
+  data-pagefind-ignore
+  id="docs-image-lightbox"
+>
+  <div class="docs-image-lightbox-panel">
+    <button
+      aria-label="Close image preview"
+      class="docs-image-lightbox-close"
+      data-docs-image-lightbox-close
+      type="button"
+    >
+      <svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
+        <path d="M6 6l12 12M18 6 6 18" stroke="currentColor" stroke-linecap="round" stroke-width="2" />
+      </svg>
+    </button>
+    <img alt="" data-docs-image-lightbox-preview />
+    <p class="docs-image-lightbox-caption" data-docs-image-lightbox-caption hidden></p>
+  </div>
+</dialog>
+
+<script>
+  const initializeImageLightbox = () => {
+    const dialog = document.querySelector<HTMLDialogElement>(
+      "[data-docs-image-lightbox]",
+    );
+    const preview = dialog?.querySelector<HTMLImageElement>(
+      "[data-docs-image-lightbox-preview]",
+    );
+    const caption = dialog?.querySelector<HTMLElement>(
+      "[data-docs-image-lightbox-caption]",
+    );
+    const closeButton = dialog?.querySelector<HTMLButtonElement>(
+      "[data-docs-image-lightbox-close]",
+    );
+    if (!dialog || !preview || !caption || !closeButton) return;
+
+    let activeTrigger: HTMLElement | null = null;
+
+    if (dialog.dataset.docsImageLightboxReady !== "true") {
+      dialog.dataset.docsImageLightboxReady = "true";
+      closeButton.addEventListener("click", () => dialog.close());
+      dialog.addEventListener("click", (event) => {
+        if (event.target === dialog) dialog.close();
+      });
+      dialog.addEventListener("close", () => {
+        document.documentElement.classList.remove("docs-image-lightbox-open");
+        preview.removeAttribute("src");
+        activeTrigger?.focus();
+        activeTrigger = null;
+      });
+    }
+
+    for (const image of document.querySelectorAll<HTMLImageElement>(
+      ".sl-markdown-content img:not([data-docs-image-lightbox-ignore])",
+    )) {
+      if (image.closest("[data-docs-image-lightbox-trigger]")) continue;
+
+      const visual = image.closest("picture") ?? image;
+      const existingTrigger = visual.closest<HTMLAnchorElement | HTMLButtonElement>(
+        "a, button",
+      );
+      const trigger = existingTrigger ?? document.createElement("button");
+      if (!existingTrigger) {
+        trigger.setAttribute("type", "button");
+        visual.replaceWith(trigger);
+        trigger.append(visual);
+      }
+
+      const description = image.alt.trim();
+      trigger.classList.add("docs-image-lightbox-trigger");
+      trigger.dataset.docsImageLightboxTrigger = "true";
+      trigger.setAttribute("aria-controls", dialog.id);
+      trigger.setAttribute("aria-haspopup", "dialog");
+      trigger.setAttribute(
+        "aria-label",
+        description
+          ? `Open full-screen preview: ${description}`
+          : "Open full-screen image preview",
+      );
+
+      const openPreview = () => {
+        activeTrigger = trigger;
+        preview.src = image.currentSrc || image.src;
+        preview.alt = description;
+        const figureCaption = image.closest("figure")
+          ?.querySelector("figcaption")
+          ?.textContent
+          ?.trim();
+        const captionText = figureCaption || description;
+        caption.textContent = captionText;
+        caption.hidden = !captionText;
+        document.documentElement.classList.add("docs-image-lightbox-open");
+        dialog.showModal();
+        closeButton.focus();
+      };
+
+      trigger.addEventListener("click", (event) => {
+        event.preventDefault();
+        openPreview();
+      });
+      if (trigger instanceof HTMLAnchorElement) {
+        trigger.addEventListener("keydown", (event) => {
+          if (event.key !== " ") return;
+          event.preventDefault();
+          openPreview();
+        });
+      }
+    }
+  };
+
+  initializeImageLightbox();
+  document.addEventListener("astro:page-load", initializeImageLightbox);
+</script>

--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -86,6 +86,109 @@ html[data-has-hero][data-has-sidebar]:not([data-has-toc]) {
   border-radius: 0.75rem;
 }
 
+.sl-markdown-content .docs-image-lightbox-trigger {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0;
+  border: 0;
+  border-radius: 0.75rem;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.sl-markdown-content .docs-image-lightbox-trigger:hover img {
+  filter: brightness(0.96);
+}
+
+.docs-image-lightbox {
+  position: fixed;
+  z-index: 10000;
+  inset: 0;
+  box-sizing: border-box;
+  width: 100vw;
+  max-width: none;
+  height: 100vh;
+  height: 100dvh;
+  max-height: none;
+  margin: 0;
+  border: 0;
+  background: rgba(9, 9, 15, 0.96);
+  padding: clamp(1rem, 3vw, 2.5rem);
+  color: #ffffff;
+}
+
+.docs-image-lightbox[open] {
+  display: grid;
+  place-items: center;
+}
+
+.docs-image-lightbox::backdrop {
+  background: rgba(9, 9, 15, 0.82);
+}
+
+.docs-image-lightbox-panel {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  grid-template-rows: minmax(0, 1fr) auto;
+  place-items: center;
+  gap: 0.85rem;
+}
+
+.docs-image-lightbox-panel > img {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 0.5rem;
+  object-fit: contain;
+  box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.45);
+}
+
+.docs-image-lightbox-close {
+  position: fixed;
+  z-index: 1;
+  top: max(1rem, env(safe-area-inset-top));
+  right: max(1rem, env(safe-area-inset-right));
+  display: grid;
+  width: 2.75rem;
+  height: 2.75rem;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.72);
+  padding: 0.65rem;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.docs-image-lightbox-close:hover {
+  border-color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.docs-image-lightbox-close svg {
+  width: 100%;
+  height: 100%;
+}
+
+.docs-image-lightbox-caption {
+  max-width: min(70rem, 100%);
+  margin: 0;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: var(--sl-text-sm);
+  line-height: 1.45;
+  text-align: center;
+}
+
+:root.docs-image-lightbox-open {
+  overflow: hidden;
+}
+
 .quickstart-agents {
   display: flex;
   flex-wrap: wrap;

--- a/docs/start-here/index.md
+++ b/docs/start-here/index.md
@@ -8,15 +8,15 @@ handoff, then paste this prompt in any folder on your computer.
 
 <div class="quickstart-agents" aria-label="Examples of local AI agents">
   <a class="quickstart-agent" href="https://openai.com/codex/">
-    <img src="/images/agents/openai.svg" alt="" width="32" height="32">
+    <img src="/images/agents/openai.svg" alt="" width="32" height="32" data-docs-image-lightbox-ignore>
     <span>Codex</span>
   </a>
   <a class="quickstart-agent" href="https://claude.com/product/claude-code">
-    <img src="/images/agents/claude.svg" alt="" width="32" height="32">
+    <img src="/images/agents/claude.svg" alt="" width="32" height="32" data-docs-image-lightbox-ignore>
     <span>Claude Code</span>
   </a>
   <a class="quickstart-agent" href="https://cursor.com/">
-    <img src="/images/agents/cursor.svg" alt="" width="32" height="32">
+    <img src="/images/agents/cursor.svg" alt="" width="32" height="32" data-docs-image-lightbox-ignore>
     <span>Cursor</span>
   </a>
   <span class="quickstart-agent-more">or another capable local agent</span>


### PR DESCRIPTION
## Summary

- make documentation article images clickable and open them in a full-screen native dialog
- support keyboard activation, Escape, backdrop and close-button dismissal, and focus restoration
- preserve the outbound links on the decorative AI-agent icons by excluding them from previews
- add responsive, theme-independent lightbox styling and captions derived from image alt text or figure captions

This helps readers inspect documentation screenshots without leaving the guide or opening a separate browser tab.

## Related issue

N/A

## Testing

- [x] `yarn check`
- [x] `yarn docs:check`
- [x] `git diff --check`
- [x] Manually verified light and dark themes, narrow layouts, keyboard activation, Escape-to-close, close-button dismissal, and focus restoration

## Screenshots

Not added. The interaction was verified in the local documentation preview.

## Risks

Low. The enhancement is scoped to images inside Starlight documentation content and uses the native dialog element. Images explicitly marked to ignore the lightbox retain their existing link behavior.

## Checklist

- [x] This pull request contains one focused change.
- [x] Tests were added or updated when behavior changed, or the behavior was covered by the documented manual verification.
- [x] Documentation was updated when commands or public behavior changed.
- [x] No secrets, private configuration, production data, or generated files are included.
